### PR TITLE
Misskey サポートを追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "jquery": "^4.0.0",
     "lucide-react": "^0.577.0",
     "megalodon": "^10.2.4",
+    "misskey-js": "^2026.1.0-beta.0",
     "next": "^16.2.1",
     "node-emoji": "^2.2.0",
     "react": "19.2.4",

--- a/specs/timeline-query-optimization.md
+++ b/specs/timeline-query-optimization.md
@@ -1,0 +1,378 @@
+# タイムライン表示パフォーマンス最適化計画
+
+## 1. 背景
+
+posts テーブルに 5 万レコード程度蓄積された環境において、初回起動時にタイムラインが表示されるまで体感で数秒の遅延が発生している。
+
+miyulab-fe の最大の目的は **ユーザーが自由な SQL WHERE 句でタイムラインを作成できること** であり、正規化されたテーブル構造はその柔軟性の根幹を成す。したがって、本計画では **テーブル構造の非正規化を行わず、クエリ実行戦略とリアクティブ更新の効率化** によってパフォーマンスを改善する。
+
+---
+
+## 2. 現状分析
+
+### 2.1 データフロー
+
+```
+Fediverse Server
+  → megalodon (REST / WebSocket)
+  → SQLite Worker (bulkUpsert → notifyChange)
+  → subscribe('posts', fetchData) でリスナー発火
+  → Phase1 クエリ (ID フィルタ)
+  → Phase2 クエリ (詳細取得 — STATUS_SELECT)
+  → React Hooks → Virtuoso → 画面表示
+```
+
+### 2.2 ボトルネック一覧
+
+| # | 箇所 | 深刻度 | 概要 |
+|---|------|--------|------|
+| A | Phase2 `STATUS_SELECT` の相関サブクエリ | 🔴 高 | 1 行あたり最大 21 個の相関サブクエリ。50 件取得で約 1,050 回実行 |
+| B | `notifyChange` に debounce がない | 🔴 高 | ストリーミング受信のたびに全リスナーが即時発火。throttle も未実装 |
+| C | `useNotifications` に configType ガードがない | 🔴 高 | `config.type !== 'notification'` でも通知テーブルへのクエリが実行される |
+| D | `useTimelineData` で 4 Hook が常に全実行 | 🟡 中 | Hook ルール上の制約で不要な Hook も subscribe + 初期化処理が走る |
+| E | `TabbedTimeline` が非表示タブもフルマウント | 🟡 中 | CSS `hidden` で隠しているだけで全タブの Hook・リスナー・クエリが稼働 |
+| F | Phase1 カスタムクエリの互換サブクエリ | 🟡 中 | `STATUS_COMPAT_FROM` が全 posts を派生テーブル化し、インデックス push down が効かない場合がある |
+
+### 2.3 初回起動時の推定コスト
+
+| ステップ | 処理 | 推定時間 |
+|----------|------|----------|
+| 1 | SQLite Worker 起動 + OPFS 読み込み | 500ms–2s |
+| 2 | Provider チェーン初期化 (13 層) | 50–100ms |
+| 3 | `verifyAccountCredentials` × N アプリ | 200–500ms |
+| 4 | Phase1 (5 テーブル JOIN, 5 万行) × 全カラム | 50–300ms/各 |
+| 5 | Phase2 (50 件 × 21 サブクエリ) × 全カラム | 100–500ms/各 |
+| 6 | ストリーミング受信 → `notifyChange` → 全 Hook 再クエリ | 累積遅延 |
+
+---
+
+## 3. 設計原則
+
+1. **テーブル構造を変更しない** — 正規化された構造はカスタムクエリの柔軟性の根幹
+2. **Phase2 は全クエリパスで共通** — カスタムクエリが影響するのは Phase1 のみ。Phase2 の最適化はカスタムクエリの自由度に影響しない
+3. **段階的に適用可能な改善** — 各施策は独立しており、1 つずつマージできる
+4. **計測駆動** — 既存の `explainLogger.ts` (SLOW_QUERY_THRESHOLD_MS = 2000) を活用し、改善前後で計測する
+
+---
+
+## 4. 改善施策
+
+### 4.1 Phase2: `post_stats` を LEFT JOIN に変換
+
+**対象**: `STATUS_SELECT` 内の `post_stats` 相関サブクエリ 6 本 (本投稿 3 + リブログ元 3)
+
+**根拠**: `post_stats` は `post_id` が PRIMARY KEY であり、`posts` と **厳密に 1:1** の関係。JOIN しても行が膨張せず、既存の `GROUP BY s.post_id` に影響しない。
+
+**現状** (サブクエリ 3 本):
+
+```sql
+COALESCE((SELECT ps.replies_count FROM post_stats ps WHERE ps.post_id = s.post_id), 0) AS replies_count,
+COALESCE((SELECT ps.reblogs_count FROM post_stats ps WHERE ps.post_id = s.post_id), 0) AS reblogs_count,
+COALESCE((SELECT ps.favourites_count FROM post_stats ps WHERE ps.post_id = s.post_id), 0) AS favourites_count,
+```
+
+**変更後** (LEFT JOIN):
+
+```sql
+-- STATUS_BASE_JOINS に追加
+LEFT JOIN post_stats ps ON s.post_id = ps.post_id
+LEFT JOIN post_stats rps ON rs.post_id = rps.post_id
+
+-- STATUS_SELECT で直接参照
+COALESCE(ps.replies_count, 0) AS replies_count,
+COALESCE(ps.reblogs_count, 0) AS reblogs_count,
+COALESCE(ps.favourites_count, 0) AS favourites_count,
+-- リブログ元
+COALESCE(rps.replies_count, 0) AS rb_replies_count,
+COALESCE(rps.reblogs_count, 0) AS rb_reblogs_count,
+COALESCE(rps.favourites_count, 0) AS rb_favourites_count,
+```
+
+**効果**: 相関サブクエリ 6 本削減。50 件取得時に 300 回のサブクエリ実行が 0 回になる。
+
+**影響範囲**: `statusStore.ts` の `STATUS_SELECT` / `STATUS_BASE_JOINS` のみ。Phase1 やカスタムクエリには無関係。
+
+**リスク**: 低。1:1 JOIN のため結果セットは変わらない。
+
+---
+
+### 4.2 Phase2: 子テーブルごとのバッチクエリ化
+
+**対象**: `STATUS_SELECT` 内の 1:N 相関サブクエリ全般
+
+**根拠**: 現在は 1 行ごとに個別のサブクエリで子テーブルを引いているが、Phase2 の入力は Phase1 で確定した `post_id` リスト (最大 50 件) である。`WHERE post_id IN (...)` で子テーブルをまとめて取得し、JS 側で `post_id` をキーにマージすれば、クエリ回数を劇的に削減できる。
+
+**現状**: 1 つの SQL 文内に 21 個の相関サブクエリが埋め込まれている。
+
+```
+50 件 × 21 サブクエリ = 約 1,050 回のサブクエリ実行
+```
+
+**変更後**: Phase2 を以下の個別バッチクエリに分解する。
+
+```
+Phase2-A: posts 本体 + 1:1 JOIN (profiles, visibility_types, posts_backends, post_stats)
+Phase2-B: SELECT * FROM post_media WHERE post_id IN (?) ORDER BY sort_order
+Phase2-C: SELECT * FROM posts_mentions WHERE post_id IN (?)
+Phase2-D: SELECT pe.post_id, group_concat(et.code, ',') ...
+           FROM post_engagements pe JOIN engagement_types et ...
+           WHERE pe.post_id IN (?) GROUP BY pe.post_id
+Phase2-E: SELECT * FROM post_custom_emojis pce JOIN custom_emojis ce ...
+           WHERE pce.post_id IN (?)
+Phase2-F: SELECT * FROM polls pl LEFT JOIN poll_options po ...
+           WHERE pl.post_id IN (?)
+Phase2-G: SELECT ti.post_id, json_group_array(ck.code) ...
+           FROM timeline_items ti JOIN timelines t JOIN channel_kinds ck
+           WHERE ti.post_id IN (?) GROUP BY ti.post_id
+Phase2-H: SELECT * FROM posts_belonging_tags WHERE post_id IN (?)
+```
+
+```
+合計: 8 回のクエリ + JS 側マージ
+```
+
+**JS 側マージの擬似コード**:
+
+```ts
+// 各バッチクエリの結果を Map<post_id, ...> に変換
+const mediaMap = groupBy(mediaRows, 'post_id')
+const mentionsMap = groupBy(mentionRows, 'post_id')
+const engagementsMap = new Map(engagementRows.map(r => [r.post_id, r.csv]))
+// ...
+
+// 本体クエリの結果に子データをマージ
+const statuses = baseRows.map(row => ({
+  ...rowToBaseStatus(row),
+  media_attachments: mediaMap.get(row.post_id) ?? [],
+  mentions: mentionsMap.get(row.post_id) ?? [],
+  engagements_csv: engagementsMap.get(row.post_id) ?? null,
+  // ...
+}))
+```
+
+**リブログ元の処理**: Phase2-A で `reblog_of_uri` JOIN により得られたリブログ元の `post_id` を収集し、同じバッチクエリの IN 句にまとめて含める。マージ時に本投稿 / リブログ元を区別する。
+
+**効果**: 約 1,050 回 → 8 回。Wasm SQLite の per-query オーバーヘッドが支配的な環境では劇的な改善が期待できる。
+
+**影響範囲**: `statusStore.ts` の `fetchStatusesByIds` を新しい `fetchStatusesByIdsBatch` に置き換え。`rowToStoredStatus` のマッピングロジックを変更。`useCustomQueryTimeline.ts` 内のインライン Phase2 も同様に変更。
+
+**リスク**: 中。`rowToStoredStatus` の変更はテスト必須。Phase1 やカスタムクエリの WHERE 句には影響しない。
+
+---
+
+### 4.3 `notifyChange` に debounce を導入
+
+**対象**: `connection.ts` の `notifyChange`
+
+**根拠**: 現在、`notifyChange('posts')` は同期的に全リスナーを即時呼び出す。ストリーミングで短時間に複数の投稿が到着すると、リスナーが連続発火しクエリが多重実行される。debounce も throttle も一切ない。
+
+**変更方針**:
+
+```ts
+const pendingNotifications = new Set<TableName>()
+let timerId: ReturnType<typeof setTimeout> | null = null
+
+export function notifyChange(table: TableName): void {
+  pendingNotifications.add(table)
+  if (timerId != null) return
+  timerId = setTimeout(() => {
+    timerId = null
+    const tables = [...pendingNotifications]
+    pendingNotifications.clear()
+    for (const t of tables) {
+      const set = listeners.get(t)
+      if (set) {
+        for (const fn of set) {
+          try { fn() } catch (e) { console.error('Change listener error:', e) }
+        }
+      }
+    }
+  }, 80)
+}
+```
+
+**debounce 値**: 80ms。ストリーミングのバースト（数十 ms 間隔）を吸収しつつ、ユーザーの操作（ふぁぼ・ブースト等）のフィードバックが遅延しすぎない値。
+
+**効果**: ストリーミング高頻度時のクエリ発行回数を大幅に削減。
+
+**影響範囲**: `connection.ts` のみ。
+
+**リスク**: 低。最大 80ms の表示遅延が発生するが、タイムラインの性質上問題ない。ユーザー操作 (ふぁぼ等) の即時フィードバックは `optimistic update` で対応済みであれば影響なし。未対応の場合は、ユーザー操作トリガーの `notifyChange` だけ即時発火するオプションを検討する。
+
+---
+
+### 4.4 `useNotifications` に configType ガードを追加
+
+**対象**: `useNotifications.ts` の `fetchData`
+
+**根拠**: 現在、`useNotifications` の `fetchData` には `config.type` によるスキップ条件がない。そのため `config.type === 'home'` のカラムでも通知テーブルへの SQL クエリが実行されてしまう。他の 3 Hook (`useFilteredTimeline`, `useFilteredTagTimeline`, `useCustomQueryTimeline`) にはすべて configType チェックがあり、これは実装漏れと考えられる。
+
+**変更方針**:
+
+```ts
+// fetchData の冒頭に追加
+const fetchData = useCallback(async () => {
+  void refreshToken
+
+  // notification タイプ以外ではスキップ
+  if (config?.type !== 'notification') {
+    setNotifications([])
+    return
+  }
+
+  if (targetBackendUrls.length === 0 || config?.customQuery?.trim()) {
+    setNotifications([])
+    return
+  }
+  // ... 以下既存処理
+}, [/* ... */])
+```
+
+**効果**: `notification` 以外の全タイムラインカラムで通知クエリが走らなくなる。
+
+**影響範囲**: `useNotifications.ts` のみ。
+
+**リスク**: 極低。バグ修正に近い。`useCustomQueryTimeline` が notification モードを担当するため、カスタムクエリ経由の通知取得には影響しない。
+
+---
+
+### 4.5 `TabbedTimeline` の遅延マウント
+
+**対象**: `TabbedTimeline.tsx`
+
+**根拠**: 現在は全タブの `DynamicTimeline` を同時にマウントし、CSS `hidden` で非表示にしている。タブ 3 つの場合、非アクティブなタブ 2 つ分の Hook・リスナー・クエリが無駄に稼働している。
+
+**変更方針**: 一度もアクティブにされていないタブはマウントせず、一度アクティブにされたタブは `hidden` で保持する (再マウントによるデータロスを防ぐ)。
+
+```tsx
+const [mountedIndices, setMountedIndices] = useState<Set<number>>(
+  () => new Set([0]),
+)
+
+useEffect(() => {
+  setMountedIndices((prev) => {
+    if (prev.has(safeIndex)) return prev
+    return new Set([...prev, safeIndex])
+  })
+}, [safeIndex])
+
+// ...
+{configs.map((config, index) => {
+  const isActive = index === safeIndex
+  const isMounted = mountedIndices.has(index)
+  if (!isMounted) return null
+  return (
+    <div hidden={!isActive} /* ... */>
+      <DynamicTimeline config={config} headerOffset="2rem" />
+    </div>
+  )
+})}
+```
+
+**効果**: 初回起動時は 1 タブ分の Hook・クエリのみ実行。タブ 4 つなら初期コストが 1/4 に。
+
+**影響範囲**: `TabbedTimeline.tsx` のみ。
+
+**リスク**: 低。タブ切り替え時に初回マウントの遅延が発生するが、それ以降はキャッシュされる。
+
+---
+
+### 4.6 不要な Hook の subscribe 回避
+
+**対象**: `useFilteredTimeline.ts`, `useFilteredTagTimeline.ts`, `useNotifications.ts`, `useCustomQueryTimeline.ts`
+
+**根拠**: `useTimelineData` が 4 Hook を常に呼び出す制約上、不要な Hook も `subscribe('posts', fetchData)` でリスナー登録される。早期リターンする Hook であっても `subscribe` / `unsubscribe` のセットアップコストとリスナー発火時の関数呼び出しコストがかかる。
+
+**変更方針**: 各 Hook の `useEffect` 内で、自身が対象の configType でない場合は `subscribe` 自体をスキップする。
+
+```ts
+useEffect(() => {
+  // このHookの対象でない場合は subscribe しない
+  if (configType !== 'home' && configType !== 'local' && configType !== 'public') {
+    setStatuses([])
+    return
+  }
+  fetchData()
+  return subscribe('posts', fetchData)
+}, [configType, fetchData])
+```
+
+**効果**: `posts` テーブルのリスナー数が 1 カラムあたり最大 3 個 → 1 個に削減。`notifyChange` 発火時の不要な関数呼び出しが消える。
+
+**影響範囲**: 各 Hook ファイル。
+
+**リスク**: 低。configType が動的に変わるケースは `TimelineConfigV2` の設計上想定されていない（config 変更時は configId ごとリセットされる）。
+
+---
+
+### 4.7 Phase1: `STATUS_COMPAT_FROM` の改善 (将来検討)
+
+**対象**: `useCustomQueryTimeline.ts` の `STATUS_COMPAT_FROM`, `statusStore.ts` の `getStatusesByCustomQuery`
+
+**根拠**: カスタムクエリの Phase1 で `FROM (SELECT p.*, ... FROM posts p LEFT JOIN ...) s` という派生テーブルを使用しており、SQLite オプティマイザが外側の WHERE 条件を内側に push down できないケースがある。5 万件すべてに対して `post_stats`, `profiles`, `servers`, `visibility_types` の JOIN + サブクエリが実行されてからフィルタリングされる可能性がある。
+
+**検討案**:
+
+- **案 A**: 互換サブクエリを VIEW に置き換え、SQLite の VIEW 最適化（マージアルゴリズム）に期待する
+- **案 B**: `s.favourites_count` 等の互換カラム参照を検出した場合のみ派生テーブルを使い、それ以外は直接 `posts p` を FROM に使う
+- **案 C**: GENERATED COLUMN として `posts` テーブルに追加する（ただし「テーブル構造を変更しない」原則との兼ね合い）
+
+**現時点では保留**。4.1〜4.6 の施策適用後に再計測し、Phase1 がボトルネックとして残る場合に着手する。
+
+---
+
+## 5. 実施順序
+
+施策を影響範囲の小ささ・即効性・リスクの低さで並べる。
+
+| フェーズ | 施策 | 見込み効果 | 変更ファイル数 |
+|----------|------|------------|----------------|
+| **Phase I** | 4.4 `useNotifications` ガード追加 | 不要クエリ除去 | 1 |
+| **Phase I** | 4.3 `notifyChange` debounce | バースト時クエリ削減 | 1 |
+| **Phase I** | 4.1 `post_stats` LEFT JOIN 化 | サブクエリ 6 本削減 | 1 |
+| **Phase II** | 4.5 タブ遅延マウント | 初期クエリ 1/N 化 | 1 |
+| **Phase II** | 4.6 不要 Hook の subscribe 回避 | リスナー数 1/3 化 | 4 |
+| **Phase III** | 4.2 子テーブルバッチクエリ化 | サブクエリ 1,050→8 回 | 2–3 |
+| **将来** | 4.7 互換サブクエリ改善 | Phase1 高速化 | 2 |
+
+Phase I は低リスクで即座に適用可能。Phase II は小〜中規模の変更。Phase III は `fetchStatusesByIds` と `rowToStoredStatus` の書き換えを伴う中規模リファクタリング。
+
+---
+
+## 6. 計測方法
+
+### 6.1 既存インフラの活用
+
+- `explainLogger.ts` の `SLOW_QUERY_THRESHOLD_MS` を一時的に `0` に設定し、全クエリの実行時間を記録する
+- 各 Hook の `queryDuration` state を使い、UI 上でクエリ時間を確認する
+
+### 6.2 計測シナリオ
+
+| シナリオ | 条件 |
+|----------|------|
+| 初回起動 | 5 万 posts, タブ 3 個 (各 2–3 カラム), ストリーミング未接続 |
+| ストリーミングバースト | 1 秒間に 10 件の投稿受信 |
+| タブ切り替え | 非アクティブ → アクティブ切り替え時の表示完了時間 |
+| カスタムクエリ | `s.has_media = 1 AND s.favourites_count >= 5` のようなフィルタ |
+
+### 6.3 目標値
+
+| 指標 | 現状推定 | 目標 |
+|------|----------|------|
+| 初回タイムライン表示 (Worker 起動後) | 500ms–1.5s | 200ms 以下 |
+| Phase2 クエリ実行時間 (50 件) | 100–500ms | 50ms 以下 |
+| ストリーミング受信から表示更新 | 即時〜数百ms (多重発火) | 80–150ms (debounce 分のみ) |
+| `posts` リスナー数 / カラム | 3 個 | 1 個 |
+
+---
+
+## 7. 変更しないもの
+
+以下は本計画のスコープ外とし、変更しない。
+
+- **テーブル構造** — 正規化された設計はカスタムクエリの自由度に不可欠
+- **2 段階クエリ戦略** — Phase1 (ID フィルタ) → Phase2 (詳細取得) の分離は正しい設計
+- **`STATUS_COMPAT_FROM` の互換カラム** — `s.favourites_count` 等をカスタムクエリで使っている既存ユーザーを壊さない
+- **`useTimelineData` の 4 Hook 呼び出し構造** — Hook ルールの制約上、条件付き呼び出しは不可。subscribe スキップで対処する
+- **react-virtuoso** — 仮想スクロール自体はボトルネックではない
+- **Provider 階層** — 13 層の Context は初期化コストが小さく、ボトルネックではない

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -14,6 +14,7 @@ export const backendList = [
   'firefish',
   'gotosocial',
   'pixelfed',
+  'misskey',
 ] as const
 
 export type Backend = (typeof backendList)[number]

--- a/src/util/GetClient.ts
+++ b/src/util/GetClient.ts
@@ -1,8 +1,13 @@
+import type { MegalodonInterface } from 'megalodon'
 import generator from 'megalodon'
 
 import type { App } from 'types/types'
+import { MisskeyAdapter } from './misskey/MisskeyAdapter'
 
-export const GetClient = (app: App) => {
+export const GetClient = (app: App): MegalodonInterface => {
   const { backend, backendUrl, tokenData } = app
+  if (backend === 'misskey') {
+    return new MisskeyAdapter(backendUrl, tokenData?.access_token)
+  }
   return generator(backend, backendUrl, tokenData?.access_token)
 }

--- a/src/util/environment.ts
+++ b/src/util/environment.ts
@@ -20,6 +20,7 @@ assert(
     process.env.NEXT_PUBLIC_BACKEND_SNS === 'pleroma' ||
     process.env.NEXT_PUBLIC_BACKEND_SNS === 'friendica' ||
     process.env.NEXT_PUBLIC_BACKEND_SNS === 'firefish' ||
+    process.env.NEXT_PUBLIC_BACKEND_SNS === 'misskey' ||
     process.env.NEXT_PUBLIC_BACKEND_SNS === undefined,
   'Invalid NEXT_PUBLIC_BACKEND_SNS',
 )

--- a/src/util/misskey/MisskeyAdapter.ts
+++ b/src/util/misskey/MisskeyAdapter.ts
@@ -1,0 +1,1462 @@
+import type {
+  Entity,
+  MegalodonInterface,
+  OAuth,
+  Response,
+  WebSocketInterface,
+} from 'megalodon'
+import * as Misskey from 'misskey-js'
+import { createMiAuthAppData, fetchMiAuthToken } from './auth'
+import { MisskeyWebSocketAdapter } from './MisskeyWebSocketAdapter'
+import {
+  mapNoteToStatus,
+  mapNotification,
+  mapUserDetailedToAccount,
+  mapUserLiteToAccount,
+  mapVisibilityToMisskey,
+} from './mappers'
+
+// ========================================
+// Helper: megalodon Response wrapper
+// ========================================
+
+function wrapResponse<T>(data: T, status = 200): Response<T> {
+  return {
+    data,
+    headers: {},
+    status,
+    statusText: 'OK',
+  }
+}
+
+class NotImplementedError extends Error {
+  constructor(method: string) {
+    super(`MisskeyAdapter: ${method} is not implemented`)
+    this.name = 'NotImplementedError'
+  }
+}
+
+// ========================================
+// MisskeyAdapter
+// ========================================
+
+export class MisskeyAdapter implements MegalodonInterface {
+  private client: Misskey.api.APIClient
+  private origin: string
+  private credential: string | null
+
+  constructor(origin: string, credential?: string | null) {
+    this.origin = origin
+    this.credential = credential ?? null
+    this.client = new Misskey.api.APIClient({
+      credential: credential ?? undefined,
+      origin,
+    })
+  }
+
+  // =============================================
+  // OAuth / App Registration
+  // =============================================
+
+  cancel(): void {
+    // No-op: misskey-js doesn't have cancellation
+  }
+
+  async registerApp(
+    clientName: string,
+    options: Partial<{
+      scopes: Array<string>
+      redirect_uris: string
+      website: string
+    }>,
+  ): Promise<OAuth.AppData> {
+    const callbackUrl = options.redirect_uris ?? options.website ?? ''
+    return createMiAuthAppData(this.origin, clientName, callbackUrl)
+  }
+
+  async createApp(
+    clientName: string,
+    options: Partial<{
+      scopes: Array<string>
+      redirect_uris: string
+      website: string
+    }>,
+  ): Promise<OAuth.AppData> {
+    return this.registerApp(clientName, options)
+  }
+
+  async fetchAccessToken(
+    clientId: string | null,
+    _clientSecret: string,
+    _code: string,
+    _redirectUri?: string,
+  ): Promise<OAuth.TokenData> {
+    // clientId is the MiAuth session ID
+    const sessionId = clientId ?? ''
+    return fetchMiAuthToken(this.origin, sessionId)
+  }
+
+  async refreshToken(
+    _clientId: string,
+    _clientSecret: string,
+    _refreshToken: string,
+  ): Promise<OAuth.TokenData> {
+    throw new NotImplementedError('refreshToken')
+  }
+
+  async revokeToken(
+    _clientId: string,
+    _clientSecret: string,
+    _token: string,
+  ): Promise<Response<Record<string, never>>> {
+    throw new NotImplementedError('revokeToken')
+  }
+
+  async verifyAppCredentials(): Promise<Response<Entity.Application>> {
+    return wrapResponse({
+      name: 'Misskey',
+    } as Entity.Application)
+  }
+
+  async registerAccount(
+    _username: string,
+    _email: string,
+    _password: string,
+    _agreement: boolean,
+    _locale: string,
+    _reason?: string | null,
+  ): Promise<Response<Entity.Token>> {
+    throw new NotImplementedError('registerAccount')
+  }
+
+  // =============================================
+  // Account
+  // =============================================
+
+  async verifyAccountCredentials(): Promise<Response<Entity.Account>> {
+    const me = await this.client.request('i', {})
+    return wrapResponse(
+      mapUserDetailedToAccount(
+        me as unknown as Misskey.entities.UserDetailed,
+        this.origin,
+      ),
+    )
+  }
+
+  async updateCredentials(
+    _options?: Record<string, unknown>,
+  ): Promise<Response<Entity.Account>> {
+    throw new NotImplementedError('updateCredentials')
+  }
+
+  async getAccount(id: string): Promise<Response<Entity.Account>> {
+    const user = await this.client.request('users/show', { userId: id })
+    return wrapResponse(
+      mapUserDetailedToAccount(
+        user as unknown as Misskey.entities.UserDetailed,
+        this.origin,
+      ),
+    )
+  }
+
+  async getAccountStatuses(
+    id: string,
+    options?: {
+      limit?: number
+      max_id?: string
+      since_id?: string
+      min_id?: string
+      pinned?: boolean
+      exclude_replies?: boolean
+      exclude_reblogs?: boolean
+      only_media?: boolean
+      only_public?: boolean
+    },
+  ): Promise<Response<Array<Entity.Status>>> {
+    const notes = await this.client.request('users/notes', {
+      limit: options?.limit ?? 20,
+      userId: id,
+      ...(options?.max_id ? { untilId: options.max_id } : {}),
+      ...(options?.since_id ? { sinceId: options.since_id } : {}),
+      ...(options?.only_media ? { withFiles: true } : {}),
+      ...(options?.exclude_replies != null
+        ? { withReplies: !options.exclude_replies }
+        : {}),
+      ...(options?.exclude_reblogs != null
+        ? { withRenotes: !options.exclude_reblogs }
+        : {}),
+    })
+    return wrapResponse(notes.map((n) => mapNoteToStatus(n, this.origin)))
+  }
+
+  async getAccountFavourites(
+    _id: string,
+    _options?: {
+      limit?: number
+      max_id?: string
+      since_id?: string
+    },
+  ): Promise<Response<Array<Entity.Status>>> {
+    throw new NotImplementedError('getAccountFavourites')
+  }
+
+  async subscribeAccount(_id: string): Promise<Response<Entity.Relationship>> {
+    throw new NotImplementedError('subscribeAccount')
+  }
+
+  async unsubscribeAccount(
+    _id: string,
+  ): Promise<Response<Entity.Relationship>> {
+    throw new NotImplementedError('unsubscribeAccount')
+  }
+
+  async getAccountFollowers(
+    id: string,
+    options?: {
+      limit?: number
+      max_id?: string
+      since_id?: string
+      get_all?: boolean
+      sleep_ms?: number
+    },
+  ): Promise<Response<Array<Entity.Account>>> {
+    const followers = await this.client.request('users/followers', {
+      limit: options?.limit ?? 40,
+      userId: id,
+      ...(options?.max_id ? { untilId: options.max_id } : {}),
+      ...(options?.since_id ? { sinceId: options.since_id } : {}),
+    })
+    return wrapResponse(
+      followers.map((f: Record<string, unknown>) => {
+        const follower = (f as { follower?: Misskey.entities.UserLite })
+          .follower
+        if (follower) {
+          return mapUserLiteToAccount(follower, this.origin)
+        }
+        return mapUserLiteToAccount(
+          f as unknown as Misskey.entities.UserLite,
+          this.origin,
+        )
+      }),
+    )
+  }
+
+  async getAccountFollowing(
+    id: string,
+    options?: {
+      limit?: number
+      max_id?: string
+      since_id?: string
+      get_all?: boolean
+      sleep_ms?: number
+    },
+  ): Promise<Response<Array<Entity.Account>>> {
+    const following = await this.client.request('users/following', {
+      limit: options?.limit ?? 40,
+      userId: id,
+      ...(options?.max_id ? { untilId: options.max_id } : {}),
+      ...(options?.since_id ? { sinceId: options.since_id } : {}),
+    })
+    return wrapResponse(
+      following.map((f: Record<string, unknown>) => {
+        const followee = (f as { followee?: Misskey.entities.UserLite })
+          .followee
+        if (followee) {
+          return mapUserLiteToAccount(followee, this.origin)
+        }
+        return mapUserLiteToAccount(
+          f as unknown as Misskey.entities.UserLite,
+          this.origin,
+        )
+      }),
+    )
+  }
+
+  async getAccountLists(_id: string): Promise<Response<Array<Entity.List>>> {
+    throw new NotImplementedError('getAccountLists')
+  }
+
+  async getIdentityProof(
+    _id: string,
+  ): Promise<Response<Array<Entity.IdentityProof>>> {
+    throw new NotImplementedError('getIdentityProof')
+  }
+
+  async followAccount(
+    id: string,
+    _options?: { reblog?: boolean },
+  ): Promise<Response<Entity.Relationship>> {
+    await this.client.request('following/create', { userId: id })
+    return this.getRelationship(id)
+  }
+
+  async unfollowAccount(id: string): Promise<Response<Entity.Relationship>> {
+    await this.client.request('following/delete', { userId: id })
+    return this.getRelationship(id)
+  }
+
+  async blockAccount(id: string): Promise<Response<Entity.Relationship>> {
+    await this.client.request('blocking/create', { userId: id })
+    return this.getRelationship(id)
+  }
+
+  async unblockAccount(id: string): Promise<Response<Entity.Relationship>> {
+    await this.client.request('blocking/delete', { userId: id })
+    return this.getRelationship(id)
+  }
+
+  async muteAccount(
+    id: string,
+    _notifications: boolean,
+  ): Promise<Response<Entity.Relationship>> {
+    await this.client.request('mute/create', { userId: id })
+    return this.getRelationship(id)
+  }
+
+  async unmuteAccount(id: string): Promise<Response<Entity.Relationship>> {
+    await this.client.request('mute/delete', { userId: id })
+    return this.getRelationship(id)
+  }
+
+  async pinAccount(_id: string): Promise<Response<Entity.Relationship>> {
+    throw new NotImplementedError('pinAccount')
+  }
+
+  async unpinAccount(_id: string): Promise<Response<Entity.Relationship>> {
+    throw new NotImplementedError('unpinAccount')
+  }
+
+  async setAccountNote(
+    _id: string,
+    _note?: string,
+  ): Promise<Response<Entity.Relationship>> {
+    throw new NotImplementedError('setAccountNote')
+  }
+
+  async getRelationship(id: string): Promise<Response<Entity.Relationship>> {
+    const relation = await this.client.request('users/relation', {
+      userId: id,
+    })
+    const rel = relation as unknown as {
+      id: string
+      isFollowing: boolean
+      isFollowed: boolean
+      hasPendingFollowRequestFromYou: boolean
+      hasPendingFollowRequestToYou: boolean
+      isBlocking: boolean
+      isBlocked: boolean
+      isMuted: boolean
+    }
+    return wrapResponse({
+      blocked_by: rel.isBlocked ?? false,
+      blocking: rel.isBlocking ?? false,
+      domain_blocking: false,
+      endorsed: false,
+      followed_by: rel.isFollowed ?? false,
+      following: rel.isFollowing ?? false,
+      id: rel.id,
+      muting: rel.isMuted ?? false,
+      muting_notifications: false,
+      note: null,
+      notifying: false,
+      requested: rel.hasPendingFollowRequestFromYou ?? false,
+      showing_reblogs: true,
+    } as unknown as Entity.Relationship)
+  }
+
+  async getRelationships(
+    ids: Array<string>,
+  ): Promise<Response<Array<Entity.Relationship>>> {
+    const results = await Promise.all(
+      ids.map(async (id) => {
+        const res = await this.getRelationship(id)
+        return res.data
+      }),
+    )
+    return wrapResponse(results)
+  }
+
+  async searchAccount(
+    q: string,
+    options?: {
+      following?: boolean
+      resolve?: boolean
+      limit?: number
+      max_id?: string
+      since_id?: string
+    },
+  ): Promise<Response<Array<Entity.Account>>> {
+    const users = await this.client.request('users/search', {
+      limit: options?.limit ?? 20,
+      query: q,
+    })
+    return wrapResponse(
+      users.map((u) =>
+        mapUserLiteToAccount(
+          u as unknown as Misskey.entities.UserLite,
+          this.origin,
+        ),
+      ),
+    )
+  }
+
+  async lookupAccount(acct: string): Promise<Response<Entity.Account>> {
+    // Parse acct format: user@host or user
+    const parts = acct.split('@')
+    const username = parts[0]
+    const host = parts.length > 1 ? parts[1] : null
+    const users = await this.client.request(
+      'users/search-by-username-and-host',
+      {
+        username,
+        ...(host ? { host } : {}),
+        limit: 1,
+      },
+    )
+    if (users.length === 0) {
+      throw new Error(`Account not found: ${acct}`)
+    }
+    return wrapResponse(
+      mapUserLiteToAccount(
+        users[0] as unknown as Misskey.entities.UserLite,
+        this.origin,
+      ),
+    )
+  }
+
+  // =============================================
+  // Bookmarks / Favourites / Mutes / Blocks
+  // =============================================
+
+  async getBookmarks(_options?: {
+    limit?: number
+    max_id?: string
+    since_id?: string
+    min_id?: string
+  }): Promise<Response<Array<Entity.Status>>> {
+    throw new NotImplementedError('getBookmarks')
+  }
+
+  async getFavourites(_options?: {
+    limit?: number
+    max_id?: string
+    min_id?: string
+  }): Promise<Response<Array<Entity.Status>>> {
+    throw new NotImplementedError('getFavourites')
+  }
+
+  async getMutes(_options?: {
+    limit?: number
+    max_id?: string
+    min_id?: string
+  }): Promise<Response<Array<Entity.Account>>> {
+    throw new NotImplementedError('getMutes')
+  }
+
+  async getBlocks(_options?: {
+    limit?: number
+    max_id?: string
+    min_id?: string
+  }): Promise<Response<Array<Entity.Account>>> {
+    throw new NotImplementedError('getBlocks')
+  }
+
+  async getDomainBlocks(_options?: {
+    limit?: number
+    max_id?: string
+    min_id?: string
+  }): Promise<Response<Array<string>>> {
+    throw new NotImplementedError('getDomainBlocks')
+  }
+
+  async blockDomain(_domain: string): Promise<Response<Record<string, never>>> {
+    throw new NotImplementedError('blockDomain')
+  }
+
+  async unblockDomain(
+    _domain: string,
+  ): Promise<Response<Record<string, never>>> {
+    throw new NotImplementedError('unblockDomain')
+  }
+
+  // =============================================
+  // Filters
+  // =============================================
+
+  async getFilters(): Promise<Response<Array<Entity.Filter>>> {
+    return wrapResponse([])
+  }
+
+  async getFilter(_id: string): Promise<Response<Entity.Filter>> {
+    throw new NotImplementedError('getFilter')
+  }
+
+  async createFilter(
+    _phrase: string,
+    _context: Array<Entity.FilterContext>,
+    _options?: {
+      irreversible?: boolean
+      whole_word?: boolean
+      expires_in?: string
+    },
+  ): Promise<Response<Entity.Filter>> {
+    throw new NotImplementedError('createFilter')
+  }
+
+  async updateFilter(
+    _id: string,
+    _phrase: string,
+    _context: Array<Entity.FilterContext>,
+    _options?: {
+      irreversible?: boolean
+      whole_word?: boolean
+      expires_in?: string
+    },
+  ): Promise<Response<Entity.Filter>> {
+    throw new NotImplementedError('updateFilter')
+  }
+
+  async deleteFilter(_id: string): Promise<Response<Entity.Filter>> {
+    throw new NotImplementedError('deleteFilter')
+  }
+
+  // =============================================
+  // Reports
+  // =============================================
+
+  async report(
+    _accountId: string,
+    _options?: {
+      status_ids?: Array<string>
+      comment: string
+      forward?: boolean
+      category?: Entity.Category
+      rule_ids?: Array<number>
+    },
+  ): Promise<Response<Entity.Report>> {
+    throw new NotImplementedError('report')
+  }
+
+  // =============================================
+  // Follow Requests
+  // =============================================
+
+  async getFollowRequests(
+    _limit?: number,
+  ): Promise<Response<Array<Entity.Account | Entity.FollowRequest>>> {
+    const requests = await this.client.request('following/requests/list', {})
+    return wrapResponse(
+      requests.map((r: Record<string, unknown>) => {
+        const follower = (r as { follower?: Misskey.entities.UserLite })
+          .follower
+        if (follower) {
+          return mapUserLiteToAccount(follower, this.origin)
+        }
+        return mapUserLiteToAccount(
+          r as unknown as Misskey.entities.UserLite,
+          this.origin,
+        )
+      }),
+    )
+  }
+
+  async acceptFollowRequest(
+    id: string,
+  ): Promise<Response<Entity.Relationship>> {
+    await this.client.request('following/requests/accept', { userId: id })
+    return this.getRelationship(id)
+  }
+
+  async rejectFollowRequest(
+    id: string,
+  ): Promise<Response<Entity.Relationship>> {
+    await this.client.request('following/requests/reject', { userId: id })
+    return this.getRelationship(id)
+  }
+
+  // =============================================
+  // Endorsements / Featured Tags / Suggestions
+  // =============================================
+
+  async getEndorsements(_options?: {
+    limit?: number
+    max_id?: string
+    since_id?: string
+  }): Promise<Response<Array<Entity.Account>>> {
+    return wrapResponse([])
+  }
+
+  async getFeaturedTags(): Promise<Response<Array<Entity.FeaturedTag>>> {
+    return wrapResponse([])
+  }
+
+  async createFeaturedTag(
+    _name: string,
+  ): Promise<Response<Entity.FeaturedTag>> {
+    throw new NotImplementedError('createFeaturedTag')
+  }
+
+  async deleteFeaturedTag(
+    _id: string,
+  ): Promise<Response<Record<string, never>>> {
+    throw new NotImplementedError('deleteFeaturedTag')
+  }
+
+  async getSuggestedTags(): Promise<Response<Array<Entity.Tag>>> {
+    return wrapResponse([])
+  }
+
+  async getPreferences(): Promise<Response<Entity.Preferences>> {
+    throw new NotImplementedError('getPreferences')
+  }
+
+  async getFollowedTags(): Promise<Response<Array<Entity.Tag>>> {
+    return wrapResponse([])
+  }
+
+  async getSuggestions(
+    _limit?: number,
+  ): Promise<Response<Array<Entity.Account>>> {
+    return wrapResponse([])
+  }
+
+  async getTag(_id: string): Promise<Response<Entity.Tag>> {
+    throw new NotImplementedError('getTag')
+  }
+
+  async followTag(_id: string): Promise<Response<Entity.Tag>> {
+    throw new NotImplementedError('followTag')
+  }
+
+  async unfollowTag(_id: string): Promise<Response<Entity.Tag>> {
+    throw new NotImplementedError('unfollowTag')
+  }
+
+  // =============================================
+  // Statuses
+  // =============================================
+
+  async postStatus(
+    status: string,
+    options?: {
+      media_ids?: Array<string>
+      poll?: {
+        options: Array<string>
+        expires_in: number
+        multiple?: boolean
+        hide_totals?: boolean
+      }
+      in_reply_to_id?: string
+      sensitive?: boolean
+      spoiler_text?: string
+      visibility?: Entity.StatusVisibility
+      scheduled_at?: string
+      language?: string
+      quote_id?: string
+    },
+  ): Promise<Response<Entity.Status | Entity.ScheduledStatus>> {
+    const params: Record<string, unknown> = {
+      text: status,
+    }
+
+    if (options?.visibility) {
+      params.visibility = mapVisibilityToMisskey(options.visibility)
+    }
+
+    if (options?.in_reply_to_id) {
+      params.replyId = options.in_reply_to_id
+    }
+
+    if (options?.spoiler_text) {
+      params.cw = options.spoiler_text
+    }
+
+    if (options?.media_ids && options.media_ids.length > 0) {
+      params.fileIds = options.media_ids
+    }
+
+    if (options?.quote_id) {
+      params.renoteId = options.quote_id
+    }
+
+    if (options?.poll) {
+      params.poll = {
+        choices: options.poll.options,
+        expiredAfter: options.poll.expires_in * 1000,
+        multiple: options.poll.multiple ?? false,
+      }
+    }
+
+    // biome-ignore lint/complexity/noBannedTypes: misskey-js の notes/create は動的パラメータのため型安全な呼び出しが困難
+    const note = await (this.client.request as Function)('notes/create', params)
+    const createdNote = (note as { createdNote: Misskey.entities.Note })
+      .createdNote
+    return wrapResponse(mapNoteToStatus(createdNote, this.origin))
+  }
+
+  async getStatus(id: string): Promise<Response<Entity.Status>> {
+    const note = await this.client.request('notes/show', { noteId: id })
+    return wrapResponse(mapNoteToStatus(note, this.origin))
+  }
+
+  async editStatus(
+    _id: string,
+    _options: {
+      status?: string
+      spoiler_text?: string
+      sensitive?: boolean
+      media_ids?: Array<string>
+      poll?: {
+        options?: Array<string>
+        expires_in?: number
+        multiple?: boolean
+        hide_totals?: boolean
+      }
+    },
+  ): Promise<Response<Entity.Status>> {
+    throw new NotImplementedError('editStatus')
+  }
+
+  async deleteStatus(id: string): Promise<Response<Record<string, never>>> {
+    await this.client.request('notes/delete', { noteId: id })
+    return wrapResponse({} as Record<string, never>)
+  }
+
+  async getStatusContext(
+    id: string,
+    _options?: {
+      limit?: number
+      max_id?: string
+      since_id?: string
+    },
+  ): Promise<Response<Entity.Context>> {
+    // Get conversation (replies/ancestors)
+    const conversation = await this.client.request('notes/conversation', {
+      limit: 40,
+      noteId: id,
+    })
+    const children = await this.client.request('notes/children', {
+      limit: 40,
+      noteId: id,
+    })
+
+    return wrapResponse({
+      ancestors: conversation
+        .reverse()
+        .map((n) => mapNoteToStatus(n, this.origin)),
+      descendants: children.map((n) => mapNoteToStatus(n, this.origin)),
+    })
+  }
+
+  async getStatusSource(_id: string): Promise<Response<Entity.StatusSource>> {
+    throw new NotImplementedError('getStatusSource')
+  }
+
+  async getStatusRebloggedBy(
+    id: string,
+  ): Promise<Response<Array<Entity.Account>>> {
+    const renotes = await this.client.request('notes/renotes', {
+      limit: 40,
+      noteId: id,
+    })
+    return wrapResponse(
+      renotes.map((n) => mapUserLiteToAccount(n.user, this.origin)),
+    )
+  }
+
+  async getStatusFavouritedBy(
+    id: string,
+  ): Promise<Response<Array<Entity.Account>>> {
+    const reactions = await this.client.request('notes/reactions', {
+      limit: 40,
+      noteId: id,
+    })
+    return wrapResponse(
+      reactions.map((r: Record<string, unknown>) => {
+        const user = (r as { user: Misskey.entities.UserLite }).user
+        return mapUserLiteToAccount(user, this.origin)
+      }),
+    )
+  }
+
+  async favouriteStatus(id: string): Promise<Response<Entity.Status>> {
+    // Misskey uses reactions instead of favourites; use ❤️ as default
+    await this.client.request('notes/reactions/create', {
+      noteId: id,
+      reaction: '❤️',
+    })
+    return this.getStatus(id)
+  }
+
+  async unfavouriteStatus(id: string): Promise<Response<Entity.Status>> {
+    await this.client.request('notes/reactions/delete', { noteId: id })
+    return this.getStatus(id)
+  }
+
+  async reblogStatus(id: string): Promise<Response<Entity.Status>> {
+    // biome-ignore lint/complexity/noBannedTypes: misskey-js の notes/create は動的パラメータのため型安全な呼び出しが困難
+    const result = await (this.client.request as Function)('notes/create', {
+      renoteId: id,
+    })
+    const createdNote = (result as { createdNote: Misskey.entities.Note })
+      .createdNote
+    return wrapResponse(mapNoteToStatus(createdNote, this.origin))
+  }
+
+  async unreblogStatus(id: string): Promise<Response<Entity.Status>> {
+    // Misskey: delete the renote by unrenoteing
+    await this.client.request('notes/unrenote', { noteId: id })
+    return this.getStatus(id)
+  }
+
+  async bookmarkStatus(id: string): Promise<Response<Entity.Status>> {
+    await this.client.request('notes/favorites/create', { noteId: id })
+    const status = await this.getStatus(id)
+    status.data.bookmarked = true
+    return status
+  }
+
+  async unbookmarkStatus(id: string): Promise<Response<Entity.Status>> {
+    await this.client.request('notes/favorites/delete', { noteId: id })
+    const status = await this.getStatus(id)
+    status.data.bookmarked = false
+    return status
+  }
+
+  async muteStatus(_id: string): Promise<Response<Entity.Status>> {
+    throw new NotImplementedError('muteStatus')
+  }
+
+  async unmuteStatus(_id: string): Promise<Response<Entity.Status>> {
+    throw new NotImplementedError('unmuteStatus')
+  }
+
+  async pinStatus(id: string): Promise<Response<Entity.Status>> {
+    await this.client.request('i/pin', { noteId: id })
+    return this.getStatus(id)
+  }
+
+  async unpinStatus(id: string): Promise<Response<Entity.Status>> {
+    await this.client.request('i/unpin', { noteId: id })
+    return this.getStatus(id)
+  }
+
+  // =============================================
+  // Media
+  // =============================================
+
+  async uploadMedia(
+    _file: unknown,
+    _options?: {
+      description?: string
+      focus?: string
+    },
+  ): Promise<Response<Entity.Attachment | Entity.AsyncAttachment>> {
+    throw new NotImplementedError('uploadMedia')
+  }
+
+  async getMedia(_id: string): Promise<Response<Entity.Attachment>> {
+    throw new NotImplementedError('getMedia')
+  }
+
+  async updateMedia(
+    _id: string,
+    _options?: {
+      file?: unknown
+      description?: string
+      focus?: string
+      is_sensitive?: boolean
+    },
+  ): Promise<Response<Entity.Attachment>> {
+    throw new NotImplementedError('updateMedia')
+  }
+
+  // =============================================
+  // Polls
+  // =============================================
+
+  async getPoll(_id: string): Promise<Response<Entity.Poll>> {
+    throw new NotImplementedError('getPoll')
+  }
+
+  async votePoll(
+    _id: string,
+    _choices: Array<number>,
+    _status_id?: string | null,
+  ): Promise<Response<Entity.Poll>> {
+    throw new NotImplementedError('votePoll')
+  }
+
+  // =============================================
+  // Scheduled Statuses
+  // =============================================
+
+  async getScheduledStatuses(_options?: {
+    limit?: number
+    max_id?: string
+    since_id?: string
+    min_id?: string
+  }): Promise<Response<Array<Entity.ScheduledStatus>>> {
+    return wrapResponse([])
+  }
+
+  async getScheduledStatus(
+    _id: string,
+  ): Promise<Response<Entity.ScheduledStatus>> {
+    throw new NotImplementedError('getScheduledStatus')
+  }
+
+  async scheduleStatus(
+    _id: string,
+    _scheduledAt?: string | null,
+  ): Promise<Response<Entity.ScheduledStatus>> {
+    throw new NotImplementedError('scheduleStatus')
+  }
+
+  async cancelScheduledStatus(
+    _id: string,
+  ): Promise<Response<Record<string, never>>> {
+    throw new NotImplementedError('cancelScheduledStatus')
+  }
+
+  // =============================================
+  // Timelines
+  // =============================================
+
+  async getPublicTimeline(options?: {
+    only_media?: boolean
+    limit?: number
+    max_id?: string
+    since_id?: string
+    min_id?: string
+  }): Promise<Response<Array<Entity.Status>>> {
+    const notes = await this.client.request('notes/global-timeline', {
+      limit: options?.limit ?? 20,
+      ...(options?.max_id ? { untilId: options.max_id } : {}),
+      ...(options?.since_id ? { sinceId: options.since_id } : {}),
+      ...(options?.only_media ? { withFiles: true } : {}),
+    })
+    return wrapResponse(notes.map((n) => mapNoteToStatus(n, this.origin)))
+  }
+
+  async getLocalTimeline(options?: {
+    only_media?: boolean
+    limit?: number
+    max_id?: string
+    since_id?: string
+    min_id?: string
+  }): Promise<Response<Array<Entity.Status>>> {
+    const notes = await this.client.request('notes/local-timeline', {
+      limit: options?.limit ?? 20,
+      ...(options?.max_id ? { untilId: options.max_id } : {}),
+      ...(options?.since_id ? { sinceId: options.since_id } : {}),
+      ...(options?.only_media ? { withFiles: true } : {}),
+    })
+    return wrapResponse(notes.map((n) => mapNoteToStatus(n, this.origin)))
+  }
+
+  async getTagTimeline(
+    hashtag: string,
+    options?: {
+      local?: boolean
+      only_media?: boolean
+      limit?: number
+      max_id?: string
+      since_id?: string
+      min_id?: string
+    },
+  ): Promise<Response<Array<Entity.Status>>> {
+    const notes = await this.client.request('notes/search-by-tag', {
+      limit: options?.limit ?? 20,
+      tag: hashtag,
+      ...(options?.max_id ? { untilId: options.max_id } : {}),
+      ...(options?.since_id ? { sinceId: options.since_id } : {}),
+    })
+    return wrapResponse(notes.map((n) => mapNoteToStatus(n, this.origin)))
+  }
+
+  async getHomeTimeline(options?: {
+    local?: boolean
+    limit?: number
+    max_id?: string
+    since_id?: string
+    min_id?: string
+  }): Promise<Response<Array<Entity.Status>>> {
+    const notes = await this.client.request('notes/timeline', {
+      limit: options?.limit ?? 20,
+      ...(options?.max_id ? { untilId: options.max_id } : {}),
+      ...(options?.since_id ? { sinceId: options.since_id } : {}),
+    })
+    return wrapResponse(notes.map((n) => mapNoteToStatus(n, this.origin)))
+  }
+
+  async getListTimeline(
+    listId: string,
+    options?: {
+      limit?: number
+      max_id?: string
+      since_id?: string
+      min_id?: string
+    },
+  ): Promise<Response<Array<Entity.Status>>> {
+    const notes = await this.client.request('notes/user-list-timeline', {
+      limit: options?.limit ?? 20,
+      listId,
+      ...(options?.max_id ? { untilId: options.max_id } : {}),
+      ...(options?.since_id ? { sinceId: options.since_id } : {}),
+    })
+    return wrapResponse(notes.map((n) => mapNoteToStatus(n, this.origin)))
+  }
+
+  async getConversationTimeline(_options?: {
+    limit?: number
+    max_id?: string
+    since_id?: string
+    min_id?: string
+  }): Promise<Response<Array<Entity.Conversation>>> {
+    throw new NotImplementedError('getConversationTimeline')
+  }
+
+  // =============================================
+  // Lists
+  // =============================================
+
+  async deleteConversation(
+    _id: string,
+  ): Promise<Response<Record<string, never>>> {
+    throw new NotImplementedError('deleteConversation')
+  }
+
+  async readConversation(_id: string): Promise<Response<Entity.Conversation>> {
+    throw new NotImplementedError('readConversation')
+  }
+
+  async getLists(): Promise<Response<Array<Entity.List>>> {
+    const lists = await this.client.request('users/lists/list', {})
+    return wrapResponse(
+      lists.map(
+        (l) =>
+          ({
+            id: l.id,
+            replies_policy: null,
+            title: l.name,
+          }) as unknown as Entity.List,
+      ),
+    )
+  }
+
+  async getList(_id: string): Promise<Response<Entity.List>> {
+    throw new NotImplementedError('getList')
+  }
+
+  async createList(_title: string): Promise<Response<Entity.List>> {
+    throw new NotImplementedError('createList')
+  }
+
+  async updateList(
+    _id: string,
+    _title: string,
+  ): Promise<Response<Entity.List>> {
+    throw new NotImplementedError('updateList')
+  }
+
+  async deleteList(_id: string): Promise<Response<Record<string, never>>> {
+    throw new NotImplementedError('deleteList')
+  }
+
+  async getAccountsInList(
+    _id: string,
+    _options?: {
+      limit?: number
+      max_id?: string
+      since_id?: string
+    },
+  ): Promise<Response<Array<Entity.Account>>> {
+    throw new NotImplementedError('getAccountsInList')
+  }
+
+  async addAccountsToList(
+    _id: string,
+    _accountIds: Array<string>,
+  ): Promise<Response<Record<string, never>>> {
+    throw new NotImplementedError('addAccountsToList')
+  }
+
+  async deleteAccountsFromList(
+    _id: string,
+    _accountIds: Array<string>,
+  ): Promise<Response<Record<string, never>>> {
+    throw new NotImplementedError('deleteAccountsFromList')
+  }
+
+  // =============================================
+  // Markers
+  // =============================================
+
+  async getMarkers(
+    _timeline: Array<string>,
+  ): Promise<Response<Entity.Marker | Record<string, never>>> {
+    return wrapResponse({})
+  }
+
+  async saveMarkers(_options?: {
+    home?: { last_read_id: string }
+    notifications?: { last_read_id: string }
+  }): Promise<Response<Entity.Marker>> {
+    throw new NotImplementedError('saveMarkers')
+  }
+
+  // =============================================
+  // Notifications
+  // =============================================
+
+  async getNotifications(options?: {
+    limit?: number
+    max_id?: string
+    since_id?: string
+    min_id?: string
+    exclude_types?: Array<Entity.NotificationType>
+    account_id?: string
+  }): Promise<Response<Array<Entity.Notification>>> {
+    const notifications = await this.client.request('i/notifications', {
+      limit: options?.limit ?? 20,
+      ...(options?.max_id ? { untilId: options.max_id } : {}),
+      ...(options?.since_id ? { sinceId: options.since_id } : {}),
+    })
+    return wrapResponse(
+      notifications.map((n) => mapNotification(n, this.origin)),
+    )
+  }
+
+  async getNotification(_id: string): Promise<Response<Entity.Notification>> {
+    // Misskey doesn't have a single notification endpoint; use the list with includeTypes
+    throw new NotImplementedError('getNotification')
+  }
+
+  async dismissNotifications(): Promise<Response<Record<string, never>>> {
+    await this.client.request('notifications/mark-all-as-read', {})
+    return wrapResponse({} as Record<string, never>)
+  }
+
+  async dismissNotification(
+    _id: string,
+  ): Promise<Response<Record<string, never>>> {
+    throw new NotImplementedError('dismissNotification')
+  }
+
+  async readNotifications(_options: {
+    id?: string
+    max_id?: string
+  }): Promise<Response<Record<string, never>>> {
+    await this.client.request('notifications/mark-all-as-read', {})
+    return wrapResponse({} as Record<string, never>)
+  }
+
+  // =============================================
+  // Push Subscriptions
+  // =============================================
+
+  async subscribePushNotification(
+    _subscription: {
+      endpoint: string
+      keys: { p256dh: string; auth: string }
+    },
+    _data?: { alerts: Record<string, boolean> } | null,
+  ): Promise<Response<Entity.PushSubscription>> {
+    throw new NotImplementedError('subscribePushNotification')
+  }
+
+  async getPushSubscription(): Promise<Response<Entity.PushSubscription>> {
+    throw new NotImplementedError('getPushSubscription')
+  }
+
+  async updatePushSubscription(
+    _data?: { alerts: Record<string, boolean> } | null,
+  ): Promise<Response<Entity.PushSubscription>> {
+    throw new NotImplementedError('updatePushSubscription')
+  }
+
+  async deletePushSubscription(): Promise<Response<Record<string, never>>> {
+    throw new NotImplementedError('deletePushSubscription')
+  }
+
+  // =============================================
+  // Search
+  // =============================================
+
+  async search(
+    q: string,
+    options?: {
+      type?: 'accounts' | 'hashtags' | 'statuses'
+      limit?: number
+      max_id?: string
+      min_id?: string
+      resolve?: boolean
+      offset?: number
+      following?: boolean
+      account_id?: string
+      exclude_unreviewed?: boolean
+    },
+  ): Promise<Response<Entity.Results>> {
+    const results: Entity.Results = {
+      accounts: [],
+      hashtags: [],
+      statuses: [],
+    }
+
+    if (!options?.type || options.type === 'accounts') {
+      const users = await this.client.request('users/search', {
+        limit: options?.limit ?? 20,
+        query: q,
+      })
+      results.accounts = users.map((u) =>
+        mapUserLiteToAccount(
+          u as unknown as Misskey.entities.UserLite,
+          this.origin,
+        ),
+      )
+    }
+
+    if (!options?.type || options.type === 'statuses') {
+      const notes = await this.client.request('notes/search', {
+        limit: options?.limit ?? 20,
+        query: q,
+      })
+      results.statuses = notes.map((n) => mapNoteToStatus(n, this.origin))
+    }
+
+    if (!options?.type || options.type === 'hashtags') {
+      // Misskey doesn't have a dedicated hashtag search API
+      // Return empty for now
+      results.hashtags = []
+    }
+
+    return wrapResponse(results)
+  }
+
+  // =============================================
+  // Instance
+  // =============================================
+
+  async getInstance(): Promise<Response<Entity.Instance>> {
+    const meta = await this.client.request('meta', { detail: true })
+    const m = meta as Record<string, unknown>
+    return wrapResponse({
+      approval_required: false,
+      configuration: {
+        statuses: {
+          max_characters: (m.maxNoteTextLength as number) ?? 3000,
+        },
+        urls: {
+          streaming: '',
+        },
+      },
+      contact_account: null,
+      description: (m.description as string) ?? '',
+      email: (m.maintainerEmail as string) ?? '',
+      languages: (m.langs as string[]) ?? [],
+      max_toot_chars: (m.maxNoteTextLength as number) ?? 3000,
+      registrations: false,
+      rules: [],
+      stats: {
+        domain_count: 0,
+        status_count: 0,
+        user_count: 0,
+      },
+      title: (m.name as string) ?? '',
+      uri: this.origin,
+      urls: {
+        streaming_api: '',
+      },
+      version: `Misskey ${(m.version as string) ?? ''}`,
+    } as unknown as Entity.Instance)
+  }
+
+  async getInstancePeers(): Promise<Response<Array<string>>> {
+    return wrapResponse([])
+  }
+
+  async getInstanceActivity(): Promise<Response<Array<Entity.Activity>>> {
+    return wrapResponse([])
+  }
+
+  async getInstanceTrends(
+    _limit?: number | null,
+  ): Promise<Response<Array<Entity.Tag>>> {
+    return wrapResponse([])
+  }
+
+  async getInstanceDirectory(_options?: {
+    limit?: number
+    offset?: number
+    order?: 'active' | 'new'
+    local?: boolean
+  }): Promise<Response<Array<Entity.Account>>> {
+    return wrapResponse([])
+  }
+
+  async getInstanceCustomEmojis(): Promise<Response<Array<Entity.Emoji>>> {
+    const emojis = await this.client.request('emojis', {})
+    const emojiList =
+      (
+        emojis as {
+          emojis: Array<{
+            name: string
+            url: string
+            category?: string
+            aliases?: string[]
+          }>
+        }
+      ).emojis ?? []
+    return wrapResponse(
+      emojiList.map((e) => ({
+        category: e.category ?? undefined,
+        shortcode: e.name,
+        static_url: e.url,
+        url: e.url,
+        visible_in_picker: true,
+      })),
+    )
+  }
+
+  async getInstanceAnnouncements(): Promise<
+    Response<Array<Entity.Announcement>>
+  > {
+    return wrapResponse([])
+  }
+
+  async dismissInstanceAnnouncement(
+    _id: string,
+  ): Promise<Response<Record<never, never>>> {
+    throw new NotImplementedError('dismissInstanceAnnouncement')
+  }
+
+  async addReactionToAnnouncement(
+    _id: string,
+    _name: string,
+  ): Promise<Response<Record<never, never>>> {
+    throw new NotImplementedError('addReactionToAnnouncement')
+  }
+
+  async removeReactionFromAnnouncement(
+    _id: string,
+    _name: string,
+  ): Promise<Response<Record<never, never>>> {
+    throw new NotImplementedError('removeReactionFromAnnouncement')
+  }
+
+  // =============================================
+  // Emoji Reactions
+  // =============================================
+
+  async createEmojiReaction(
+    id: string,
+    emoji: string,
+  ): Promise<Response<Entity.Status>> {
+    await this.client.request('notes/reactions/create', {
+      noteId: id,
+      reaction: emoji,
+    })
+    return this.getStatus(id)
+  }
+
+  async deleteEmojiReaction(
+    id: string,
+    _emoji: string,
+  ): Promise<Response<Entity.Status>> {
+    await this.client.request('notes/reactions/delete', { noteId: id })
+    return this.getStatus(id)
+  }
+
+  async getEmojiReactions(
+    id: string,
+  ): Promise<Response<Array<Entity.Reaction>>> {
+    const note = await this.client.request('notes/show', { noteId: id })
+    const reactions: Record<string, number> = note.reactions ?? {}
+    return wrapResponse(
+      Object.entries(reactions).map(
+        ([name, count]: [string, number]) =>
+          ({
+            accounts: [],
+            count,
+            me: note.myReaction === name,
+            name,
+          }) as Entity.Reaction,
+      ),
+    )
+  }
+
+  async getEmojiReaction(
+    id: string,
+    emoji: string,
+  ): Promise<Response<Entity.Reaction>> {
+    const res = await this.getEmojiReactions(id)
+    const found = res.data.find((r) => r.name === emoji)
+    if (!found) {
+      return wrapResponse({
+        accounts: [],
+        count: 0,
+        me: false,
+        name: emoji,
+      } as Entity.Reaction)
+    }
+    return wrapResponse(found)
+  }
+
+  // =============================================
+  // Streaming
+  // =============================================
+
+  async streamingURL(): Promise<string> {
+    return this.origin
+  }
+
+  async userStreaming(): Promise<WebSocketInterface> {
+    const adapter = new MisskeyWebSocketAdapter(
+      this.origin,
+      this.credential ?? '',
+      'homeTimeline',
+    )
+    adapter.start()
+    return adapter
+  }
+
+  async publicStreaming(): Promise<WebSocketInterface> {
+    const adapter = new MisskeyWebSocketAdapter(
+      this.origin,
+      this.credential ?? '',
+      'globalTimeline',
+    )
+    adapter.start()
+    return adapter
+  }
+
+  async localStreaming(): Promise<WebSocketInterface> {
+    const adapter = new MisskeyWebSocketAdapter(
+      this.origin,
+      this.credential ?? '',
+      'localTimeline',
+    )
+    adapter.start()
+    return adapter
+  }
+
+  async tagStreaming(tag: string): Promise<WebSocketInterface> {
+    const adapter = new MisskeyWebSocketAdapter(
+      this.origin,
+      this.credential ?? '',
+      'hashtag',
+      { tag },
+    )
+    adapter.start()
+    return adapter
+  }
+
+  async listStreaming(_listId: string): Promise<WebSocketInterface> {
+    throw new NotImplementedError('listStreaming')
+  }
+
+  async directStreaming(): Promise<WebSocketInterface> {
+    throw new NotImplementedError('directStreaming')
+  }
+}

--- a/src/util/misskey/MisskeyWebSocketAdapter.ts
+++ b/src/util/misskey/MisskeyWebSocketAdapter.ts
@@ -1,0 +1,129 @@
+import { EventEmitter } from 'node:events'
+import type { WebSocketInterface } from 'megalodon'
+import * as Misskey from 'misskey-js'
+import { mapNoteToStatus, mapNotification } from './mappers'
+
+type ChannelType =
+  | 'homeTimeline'
+  | 'localTimeline'
+  | 'globalTimeline'
+  | 'hashtag'
+  | 'main'
+
+/**
+ * misskey-js の Stream/Connection を megalodon の WebSocketInterface でラップするアダプター
+ *
+ * megalodon の WebSocketInterface はイベントベース:
+ *   - 'update'        → Entity.Status
+ *   - 'status_update'  → Entity.Status
+ *   - 'notification'   → Entity.Notification
+ *   - 'delete'         → string (status id)
+ *   - 'connect'        → void
+ *   - 'error'          → Error
+ *
+ * misskey-js の Stream はチャンネルベース:
+ *   - channel.on('note', Note)
+ *   - mainChannel.on('notification', Notification)
+ *   - stream.on('_connected_')
+ *   - stream.on('_disconnected_')
+ */
+export class MisskeyWebSocketAdapter
+  extends EventEmitter
+  implements WebSocketInterface
+{
+  private stream: Misskey.Stream
+  // biome-ignore lint/suspicious/noExplicitAny: misskey-js の Connection 型は厳密なジェネリクスを持ち、チャンネル横断で統一的に扱えないため any を使用
+  private channel: any = null
+  // biome-ignore lint/suspicious/noExplicitAny: 同上
+  private mainChannel: any = null
+  private channelType: ChannelType
+  private channelParams: Record<string, unknown>
+  private origin: string
+  private started = false
+
+  constructor(
+    origin: string,
+    token: string,
+    channelType: ChannelType,
+    channelParams: Record<string, unknown> = {},
+  ) {
+    super()
+    this.origin = origin
+    this.channelType = channelType
+    this.channelParams = channelParams
+    this.stream = new Misskey.Stream(origin, { token })
+    this.setupStreamEvents()
+  }
+
+  private setupStreamEvents(): void {
+    this.stream.on('_connected_', () => {
+      this.emit('connect')
+    })
+
+    this.stream.on('_disconnected_', () => {
+      // megalodon では disconnect 時に error を発火してリトライを促す
+      this.emit('error', new Error('Misskey stream disconnected'))
+    })
+  }
+
+  private setupChannel(): void {
+    if (this.channelType === 'hashtag') {
+      // hashtag チャンネルは q パラメータが string[][] 形式
+      const tag = this.channelParams.tag as string
+      // biome-ignore lint/correctness/useHookAtTopLevel: useChannel は React hook ではなく misskey-js の Stream メソッド
+      this.channel = this.stream.useChannel('hashtag', {
+        q: [[tag]],
+      })
+    } else {
+      // biome-ignore lint/correctness/useHookAtTopLevel: useChannel は React hook ではなく misskey-js の Stream メソッド
+      this.channel = this.stream.useChannel(
+        this.channelType as 'homeTimeline' | 'localTimeline' | 'globalTimeline',
+        this.channelParams as Record<string, never>,
+      )
+    }
+
+    // Note イベント → 'update' に変換
+    this.channel.on('note', (note: Misskey.entities.Note) => {
+      const status = mapNoteToStatus(note, this.origin)
+      this.emit('update', status)
+    })
+
+    // homeTimeline の場合は main チャンネルも接続して通知を受信
+    if (this.channelType === 'homeTimeline') {
+      // biome-ignore lint/correctness/useHookAtTopLevel: useChannel は React hook ではなく misskey-js の Stream メソッド
+      this.mainChannel = this.stream.useChannel('main')
+
+      this.mainChannel.on(
+        'notification',
+        (notif: Misskey.entities.Notification) => {
+          const mapped = mapNotification(notif, this.origin)
+          this.emit('notification', mapped)
+        },
+      )
+    }
+  }
+
+  start(): void {
+    if (this.started) return
+    this.started = true
+    this.setupChannel()
+  }
+
+  stop(): void {
+    if (!this.started) return
+    this.started = false
+
+    if (this.channel) {
+      this.channel.dispose()
+      this.channel = null
+    }
+    if (this.mainChannel) {
+      this.mainChannel.dispose()
+      this.mainChannel = null
+    }
+
+    this.stream.close()
+  }
+
+  // on, once, removeListener, removeAllListeners are inherited from EventEmitter
+}

--- a/src/util/misskey/auth.ts
+++ b/src/util/misskey/auth.ts
@@ -1,0 +1,121 @@
+import type { OAuth } from 'megalodon'
+
+/**
+ * MiAuth のパーミッションスコープ
+ * read/write の Mastodon スコープを Misskey パーミッションにマッピング
+ */
+const MISSKEY_PERMISSIONS = [
+  'read:account',
+  'write:account',
+  'read:blocks',
+  'write:blocks',
+  'read:drive',
+  'write:drive',
+  'read:favorites',
+  'write:favorites',
+  'read:following',
+  'write:following',
+  'read:mutes',
+  'write:mutes',
+  'write:notes',
+  'read:notifications',
+  'write:notifications',
+  'read:reactions',
+  'write:reactions',
+  'write:votes',
+]
+
+/**
+ * MiAuth セッション ID を生成
+ */
+function generateSessionId(): string {
+  return crypto.randomUUID()
+}
+
+/**
+ * MiAuth 認証 URL を構築する
+ *
+ * @returns OAuth.AppData 互換オブジェクト（url に MiAuth URL を格納）
+ */
+export function createMiAuthAppData(
+  origin: string,
+  appName: string,
+  callbackUrl: string,
+): OAuth.AppData {
+  const sessionId = generateSessionId()
+  const permissions = MISSKEY_PERMISSIONS.join(',')
+  const miAuthUrl = `${origin}/miauth/${sessionId}?name=${encodeURIComponent(appName)}&callback=${encodeURIComponent(callbackUrl)}&permission=${permissions}`
+
+  return {
+    client_id: sessionId,
+    client_secret: '',
+    id: '',
+    name: appName,
+    redirect_uri: callbackUrl,
+    session_token: sessionId,
+    url: miAuthUrl,
+    website: callbackUrl,
+  }
+}
+
+/**
+ * MiAuth セッションからアクセストークンを取得する
+ *
+ * @param origin Misskey インスタンスの URL
+ * @param sessionId MiAuth セッション ID (= appData.client_id)
+ * @returns OAuth.TokenData 互換オブジェクト
+ */
+export async function fetchMiAuthToken(
+  origin: string,
+  sessionId: string,
+): Promise<OAuth.TokenData> {
+  const response = await fetch(`${origin}/api/miauth/${sessionId}/check`, {
+    body: '{}',
+    headers: { 'Content-Type': 'application/json' },
+    method: 'POST',
+  })
+
+  if (!response.ok) {
+    throw new Error(
+      `MiAuth check failed: ${response.status} ${response.statusText}`,
+    )
+  }
+
+  const data = (await response.json()) as {
+    ok: boolean
+    token: string
+    user: Record<string, unknown>
+  }
+
+  if (!data.ok || !data.token) {
+    throw new Error('MiAuth check returned ok=false or missing token')
+  }
+
+  return {
+    access_token: data.token,
+    created_at: Math.floor(Date.now() / 1000),
+    expires_in: null,
+    refresh_token: null,
+    scope: MISSKEY_PERMISSIONS.join(' '),
+    token_type: 'Bearer',
+  }
+}
+
+/**
+ * Misskey インスタンスかどうかを nodeinfo から判定する
+ */
+export async function detectMisskey(origin: string): Promise<boolean> {
+  try {
+    const res = await fetch(`${origin}/api/meta`, {
+      body: '{}',
+      headers: { 'Content-Type': 'application/json' },
+      method: 'POST',
+    })
+    if (!res.ok) return false
+    const meta = (await res.json()) as Record<string, unknown>
+    // Misskey の /api/meta は version フィールドを持つ
+    return typeof meta.version === 'string'
+  } catch {
+    return false
+  }
+}

--- a/src/util/misskey/mappers.ts
+++ b/src/util/misskey/mappers.ts
@@ -1,0 +1,370 @@
+import type { Entity } from 'megalodon'
+import type * as Misskey from 'misskey-js'
+
+// ========================================
+// Visibility Mapping
+// ========================================
+
+export function mapVisibility(
+  v: 'public' | 'home' | 'followers' | 'specified',
+): Entity.StatusVisibility {
+  switch (v) {
+    case 'public':
+      return 'public'
+    case 'home':
+      return 'unlisted'
+    case 'followers':
+      return 'private'
+    case 'specified':
+      return 'direct'
+  }
+}
+
+export function mapVisibilityToMisskey(
+  v: string,
+): 'public' | 'home' | 'followers' | 'specified' {
+  switch (v) {
+    case 'public':
+      return 'public'
+    case 'unlisted':
+      return 'home'
+    case 'private':
+      return 'followers'
+    case 'direct':
+      return 'specified'
+    default:
+      return 'public'
+  }
+}
+
+// ========================================
+// Emoji Mapping
+// ========================================
+
+export function mapEmojis(
+  emojis: Record<string, string> | undefined,
+): Entity.Emoji[] {
+  if (!emojis) return []
+  return Object.entries(emojis).map(([shortcode, url]) => ({
+    shortcode,
+    static_url: url,
+    url,
+    visible_in_picker: true,
+  }))
+}
+
+// ========================================
+// DriveFile → Attachment
+// ========================================
+
+function getAttachmentType(
+  mimeType: string,
+): 'image' | 'video' | 'audio' | 'gifv' | 'unknown' {
+  if (mimeType.startsWith('image/gif')) return 'gifv'
+  if (mimeType.startsWith('image/')) return 'image'
+  if (mimeType.startsWith('video/')) return 'video'
+  if (mimeType.startsWith('audio/')) return 'audio'
+  return 'unknown'
+}
+
+export function mapDriveFileToAttachment(
+  file: Misskey.entities.DriveFile,
+): Entity.Attachment {
+  return {
+    blurhash: file.blurhash ?? null,
+    description: file.comment ?? null,
+    id: file.id,
+    meta: file.properties
+      ? {
+          height: file.properties.height,
+          width: file.properties.width,
+        }
+      : null,
+    preview_url: file.thumbnailUrl ?? null,
+    remote_url: null,
+    text_url: null,
+    type: getAttachmentType(file.type),
+    url: file.url,
+  }
+}
+
+// ========================================
+// UserLite → Account
+// ========================================
+
+export function mapUserLiteToAccount(
+  user: Misskey.entities.UserLite,
+  instanceHost?: string,
+): Entity.Account {
+  const acct = user.host ? `${user.username}@${user.host}` : user.username
+  const userUrl = user.host
+    ? `https://${user.host}/@${user.username}`
+    : instanceHost
+      ? `${instanceHost}/@${user.username}`
+      : ''
+
+  return {
+    acct,
+    avatar: user.avatarUrl,
+    avatar_static: user.avatarUrl,
+    bot: user.isBot ?? null,
+    created_at: '',
+    display_name: user.name ?? user.username,
+    emojis: mapEmojis(user.emojis),
+    fields: [],
+    followers_count: 0,
+    following_count: 0,
+    group: null,
+    header: '',
+    header_static: '',
+    id: user.id,
+    limited: null,
+    locked: false,
+    moved: null,
+    noindex: null,
+    note: '',
+    statuses_count: 0,
+    suspended: null,
+    url: userUrl,
+    username: user.username,
+  }
+}
+
+// ========================================
+// UserDetailed → Account (with full profile)
+// ========================================
+
+export function mapUserDetailedToAccount(
+  user: Misskey.entities.UserDetailed,
+  instanceHost?: string,
+): Entity.Account {
+  const base = mapUserLiteToAccount(user, instanceHost)
+  // UserDetailed has additional fields
+  const detailed = user as Misskey.entities.UserDetailed & {
+    createdAt?: string
+    description?: string | null
+    followersCount?: number
+    followingCount?: number
+    notesCount?: number
+    isLocked?: boolean
+    fields?: Array<{ name: string; value: string }>
+    bannerUrl?: string | null
+  }
+
+  return {
+    ...base,
+    created_at: detailed.createdAt ?? '',
+    fields: (detailed.fields ?? []).map((f) => ({
+      name: f.name,
+      value: f.value,
+      verified_at: null,
+    })),
+    followers_count: detailed.followersCount ?? 0,
+    following_count: detailed.followingCount ?? 0,
+    header: detailed.bannerUrl ?? '',
+    header_static: detailed.bannerUrl ?? '',
+    locked: detailed.isLocked ?? false,
+    note: detailed.description ?? '',
+    statuses_count: detailed.notesCount ?? 0,
+  }
+}
+
+// ========================================
+// Emoji Reactions → megalodon Reaction[]
+// ========================================
+
+export function mapReactions(
+  reactions: Record<string, number>,
+  myReaction?: string | null,
+  reactionEmojis?: Record<string, string>,
+): Entity.Reaction[] {
+  return Object.entries(reactions).map(([name, count]) => {
+    // Custom emoji reactions have format :emoji_name: or :emoji_name@.:
+    const isCustom = name.startsWith(':') && name.endsWith(':')
+    const shortcode = isCustom ? name.slice(1, -1).replace(/@\.$/, '') : name
+    const emojiUrl = reactionEmojis?.[shortcode] ?? null
+
+    return {
+      accounts: [],
+      count,
+      me: myReaction === name,
+      name,
+      // Only include static_url/url if it's a custom emoji with a known URL
+      ...(emojiUrl ? { static_url: emojiUrl, url: emojiUrl } : {}),
+    } as Entity.Reaction
+  })
+}
+
+// ========================================
+// Note → Status
+// ========================================
+
+export function mapNoteToStatus(
+  note: Misskey.entities.Note,
+  instanceHost?: string,
+): Entity.Status {
+  const account = mapUserLiteToAccount(note.user, instanceHost)
+  const host = instanceHost ?? ''
+  const uri = note.uri ?? `${host}/notes/${note.id}`
+  const url = note.url ?? note.uri ?? `${host}/notes/${note.id}`
+
+  // Handle renote (reblog)
+  const isRenote =
+    note.renote != null &&
+    note.text == null &&
+    (note.fileIds?.length ?? 0) === 0
+  const reblog =
+    isRenote && note.renote ? mapNoteToStatus(note.renote, instanceHost) : null
+
+  // Build content from text (basic MFM → HTML)
+  const content = note.text ? escapeHtml(note.text) : ''
+
+  return {
+    account,
+    application: null,
+    bookmarked: false,
+    card: null,
+    content,
+    created_at: note.createdAt,
+    edited_at: null,
+    emoji_reactions: mapReactions(
+      note.reactions ?? {},
+      note.myReaction,
+      note.reactionEmojis,
+    ),
+    emojis: mapEmojis(note.emojis),
+    favourited: note.myReaction != null ? true : null,
+    favourites_count: note.reactionCount ?? 0,
+    id: note.id,
+    in_reply_to_account_id: null,
+    in_reply_to_id: note.replyId ?? null,
+    language: null,
+    media_attachments: (note.files ?? []).map(mapDriveFileToAttachment),
+    mentions: (note.mentions ?? []).map((id) => ({
+      acct: '',
+      id,
+      url: '',
+      username: '',
+    })),
+    muted: null,
+    pinned: null,
+    plain_content: note.text ?? null,
+    poll: note.poll
+      ? {
+          expired: false,
+          expires_at: note.poll.expiresAt ?? null,
+          id: note.id,
+          multiple: note.poll.multiple,
+          options: note.poll.choices.map((c) => ({
+            title: c.text,
+            votes_count: c.votes,
+          })),
+          voted: note.poll.choices.some((c) => c.isVoted),
+          votes_count: note.poll.choices.reduce((sum, c) => sum + c.votes, 0),
+        }
+      : null,
+    quote:
+      note.renote && !isRenote
+        ? {
+            quoted_status: mapNoteToStatus(note.renote, instanceHost),
+            state: 'accepted' as Entity.QuoteState,
+          }
+        : null,
+    quote_approval: null as unknown as Entity.Status['quote_approval'],
+    reblog,
+    reblogged: null,
+    reblogs_count: note.renoteCount ?? 0,
+    replies_count: note.repliesCount ?? 0,
+    sensitive: (note.files ?? []).some((f) => f.isSensitive),
+    spoiler_text: note.cw ?? '',
+    tags: (note.tags ?? []).map((tag) => ({
+      name: tag,
+      url: `${host}/tags/${tag}`,
+    })),
+    uri,
+    url,
+    visibility: mapVisibility(note.visibility),
+  }
+}
+
+// ========================================
+// Notification → megalodon Notification
+// ========================================
+
+function mapNotificationType(type: string): string {
+  switch (type) {
+    case 'follow':
+      return 'follow'
+    case 'receiveFollowRequest':
+      return 'follow_request'
+    case 'mention':
+    case 'reply':
+      return 'mention'
+    case 'renote':
+    case 'quote':
+      return 'reblog'
+    case 'reaction':
+      return 'favourite'
+    case 'pollEnded':
+      return 'poll'
+    case 'note':
+      return 'status'
+    default:
+      return type
+  }
+}
+
+export function mapNotification(
+  notif: Misskey.entities.Notification,
+  instanceHost?: string,
+): Entity.Notification {
+  const base = {
+    created_at: notif.createdAt,
+    id: notif.id,
+    type: mapNotificationType(notif.type),
+  }
+
+  // Handle different notification types
+  if ('user' in notif && notif.user) {
+    const account = mapUserLiteToAccount(
+      notif.user as Misskey.entities.UserLite,
+      instanceHost,
+    )
+    if ('note' in notif && notif.note) {
+      const status = mapNoteToStatus(
+        notif.note as Misskey.entities.Note,
+        instanceHost,
+      )
+      if (notif.type === 'reaction' && 'reaction' in notif) {
+        return {
+          ...base,
+          account,
+          reaction: {
+            accounts: [],
+            count: 1,
+            me: false,
+            name: (notif as { reaction: string }).reaction,
+          },
+          status,
+        }
+      }
+      return { ...base, account, status }
+    }
+    return { ...base, account }
+  }
+
+  // Notifications without user (scheduledNotePosted, achievementEarned, etc.)
+  return { ...base, account: null }
+}
+
+// ========================================
+// Utilities
+// ========================================
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/\n/g, '<br>')
+}

--- a/src/util/provider/AppsProvider.tsx
+++ b/src/util/provider/AppsProvider.tsx
@@ -11,8 +11,10 @@ import {
   useEffect,
   useState,
 } from 'react'
-import type { App, Backend } from 'types/types'
+import { type App, type Backend, backendList } from 'types/types'
 import { APP_NAME, APP_URL, BACKEND_SNS, BACKEND_URL } from 'util/environment'
+import { detectMisskey, fetchMiAuthToken } from 'util/misskey/auth'
+import { MisskeyAdapter } from 'util/misskey/MisskeyAdapter'
 
 export const AppsContext = createContext<App[]>([])
 
@@ -24,7 +26,9 @@ export const AppsProvider = ({
   children,
 }: Readonly<{ children: ReactNode }>) => {
   const router = useRouter()
-  const code = useSearchParams().get('code')
+  const searchParams = useSearchParams()
+  const code = searchParams.get('code')
+  const session = searchParams.get('session')
   const [apps, setApps] = useState<App[]>([])
 
   const [backend, setBackend] = useState<Backend | ''>(BACKEND_SNS)
@@ -50,7 +54,7 @@ export const AppsProvider = ({
       return
     }
 
-    if (code != null) {
+    if (code != null || session != null) {
       if (isRequestedToken) {
         return
       }
@@ -63,18 +67,23 @@ export const AppsProvider = ({
         return
       }
 
-      const client = generator(
-        processingAppData.backend,
-        processingAppData.backendUrl,
-      )
       setIsRequestedToken(true)
-      client
-        .fetchAccessToken(
-          processingAppData.appData.client_id,
-          processingAppData.appData.client_secret,
-          code,
-          APP_URL,
-        )
+      const tokenPromise =
+        processingAppData.backend === 'misskey'
+          ? fetchMiAuthToken(
+              processingAppData.backendUrl,
+              processingAppData.appData.client_id,
+            )
+          : generator(
+              processingAppData.backend,
+              processingAppData.backendUrl,
+            ).fetchAccessToken(
+              processingAppData.appData.client_id,
+              processingAppData.appData.client_secret,
+              code ?? '',
+              APP_URL,
+            )
+      tokenPromise
         .then((tokenData) => {
           const newApp: App = {
             appData: processingAppData.appData,
@@ -120,6 +129,7 @@ export const AppsProvider = ({
             }
 
             if (expires - now < 1000 * 60 * 60 * 24) {
+              if (app.backend === 'misskey') return // Misskey はリフレッシュトークン非対応
               const client = generator(app.backend, app.backendUrl)
               await client
                 .refreshToken(
@@ -140,7 +150,15 @@ export const AppsProvider = ({
       })
       setFinishLoading(true)
     }
-  }, [apps, code, isRequestedToken, router, storageLoading, updateApps])
+  }, [
+    apps,
+    code,
+    session,
+    isRequestedToken,
+    router,
+    storageLoading,
+    updateApps,
+  ])
 
   const onRegister = async () => {
     if (backendUrl === '') {
@@ -152,7 +170,15 @@ export const AppsProvider = ({
       try {
         return await detector(backendUrl)
       } catch (e) {
-        console.error('Failed to detect backend:', e)
+        console.error('Failed to detect backend via megalodon:', e)
+        // megalodon が検出できない場合、Misskey かどうか確認
+        try {
+          if (await detectMisskey(backendUrl)) {
+            return 'misskey' as Backend
+          }
+        } catch (e2) {
+          console.error('Failed to detect Misskey:', e2)
+        }
         return null
       }
     })()
@@ -160,7 +186,10 @@ export const AppsProvider = ({
       return
     }
     setBackend(detectedBackend)
-    const client = generator(detectedBackend, backendUrl)
+    const client =
+      detectedBackend === 'misskey'
+        ? new MisskeyAdapter(backendUrl)
+        : generator(detectedBackend, backendUrl)
 
     const findApp = apps.find(
       (app) => app.backend === detectedBackend && app.backendUrl === backendUrl,
@@ -217,6 +246,20 @@ export const AppsProvider = ({
               type="text"
               value={backendUrl}
             />
+            <select
+              className="w-full rounded-md border bg-gray-800 px-2 py-1 text-white"
+              onChange={(e) => {
+                setBackend(e.target.value as Backend | '')
+              }}
+              value={backend}
+            >
+              <option value="">自動検出</option>
+              {backendList.map((b) => (
+                <option key={b} value={b}>
+                  {b}
+                </option>
+              ))}
+            </select>
           </div>
           <div className="pt-4">
             <button

--- a/test.json
+++ b/test.json
@@ -1,0 +1,332 @@
+{
+  "account": {
+    "acct": "jizouninattamakaizou@misskey.art",
+    "avatar": "https://files.misskey.art/webpublic-60c1c9a5-d9f0-46d8-b97b-08b9f9db540c.webp",
+    "avatar_static": "https://files.misskey.art/webpublic-60c1c9a5-d9f0-46d8-b97b-08b9f9db540c.webp",
+    "bot": false,
+    "created_at": "2025-09-04T00:03:32.000Z",
+    "display_name": "🔞エロフィギュアに改造するピーマン🫑",
+    "emojis": [],
+    "fields": [],
+    "followers_count": 22,
+    "following_count": 134,
+    "fqn": "jizouninattamakaizou@misskey.art",
+    "header": "https://files.misskey.art/webpublic-ce7201a6-c6e1-41cf-bf31-c5ff5986a0d7.webp",
+    "header_static": "https://files.misskey.art/webpublic-ce7201a6-c6e1-41cf-bf31-c5ff5986a0d7.webp",
+    "id": "AxqSia9i1J2dX3mf0C",
+    "last_status_at": "2026-03-20",
+    "locked": false,
+    "note": "<p>僧侶になりピーマン🫑<span>になりサイレンスになりました。<br/>ノートはフォローしないと見えないようです。<br/>フィギュア関連は連絡どぞ<br/>基本ロリロリエロエロなフィギュアの魔改造してる。依頼であれば爆乳おっぱいマンもしてます<br/>無修正のアップするかもなTwitter<br/></span><a href=\"https://misskey.art/@966kom\" class=\"u-url mention\">@966kom</a><span><br/>手持ちや好きなキャラのフィギュアをエロエロにしませんか？依頼お待ちしてる。<br/><br/>消えた彼を覚えていますか?<br/></span></p>",
+    "pleroma": {
+      "accepts_chat_messages": null,
+      "also_known_as": [],
+      "ap_id": "https://misskey.art/users/ac7dozt439",
+      "avatar_description": "",
+      "background_image": null,
+      "deactivated": false,
+      "favicon": "https://files.misskey.art//2ddd6a58-2203-47ba-9aae-af6529f73b0b.png",
+      "header_description": "",
+      "hide_favorites": true,
+      "hide_followers": false,
+      "hide_followers_count": false,
+      "hide_follows": false,
+      "hide_follows_count": false,
+      "is_admin": false,
+      "is_confirmed": true,
+      "is_moderator": false,
+      "is_suggested": false,
+      "privileges": [],
+      "relationship": {},
+      "skip_thread_containment": false,
+      "tags": []
+    },
+    "source": {
+      "fields": [],
+      "note": "",
+      "pleroma": { "actor_type": "Person", "discoverable": true },
+      "sensitive": false
+    },
+    "statuses_count": 3761,
+    "url": "https://misskey.art/@jizouninattamakaizou",
+    "username": "jizouninattamakaizou"
+  },
+  "application": null,
+  "bookmarked": false,
+  "content": "<p>​:lolicon2:​​:arienai:​</p>",
+  "created_at": "2026-03-20T07:34:45.000Z",
+  "emojis": [],
+  "favourited": false,
+  "favourites_count": 0,
+  "id": "B4RSD2LEgxHzhTJGbo",
+  "in_reply_to_account_id": null,
+  "in_reply_to_id": null,
+  "language": null,
+  "media_attachments": [
+    {
+      "blurhash": null,
+      "description": null,
+      "id": "869664441",
+      "pleroma": { "mime_type": "image/png" },
+      "preview_url": "https://media.misskeyusercontent.com/io/webpublic-2d298516-35c3-4f47-99d9-f5269797b3ec.png?sensitive=true",
+      "remote_url": "https://media.misskeyusercontent.com/io/webpublic-2d298516-35c3-4f47-99d9-f5269797b3ec.png?sensitive=true",
+      "text_url": "https://media.misskeyusercontent.com/io/webpublic-2d298516-35c3-4f47-99d9-f5269797b3ec.png?sensitive=true",
+      "type": "image",
+      "url": "https://media.misskeyusercontent.com/io/webpublic-2d298516-35c3-4f47-99d9-f5269797b3ec.png?sensitive=true"
+    },
+    {
+      "blurhash": null,
+      "description": null,
+      "id": "-1396510378",
+      "pleroma": { "mime_type": "image/png" },
+      "preview_url": "https://media.misskeyusercontent.com/io/webpublic-a2a29739-a4e2-4ee4-8e53-228137f6fb93.png?sensitive=true",
+      "remote_url": "https://media.misskeyusercontent.com/io/webpublic-a2a29739-a4e2-4ee4-8e53-228137f6fb93.png?sensitive=true",
+      "text_url": "https://media.misskeyusercontent.com/io/webpublic-a2a29739-a4e2-4ee4-8e53-228137f6fb93.png?sensitive=true",
+      "type": "image",
+      "url": "https://media.misskeyusercontent.com/io/webpublic-a2a29739-a4e2-4ee4-8e53-228137f6fb93.png?sensitive=true"
+    },
+    {
+      "blurhash": null,
+      "description": null,
+      "id": "-1473806809",
+      "pleroma": { "mime_type": "image/png" },
+      "preview_url": "https://media.misskeyusercontent.com/io/03bc8a4b-b3dd-46d5-98ba-6f22fe699b7b.png?sensitive=true",
+      "remote_url": "https://media.misskeyusercontent.com/io/03bc8a4b-b3dd-46d5-98ba-6f22fe699b7b.png?sensitive=true",
+      "text_url": "https://media.misskeyusercontent.com/io/03bc8a4b-b3dd-46d5-98ba-6f22fe699b7b.png?sensitive=true",
+      "type": "image",
+      "url": "https://media.misskeyusercontent.com/io/03bc8a4b-b3dd-46d5-98ba-6f22fe699b7b.png?sensitive=true"
+    },
+    {
+      "blurhash": null,
+      "description": null,
+      "id": "-884683472",
+      "pleroma": { "mime_type": "image/png" },
+      "preview_url": "https://media.misskeyusercontent.com/io/webpublic-b399d813-f7f9-4523-9c38-9894113c64ce.png?sensitive=true",
+      "remote_url": "https://media.misskeyusercontent.com/io/webpublic-b399d813-f7f9-4523-9c38-9894113c64ce.png?sensitive=true",
+      "text_url": "https://media.misskeyusercontent.com/io/webpublic-b399d813-f7f9-4523-9c38-9894113c64ce.png?sensitive=true",
+      "type": "image",
+      "url": "https://media.misskeyusercontent.com/io/webpublic-b399d813-f7f9-4523-9c38-9894113c64ce.png?sensitive=true"
+    }
+  ],
+  "mentions": [
+    {
+      "acct": "aji_1332@misskey.io",
+      "id": "AbyBHC2i4d8gYleZV2",
+      "url": "https://misskey.io/@aji_1332",
+      "username": "aji_1332"
+    }
+  ],
+  "muted": false,
+  "pinned": false,
+  "pleroma": { "bookmark_folder": null, "local": false, "pinned_at": null },
+  "reblog": {
+    "account": {
+      "acct": "aji_1332@misskey.io",
+      "avatar": "https://media.misskeyusercontent.com/misskey/webpublic-adefef72-0dff-48bc-a19f-f79aaaa6561e.jpg",
+      "avatar_static": "https://media.misskeyusercontent.com/misskey/webpublic-adefef72-0dff-48bc-a19f-f79aaaa6561e.jpg",
+      "bot": false,
+      "created_at": "2023-11-19T16:19:33.000Z",
+      "display_name": "鯵沢あじ",
+      "emojis": [],
+      "fields": [
+        {
+          "name": "Twitter(X)",
+          "value": "<a href=\"https://x.com/aji_1053\">Twitter(X)</a>",
+          "verified_at": null
+        },
+        {
+          "name": "DLsite",
+          "value": "<a href=\"https://www.dlsite.com/maniax/circle/profile/=/maker_id/RG01054971.html\"></a>",
+          "verified_at": null
+        },
+        {
+          "name": "Twitter",
+          "value": "<a href=\"https://twitter.com/aji_1053\">https://twitter.com/aji_1053</a>",
+          "verified_at": null
+        },
+        {
+          "name": "ニジエ",
+          "value": "<a href=\"https://nijie.info/members.php?id=894100\">https://nijie.info/members.php?id=894100</a>",
+          "verified_at": null
+        }
+      ],
+      "followers_count": 0,
+      "following_count": 0,
+      "fqn": "aji_1332@misskey.io",
+      "header": "https://media.misskeyusercontent.com/io/webpublic-48bae911-bf96-4347-a677-a715935aec98.png",
+      "header_static": "https://media.misskeyusercontent.com/io/webpublic-48bae911-bf96-4347-a677-a715935aec98.png",
+      "id": "AbyBHC2i4d8gYleZV2",
+      "last_status_at": "2026-03-18",
+      "locked": false,
+      "note": "<p>プリズムの煌めきで生きている 雑多r18要素有 スケブやってます<a href=\"https://skeb.jp/@ajisawa1053\">https://skeb.jp/@ajisawa1053</a><span><br/>無断転載その他一般的に禁止されてる行為はやめて下さい</span></p>",
+      "pleroma": {
+        "accepts_chat_messages": null,
+        "also_known_as": [],
+        "ap_id": "https://misskey.io/users/9d5t13908z",
+        "avatar_description": "",
+        "background_image": null,
+        "deactivated": false,
+        "favicon": "https://media.misskeyusercontent.jp/io/c975a67f-dde4-4e49-9dbc-2bc3a8e34e25.png",
+        "header_description": "",
+        "hide_favorites": true,
+        "hide_followers": false,
+        "hide_followers_count": false,
+        "hide_follows": false,
+        "hide_follows_count": false,
+        "is_admin": false,
+        "is_confirmed": true,
+        "is_moderator": false,
+        "is_suggested": false,
+        "privileges": [],
+        "relationship": {},
+        "skip_thread_containment": false,
+        "tags": []
+      },
+      "source": {
+        "fields": [],
+        "note": "",
+        "pleroma": { "actor_type": "Person", "discoverable": true },
+        "sensitive": false
+      },
+      "statuses_count": 645,
+      "url": "https://misskey.io/@aji_1332",
+      "username": "aji_1332"
+    },
+    "application": null,
+    "bookmarked": false,
+    "card": null,
+    "content": "<p>​:lolicon2:​​:arienai:​</p>",
+    "created_at": "2026-03-18T15:12:46.000Z",
+    "edited_at": null,
+    "emojis": [
+      {
+        "shortcode": "arienai",
+        "static_url": "https://media.misskeyusercontent.com/emoji/arienai.png",
+        "url": "https://media.misskeyusercontent.com/emoji/arienai.png",
+        "visible_in_picker": false
+      },
+      {
+        "shortcode": "lolicon2",
+        "static_url": "https://media.misskeyusercontent.com/misskey/c6e847b2-fa08-44d4-82ef-07856e470fab.png",
+        "url": "https://media.misskeyusercontent.com/misskey/c6e847b2-fa08-44d4-82ef-07856e470fab.png",
+        "visible_in_picker": false
+      }
+    ],
+    "favourited": false,
+    "favourites_count": 0,
+    "id": "B4Ny7tE5Zgv9smiUam",
+    "in_reply_to_account_id": null,
+    "in_reply_to_id": null,
+    "language": null,
+    "media_attachments": [
+      {
+        "blurhash": null,
+        "description": null,
+        "id": "869664441",
+        "pleroma": { "mime_type": "image/png" },
+        "preview_url": "https://media.misskeyusercontent.com/io/webpublic-2d298516-35c3-4f47-99d9-f5269797b3ec.png?sensitive=true",
+        "remote_url": "https://media.misskeyusercontent.com/io/webpublic-2d298516-35c3-4f47-99d9-f5269797b3ec.png?sensitive=true",
+        "text_url": "https://media.misskeyusercontent.com/io/webpublic-2d298516-35c3-4f47-99d9-f5269797b3ec.png?sensitive=true",
+        "type": "image",
+        "url": "https://media.misskeyusercontent.com/io/webpublic-2d298516-35c3-4f47-99d9-f5269797b3ec.png?sensitive=true"
+      },
+      {
+        "blurhash": null,
+        "description": null,
+        "id": "-1396510378",
+        "pleroma": { "mime_type": "image/png" },
+        "preview_url": "https://media.misskeyusercontent.com/io/webpublic-a2a29739-a4e2-4ee4-8e53-228137f6fb93.png?sensitive=true",
+        "remote_url": "https://media.misskeyusercontent.com/io/webpublic-a2a29739-a4e2-4ee4-8e53-228137f6fb93.png?sensitive=true",
+        "text_url": "https://media.misskeyusercontent.com/io/webpublic-a2a29739-a4e2-4ee4-8e53-228137f6fb93.png?sensitive=true",
+        "type": "image",
+        "url": "https://media.misskeyusercontent.com/io/webpublic-a2a29739-a4e2-4ee4-8e53-228137f6fb93.png?sensitive=true"
+      },
+      {
+        "blurhash": null,
+        "description": null,
+        "id": "-1473806809",
+        "pleroma": { "mime_type": "image/png" },
+        "preview_url": "https://media.misskeyusercontent.com/io/03bc8a4b-b3dd-46d5-98ba-6f22fe699b7b.png?sensitive=true",
+        "remote_url": "https://media.misskeyusercontent.com/io/03bc8a4b-b3dd-46d5-98ba-6f22fe699b7b.png?sensitive=true",
+        "text_url": "https://media.misskeyusercontent.com/io/03bc8a4b-b3dd-46d5-98ba-6f22fe699b7b.png?sensitive=true",
+        "type": "image",
+        "url": "https://media.misskeyusercontent.com/io/03bc8a4b-b3dd-46d5-98ba-6f22fe699b7b.png?sensitive=true"
+      },
+      {
+        "blurhash": null,
+        "description": null,
+        "id": "-884683472",
+        "pleroma": { "mime_type": "image/png" },
+        "preview_url": "https://media.misskeyusercontent.com/io/webpublic-b399d813-f7f9-4523-9c38-9894113c64ce.png?sensitive=true",
+        "remote_url": "https://media.misskeyusercontent.com/io/webpublic-b399d813-f7f9-4523-9c38-9894113c64ce.png?sensitive=true",
+        "text_url": "https://media.misskeyusercontent.com/io/webpublic-b399d813-f7f9-4523-9c38-9894113c64ce.png?sensitive=true",
+        "type": "image",
+        "url": "https://media.misskeyusercontent.com/io/webpublic-b399d813-f7f9-4523-9c38-9894113c64ce.png?sensitive=true"
+      }
+    ],
+    "mentions": [],
+    "muted": false,
+    "pinned": false,
+    "pleroma": {
+      "bookmark_folder": null,
+      "content": { "text/plain": "​:lolicon2:​​:arienai:​" },
+      "context": "https://misskey.io/notes/ajzqvma5lk5o00mv",
+      "conversation_id": 2008919292,
+      "direct_conversation_id": null,
+      "emoji_reactions": [
+        {
+          "account_ids": [
+            "AZ4cbfObtP6QWxRKca",
+            "AZJyPWZnyBMy46grJ2",
+            "Aa7XGcXmWvihYYl972"
+          ],
+          "count": 3,
+          "me": false,
+          "name": "sorede_lolicon_janaiwa_muriga_aru@media.misskeyusercontent.com",
+          "url": "https://media.misskeyusercontent.com/io/b16dd996-191a-464a-a5eb-2852a21e04ca.webp"
+        },
+        {
+          "account_ids": ["B2FGQEeWbjpahPJEB6"],
+          "count": 1,
+          "me": false,
+          "name": "nice_pants@media.misskeyusercontent.com",
+          "url": "https://media.misskeyusercontent.com/misskey/8046d5f7-1e2a-4ef2-a3f5-dc89dd085e78.gif"
+        }
+      ],
+      "expires_at": null,
+      "in_reply_to_account_acct": null,
+      "list_id": null,
+      "local": false,
+      "parent_visible": false,
+      "pinned_at": null,
+      "quote": null,
+      "quote_id": null,
+      "quote_url": null,
+      "quote_visible": false,
+      "quotes_count": 0,
+      "spoiler_text": { "text/plain": "" },
+      "thread_muted": false
+    },
+    "poll": null,
+    "quotes_count": 0,
+    "reblog": null,
+    "reblogged": false,
+    "reblogs_count": 4,
+    "replies_count": 0,
+    "sensitive": true,
+    "spoiler_text": "",
+    "tags": [],
+    "text": null,
+    "uri": "https://misskey.io/notes/ajzqvma5lk5o00mv",
+    "url": "https://misskey.io/notes/ajzqvma5lk5o00mv",
+    "visibility": "public"
+  },
+  "reblogged": false,
+  "reblogs_count": 0,
+  "replies_count": 0,
+  "sensitive": false,
+  "spoiler_text": "",
+  "tags": [],
+  "uri": "https://misskey.io/notes/ajzqvma5lk5o00mv",
+  "url": "https://misskey.io/notes/ajzqvma5lk5o00mv",
+  "visibility": "unlisted"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1173,6 +1173,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@simplewebauthn/types@npm:12.0.0":
+  version: 12.0.0
+  resolution: "@simplewebauthn/types@npm:12.0.0"
+  checksum: 10c0/b7ce0ae692ea1e069ad9cb028fc1ccfe3f37e0f197825ba9e468e60194f463e88f5db254ddea296019b470a465ffaffa96fe27bb5e1e5d5d14bfcd068b04abed
+  languageName: node
+  linkType: hard
+
 "@sindresorhus/is@npm:^4.6.0":
   version: 4.6.0
   resolution: "@sindresorhus/is@npm:4.6.0"
@@ -1975,7 +1982,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eventemitter3@npm:^5.0.1":
+"eventemitter3@npm:5.0.1, eventemitter3@npm:^5.0.1":
   version: 5.0.1
   resolution: "eventemitter3@npm:5.0.1"
   checksum: 10c0/4ba5c00c506e6c786b4d6262cfbce90ddc14c10d4667e5c83ae993c9de88aa856033994dd2b35b83e8dc1170e224e66a319fa80adc4c32adcd2379bbc75da814
@@ -2602,6 +2609,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"misskey-js@npm:^2026.1.0-beta.0":
+  version: 2026.1.0-beta.0
+  resolution: "misskey-js@npm:2026.1.0-beta.0"
+  dependencies:
+    "@simplewebauthn/types": "npm:12.0.0"
+    eventemitter3: "npm:5.0.1"
+    reconnecting-websocket: "npm:4.4.0"
+  checksum: 10c0/457ffaa22c3cfa3988d27ee8dc72a6ceb2be3758fb88ee511c57d53e53b234533d359294db6aa1371cd27e1831bed37abec2b714e072f6635260b1ac3501702f
+  languageName: node
+  linkType: hard
+
 "miyulab-fe@workspace:.":
   version: 0.0.0-use.local
   resolution: "miyulab-fe@workspace:."
@@ -2632,6 +2650,7 @@ __metadata:
     lint-staged: "npm:^16.4.0"
     lucide-react: "npm:^0.577.0"
     megalodon: "npm:^10.2.4"
+    misskey-js: "npm:^2026.1.0-beta.0"
     next: "npm:^16.2.1"
     node-emoji: "npm:^2.2.0"
     postcss: "npm:^8.5.8"
@@ -3043,6 +3062,13 @@ __metadata:
   version: 19.2.4
   resolution: "react@npm:19.2.4"
   checksum: 10c0/cd2c9ff67a720799cc3b38a516009986f7fc4cb8d3e15716c6211cf098d1357ee3e348ab05ad0600042bbb0fd888530ba92e329198c92eafa0994f5213396596
+  languageName: node
+  linkType: hard
+
+"reconnecting-websocket@npm:4.4.0":
+  version: 4.4.0
+  resolution: "reconnecting-websocket@npm:4.4.0"
+  checksum: 10c0/0155223200882e123bc884eb5935bdff7ee4d2998eee578c23bba6a6fec63b68c22ccaf9ff4bdcd05284568d89f02e6a664cc40daf108872f820197848b09579
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- MisskeyAdapter / MisskeyWebSocketAdapter を実装し megalodon インターフェースを提供
- auth, mappers を追加して Misskey API のマッピングを実装
- GetClient, AppsProvider, types, environment を更新して backend に misskey を統合
- package.json に misskey-js を追加、yarn.lock を更新、test.json を追加
- タイムラインクエリ最適化計画書 specs/timeline-query-optimization.md を追加