### PR TITLE
fix: DB キュー振り分け（#371）— ページネーション補助 Read を other に

### DIFF
--- a/src/app/_components/DatabaseStatsPanel.tsx
+++ b/src/app/_components/DatabaseStatsPanel.tsx
@@ -48,6 +48,7 @@ export const DatabaseStatsPanel = () => {
       ).join(' UNION ALL ')
 
       const rows = (await handle.execAsync(sql, {
+        kind: 'other',
         returnValue: 'resultRows',
       })) as [string, number][]
 

--- a/src/app/_components/UnifiedTimeline.tsx
+++ b/src/app/_components/UnifiedTimeline.tsx
@@ -183,7 +183,8 @@ export const UnifiedTimeline = ({
                  LIMIT 1;`,
                 {
                   bind: [tag, url],
-                  kind: 'timeline',
+                  // fetchMore 用 max_id 解決（API 取得の補助）→ other
+                  kind: 'other',
                   returnValue: 'resultRows',
                 },
               )) as string[][]
@@ -205,7 +206,8 @@ export const UnifiedTimeline = ({
                LIMIT 1;`,
               {
                 bind: [url, timelineType],
-                kind: 'timeline',
+                // fetchMore 用 max_id 解決（API 取得の補助）→ other
+                kind: 'other',
                 returnValue: 'resultRows',
               },
             )) as string[][]

--- a/src/util/explainQueryPlan.ts
+++ b/src/util/explainQueryPlan.ts
@@ -121,6 +121,7 @@ export async function runExplainQueryPlan(
     const explainSql = `EXPLAIN QUERY PLAN ${sql}`
     const rows = (await handle.execAsync(explainSql, {
       bind: binds,
+      kind: 'other',
       returnValue: 'resultRows',
     })) as unknown[][]
 

--- a/src/util/timelineFetcher.ts
+++ b/src/util/timelineFetcher.ts
@@ -116,7 +116,8 @@ export async function fetchMoreData(
            LIMIT 1;`,
           {
             bind: [tag, backendUrl],
-            kind: 'timeline',
+            // API ページネーション用の補助 Read（表示タイムライン構築ではない）→ other
+            kind: 'other',
             returnValue: 'resultRows',
           },
         )) as string[][]


### PR DESCRIPTION
## 概要
Closes #371

Issue #371 の方針に沿い、**タイムライン UI を組み立てる Read** と **API／ページネーション補助の Read** のキュー振り分けを整理しました。

## 変更内容
- \	imelineFetcher.fetchMoreData\（タグタイムラインの max_id 用 SELECT）: \kind: 'timeline'\ → \'other'\
- \UnifiedTimeline\ の \moreLoad\（最古 local_id 取得）: 同様に \'other'\
- \DatabaseStatsPanel\ / \explainQueryPlan\: 監査のため \kind: 'other'\ を明示

## キュー振り分け一覧（メインスレッド → Worker）

| 用途 | 経路 | キュー |
|------|------|--------|
| タイムライン構築 Read | \useTimeline\ / \useTagTimeline\ の \execAsync\ | **timeline** |
| 同上 | \useFilteredTimeline\ / \useFilteredTagTimeline\ / \useCustomQueryTimeline\ の \execAsyncTimed\ | **timeline** |
| 同上 | \useNotifications\ の \execAsyncTimed\ | **timeline** |
| 同上 | \statusStore\ の \etchStatusesByIds\ / \executeBatchQueries\ / \getStatusesBy*\ phase1 等 | **timeline** |
| 同上 | \
otificationStore.getNotifications\ | **timeline** |
| API・ページネーション補助 Read | \	imelineFetcher\（タグ最古 JSON） | **other**（本 PR） |
| 同上 | \UnifiedTimeline.moreLoad\（最古 local_id） | **other**（本 PR） |
| 管理・診断 | \DatabaseStatsPanel\ / \explainQueryPlan\ | **other** |
| 管理 UI | \MuteManager\ / \InstanceBlockManager\（未指定＝デフォルト） | **other** |
| クエリ補助 | \statusStore\ の \alidateCustomQuery\ / \getDistinct*\ 等（デフォルト） | **other** |
| 書き込み・専用ハンドラ | 全 \sendCommand\ / \execBatch\（\workerClient\） | **other** |
| フォールバック | \initSqlite\ メインスレッド SQLite | キュー対象外 |

## 確認
- \yarn check\
- \yarn exec tsc --noEmit\
