### PR TITLE
feat(cleanup): すべてのクリーンアップを priority キューで実行する

### DIFF
--- a/src/util/db/sqlite/__tests__/cleanup-batchLoop.test.ts
+++ b/src/util/db/sqlite/__tests__/cleanup-batchLoop.test.ts
@@ -78,9 +78,15 @@ describe('enforceMaxLength — batch loop', () => {
     expect(calls[0].opts?.kind).toBe('priority')
   })
 
-  it('options.kind 未指定のとき "other" が使われる', async () => {
+  it('options.kind 未指定のとき "priority" が使われる', async () => {
     const { calls } = installMockHandle([{ hasMore: false }])
     await enforceMaxLength()
+    expect(calls[0].opts?.kind).toBe('priority')
+  })
+
+  it('options.kind="other" を明示指定すれば sendCommand に伝播する', async () => {
+    const { calls } = installMockHandle([{ hasMore: false }])
+    await enforceMaxLength({ kind: 'other' })
     expect(calls[0].opts?.kind).toBe('other')
   })
 

--- a/src/util/db/sqlite/cleanup.ts
+++ b/src/util/db/sqlite/cleanup.ts
@@ -55,7 +55,12 @@ const MAX_BATCH_ITERATIONS = 100
 type EnforceMaxLengthOptions = {
   mode?: 'periodic' | 'emergency'
   targetRatio?: number
-  /** Worker キューの振り分け (default 'other'; 緊急時は 'priority') */
+  /**
+   * Worker キューの振り分け (default 'priority')。
+   *
+   * クリーンアップは書き込み・タイムライン取得より優先して処理する方針のため、
+   * 基本的にすべて 'priority' で投入する。テスト等の特殊用途で上書き可能。
+   */
   kind?: 'priority' | 'other'
 }
 
@@ -80,7 +85,8 @@ type EnforceMaxLengthResponse = {
  *
  * @param options.mode - 'periodic' (default): 上限までの削減 / 'emergency': targetRatio までの削減
  * @param options.targetRatio - emergency モードで残す割合 (default 0.5)
- * @param options.kind - Worker キューの振り分け (default 'other'; 緊急時は 'priority')
+ * @param options.kind - Worker キューの振り分け (default 'priority')。
+ *   クリーンアップは他の書き込みより優先処理する方針のため、基本 'priority' を使う。
  */
 export async function enforceMaxLength(
   options?: EnforceMaxLengthOptions,
@@ -88,7 +94,7 @@ export async function enforceMaxLength(
   const handle = await getSqliteDb()
   const mode = options?.mode ?? 'periodic'
   const targetRatio = options?.targetRatio ?? EMERGENCY_TARGET_RATIO
-  const kind = options?.kind ?? 'other'
+  const kind = options?.kind ?? 'priority'
 
   const startedAt = Date.now()
   const totalDeleted = {
@@ -143,7 +149,9 @@ async function runPeriodicCleanup(): Promise<void> {
   console.info('[cleanup] Periodic cleanup started')
   const startedAt = Date.now()
   try {
-    await enforceMaxLength({ kind: 'other', mode: 'periodic' })
+    // 定期クリーンアップも priority キューで処理し、書き込み・タイムライン取得より優先する。
+    // other キューで投入すると bulkUpsertStatuses 等と競合して 90s timeout に巻き込まれやすい。
+    await enforceMaxLength({ kind: 'priority', mode: 'periodic' })
     console.info(
       `[cleanup] Periodic cleanup finished (elapsedMs=${Date.now() - startedAt})`,
     )


### PR DESCRIPTION
## 概要

SQLite クリーンアップ処理を **常に priority キューで実行** するようにする。

## 背景

実環境ログで、定期クリーンアップ (`kind: 'other'`) が `bulkUpsertStatuses` / `executeGraphPlan` と競合して 90s timeout に巻き込まれているケースを確認:

```
[cleanup] Periodic cleanup started
Failed to perform periodic cleanup (attempt 1) Error: Worker request timed out (id=108, type=enforceMaxLength)
Failed to flush upsert buffer: Error: Worker request timed out (id=110, type=bulkUpsertStatuses)
Failed to flush upsert buffer: Error: Worker request timed out (id=111, type=bulkUpsertStatuses)
[useTimelineDataSource] fetch error: Error: Worker request timed out (id=66, type=executeGraphPlan)
```

DB が 30 万件級に育っている状況では、定期クリーンアップこそ最優先で進めないと「常に他の書き込みに押し負けて timeout → 1 分後リトライ → また timeout」のループに陥り、結局一度もクリーンアップが完走しない。

`priority` キュー機構は #446 で既に導入済みで、緊急クリーンアップは既にこれを使っている。**定期クリーンアップも同じ扱いに統一**する。

## 変更内容

`src/util/db/sqlite/cleanup.ts`:

- `enforceMaxLength` の `kind` デフォルト値を `'other'` → `'priority'` に変更
- `runPeriodicCleanup` で明示的に `kind: 'priority'` を指定
- JSDoc / コメントを方針にあわせて更新

テスト (`src/util/db/sqlite/__tests__/cleanup-batchLoop.test.ts`):

- 「未指定時に `"other"` が使われる」テストを「`"priority"` が使われる」に変更
- 「`kind: "other"` を明示指定すれば伝播する」テストを追加（後方互換の動作保証）

## priority キューの既存実装

`src/util/db/sqlite/workerClient/queueManager.ts` の `processQueue` が既に以下の優先順で処理する。

```
priorityQueue > otherQueue (maxConsecutiveOther 制約) > timelineQueue
```

`priority` は `maxConsecutiveOther` カウンタに影響しないため、書き込みキューの状態によらず常に最優先で取り出される。

## 動作確認

- `yarn test run src/util/db/sqlite/__tests__/cleanup-batchLoop.test.ts` ✅ (6 passed)
- `yarn check` ✅
- `yarn build` ✅

## 関連

- Parent: #445
- 関連 PR: #446 (priority キュー導入), #448 (ログ出力)
- 関連 Issue: #449 (タイムアウト時の部分集計ログ) — 別途対応