### PR TITLE
feat: タイムラインにメディアグリッド表示タイプを追加

### DIFF
--- a/src/app/_components/DynamicTimeline.tsx
+++ b/src/app/_components/DynamicTimeline.tsx
@@ -8,6 +8,7 @@ import {
   queryPlanV2ReferencedTables,
 } from 'util/db/query-ir/nodes'
 import { isMixedQuery, isNotificationQuery } from 'util/queryBuilder'
+import { MediaGridTimeline } from './MediaGridTimeline'
 import { MixedTimeline } from './MixedTimeline'
 
 export const DynamicTimeline = ({
@@ -19,6 +20,11 @@ export const DynamicTimeline = ({
 }) => {
   if (!config.visible) {
     return null
+  }
+
+  // メディアグリッド表示タイプの場合は MediaGridTimeline を使用
+  if (config.displayType === 'media-grid') {
+    return <MediaGridTimeline config={config} headerOffset={headerOffset} />
   }
 
   const query = config.customQuery ?? ''

--- a/src/app/_components/FlowEditor/FlowQueryEditorModal.tsx
+++ b/src/app/_components/FlowEditor/FlowQueryEditorModal.tsx
@@ -89,6 +89,9 @@ export function FlowQueryEditorModal({
   onSave,
 }: FlowQueryEditorModalProps) {
   const [label, setLabel] = useState(config.label ?? '')
+  const [displayType, setDisplayType] = useState<'list' | 'media-grid'>(
+    config.displayType ?? 'list',
+  )
   const [showMuteManager, setShowMuteManager] = useState(false)
   const [showBlockManager, setShowBlockManager] = useState(false)
 
@@ -111,8 +114,9 @@ export function FlowQueryEditorModal({
   useEffect(() => {
     if (open) {
       setLabel(config.label ?? '')
+      setDisplayType(config.displayType ?? 'list')
     }
-  }, [open, config.label])
+  }, [open, config.label, config.displayType])
 
   // モーダルが開いた瞬間のみフローを初期化する
   // resolvedPlanV2 の参照変更で再初期化しないようにする
@@ -211,6 +215,7 @@ export function FlowQueryEditorModal({
         applyMuteFilter: applyMute || undefined,
         backendFilter,
         customQuery: undefined,
+        displayType: displayType === 'list' ? undefined : displayType,
         label: label.trim() || undefined,
         queryPlan: plan,
       }
@@ -218,12 +223,15 @@ export function FlowQueryEditorModal({
       onSave(updates)
       onOpenChange(false)
     },
-    [label, onSave, onOpenChange],
+    [displayType, label, onSave, onOpenChange],
   )
 
   const handleSave = useCallback(() => {
-    onSave({ label: label.trim() || undefined })
-  }, [label, onSave])
+    onSave({
+      displayType: displayType === 'list' ? undefined : displayType,
+      label: label.trim() || undefined,
+    })
+  }, [displayType, label, onSave])
 
   const handleSaveFlow = useCallback(() => {
     handleFlowSave(currentPlanV2)
@@ -351,6 +359,33 @@ export function FlowQueryEditorModal({
                   value={label}
                 />
               </label>
+              <div className="flex items-center gap-1 shrink-0">
+                <span className="text-xs text-gray-500">表示:</span>
+                <button
+                  className={`px-2 py-1 rounded text-xs transition-colors ${
+                    displayType === 'list'
+                      ? 'bg-blue-700 text-white'
+                      : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+                  }`}
+                  onClick={() => setDisplayType('list')}
+                  title="リスト表示"
+                  type="button"
+                >
+                  📋 リスト
+                </button>
+                <button
+                  className={`px-2 py-1 rounded text-xs transition-colors ${
+                    displayType === 'media-grid'
+                      ? 'bg-blue-700 text-white'
+                      : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+                  }`}
+                  onClick={() => setDisplayType('media-grid')}
+                  title="メディアグリッド表示"
+                  type="button"
+                >
+                  🖼 グリッド
+                </button>
+              </div>
             </div>
             <div className="flex items-center gap-2 shrink-0">
               {!validation.valid && (

--- a/src/app/_components/MediaGridTimeline.tsx
+++ b/src/app/_components/MediaGridTimeline.tsx
@@ -1,0 +1,130 @@
+'use client'
+
+import { Media } from 'app/_parts/Media'
+import { Panel } from 'app/_parts/Panel'
+import { TimelineLoading } from 'app/_parts/TimelineLoading'
+import type { Entity } from 'megalodon'
+import { useCallback, useContext, useMemo } from 'react'
+import type { StatusAddAppIndex, TimelineConfigV2 } from 'types/types'
+import { useOtherQueueProgress } from 'util/hooks/useOtherQueueProgress'
+import { useTimelineData } from 'util/hooks/useTimelineData'
+import { SetMediaModalContext } from 'util/provider/ModalProvider'
+import { SetPlayerContext } from 'util/provider/PlayerProvider'
+import { getDefaultTimelineName } from 'util/timelineDisplayName'
+
+/**
+ * メディアグリッドタイムライン (Container)
+ *
+ * メディア付き投稿のサムネイルを3カラムのグリッドで表示する。
+ * クリックするとメディアモーダルまたはプレイヤーを開く。
+ */
+export const MediaGridTimeline = ({
+  config,
+  headerOffset,
+}: {
+  config: TimelineConfigV2
+  headerOffset?: string
+}) => {
+  // メディア付き投稿のみ取得
+  const mediaConfig = useMemo(() => ({ ...config, onlyMedia: true }), [config])
+  const { data, hasMoreOlder, isLoadingOlder, loadOlder, queryDuration } =
+    useTimelineData(mediaConfig) as {
+      data: StatusAddAppIndex[]
+      hasMoreOlder: boolean
+      isLoadingOlder: boolean
+      loadOlder: () => Promise<void>
+      queryDuration: number | null
+    }
+  const { initializing } = useOtherQueueProgress()
+  const setMediaModal = useContext(SetMediaModalContext)
+  const setPlayer = useContext(SetPlayerContext)
+
+  const displayName = useMemo(() => {
+    if (config.label) return config.label
+    return getDefaultTimelineName(config)
+  }, [config])
+
+  // 各ステータスのメディアアタッチメントを展開してフラットなリストにする
+  const mediaItems = useMemo(() => {
+    const items: {
+      attachment: Entity.Attachment
+      attachments: Entity.Attachment[]
+      attachmentIndex: number
+      statusId: string
+    }[] = []
+    for (const status of data) {
+      const attachments =
+        status.reblog?.media_attachments ?? status.media_attachments
+      for (let i = 0; i < attachments.length; i++) {
+        items.push({
+          attachment: attachments[i],
+          attachmentIndex: i,
+          attachments,
+          statusId: status.id,
+        })
+      }
+    }
+    return items
+  }, [data])
+
+  const handleClick = useCallback(
+    (
+      attachment: Entity.Attachment,
+      allAttachments: Entity.Attachment[],
+      index: number,
+    ) => {
+      if (['video', 'gifv', 'audio'].includes(attachment.type)) {
+        setPlayer({ attachment: allAttachments, index })
+      } else {
+        setMediaModal({ attachment: allAttachments, index })
+      }
+    },
+    [setMediaModal, setPlayer],
+  )
+
+  return (
+    <Panel
+      className="relative overflow-y-auto"
+      headerOffset={headerOffset}
+      name={displayName}
+      queryDuration={queryDuration}
+    >
+      {data.length === 0 && initializing ? (
+        <TimelineLoading />
+      ) : (
+        <div className="flex flex-col">
+          <div className="grid grid-cols-3 gap-px bg-gray-700">
+            {mediaItems.map(
+              ({ attachment, attachments, attachmentIndex, statusId }) => (
+                <button
+                  className="aspect-square overflow-hidden bg-black"
+                  key={`${statusId}-${attachment.id}`}
+                  onClick={() =>
+                    handleClick(attachment, attachments, attachmentIndex)
+                  }
+                  type="button"
+                >
+                  <Media
+                    className="h-full w-full"
+                    media={attachment}
+                    scrolling={false}
+                  />
+                </button>
+              ),
+            )}
+          </div>
+          {hasMoreOlder && (
+            <button
+              className="w-full py-3 text-xs text-gray-400 hover:text-white disabled:opacity-50"
+              disabled={isLoadingOlder}
+              onClick={loadOlder}
+              type="button"
+            >
+              {isLoadingOlder ? '読み込み中…' : 'さらに読み込む'}
+            </button>
+          )}
+        </div>
+      )}
+    </Panel>
+  )
+}

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -172,6 +172,15 @@ export type TimelineConfigV2 = {
   id: string
   /** 表示名（ユーザーがカスタマイズ可能、未設定時はデフォルト名を使用） */
   label?: string
+  /**
+   * タイムラインの表示タイプ
+   *
+   * - 'list' (デフォルト): 通常のリスト表示
+   * - 'media-grid': メディア付き投稿をグリッド表示
+   *
+   * @default 'list'
+   */
+  displayType?: 'list' | 'media-grid'
   /** メディア付き投稿のみ表示するか（デフォルト: false） */
   onlyMedia?: boolean
   /** 表示順序（0始まり、昇順） */


### PR DESCRIPTION
## 概要

タイムラインの表示パターンとして「メディアグリッド」を追加しました。メディア付き投稿のサムネイルを3カラムのグリッド(Instagram風)で表示する新しい表示タイプです。

Closes #395

## 変更内容

### 新規ファイル
- `src/app/_components/MediaGridTimeline.tsx` — メディアグリッドを描画するコンポーネント。メディア付き投稿をフラット化して3列グリッドに表示し、クリックで既存のメディアモーダル/プレイヤーを開く。

### 変更ファイル
- `src/types/types.ts` — `TimelineConfigV2` に `displayType?: 'list' | 'media-grid'` フィールドを追加
- `src/app/_components/DynamicTimeline.tsx` — `displayType === 'media-grid'` のとき `MediaGridTimeline` にルーティング
- `src/app/_components/FlowEditor/FlowQueryEditorModal.tsx` — ヘッダーに「📋 リスト」/「🖼 グリッド」の表示タイプ切替ボタンを追加。保存時に `displayType` を `TimelineConfigV2` に反映

## 動作

1. フローエディタを開く
2. ヘッダーの「🖼 グリッド」ボタンを押す
3. 「クエリを保存」または「名前のみ保存」を押す
4. タイムラインがメディアグリッドビューに切り替わる
5. サムネイルクリックで画像モーダルまたは動画プレイヤーが開く
6. 末尾の「さらに読み込む」ボタンでスクロールバック対応

## 今後の拡張余地

- グリッドカラム数の設定
- ホバー時にアカウント名や投稿時刻を表示
- 他の表示タイプ(mentions-only、boosts-only など)




> Generated by [🤖 Daily Auto-Work Agent](https://github.com/WakuwakuP/miyulab-fe/actions/runs/24254698581)

> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `fonts.googleapis.com`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "fonts.googleapis.com"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


<!-- gh-aw-agentic-workflow: 🤖 Daily Auto-Work Agent, engine: copilot, id: 24254698581, workflow_id: daily-work, run: https://github.com/WakuwakuP/miyulab-fe/actions/runs/24254698581 -->

<!-- gh-aw-workflow-id: daily-work -->