### PR TITLE
feat(cleanup): enforceMaxLength 中断時にも途中までの削除件数をログ出力

### DIFF
--- a/src/util/db/sqlite/__tests__/cleanup-batchLoop.test.ts
+++ b/src/util/db/sqlite/__tests__/cleanup-batchLoop.test.ts
@@ -103,4 +103,47 @@ describe('enforceMaxLength — batch loop', () => {
       type: 'enforceMaxLength',
     })
   })
+
+  it('sendCommand が throw した場合、途中までの集計ログを出してから再 throw する', async () => {
+    // 1 回目は成功 (削除件数あり)、2 回目で throw
+    let callCount = 0
+    const sendCommand = vi.fn(async () => {
+      callCount++
+      if (callCount === 1) {
+        return {
+          deletedCounts: {
+            notifications: 3,
+            posts: 5,
+            timeline_entries: 10,
+          },
+          hasMore: true,
+          ok: true,
+        }
+      }
+      throw new Error(
+        'Worker request timed out (id=108, type=enforceMaxLength)',
+      )
+    })
+    vi.mocked(getSqliteDb).mockResolvedValue({
+      sendCommand,
+    } as unknown as Awaited<ReturnType<typeof getSqliteDb>>)
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await expect(enforceMaxLength()).rejects.toThrow(/Worker request timed out/)
+
+    // `aborted (partial)` を含むログが呼ばれている
+    const abortedCalls = warnSpy.mock.calls.filter((args) =>
+      String(args[0]).includes('aborted (partial)'),
+    )
+    expect(abortedCalls.length).toBeGreaterThan(0)
+    const message = String(abortedCalls[0][0])
+    expect(message).toContain('timeline_entries=10')
+    expect(message).toContain('notifications=3')
+    expect(message).toContain('posts=5')
+    expect(message).toContain('total=18')
+    expect(message).toContain('iterations=2')
+
+    warnSpy.mockRestore()
+  })
 })

--- a/src/util/db/sqlite/cleanup.ts
+++ b/src/util/db/sqlite/cleanup.ts
@@ -104,37 +104,49 @@ export async function enforceMaxLength(
   }
 
   let iteration = 0
-  while (iteration < MAX_BATCH_ITERATIONS) {
-    iteration++
-    const result = (await handle.sendCommand(
-      {
-        mode,
-        targetRatio,
-        type: 'enforceMaxLength',
-      },
-      { kind },
-    )) as EnforceMaxLengthResponse | undefined
-    if (result?.deletedCounts) {
-      totalDeleted.timeline_entries += result.deletedCounts.timeline_entries
-      totalDeleted.notifications += result.deletedCounts.notifications
-      totalDeleted.posts += result.deletedCounts.posts
+  let aborted = false
+  let abortError: unknown
+  try {
+    while (iteration < MAX_BATCH_ITERATIONS) {
+      iteration++
+      const result = (await handle.sendCommand(
+        {
+          mode,
+          targetRatio,
+          type: 'enforceMaxLength',
+        },
+        { kind },
+      )) as EnforceMaxLengthResponse | undefined
+      if (result?.deletedCounts) {
+        totalDeleted.timeline_entries += result.deletedCounts.timeline_entries
+        totalDeleted.notifications += result.deletedCounts.notifications
+        totalDeleted.posts += result.deletedCounts.posts
+      }
+      if (!result?.hasMore) break
     }
-    if (!result?.hasMore) break
+    if (iteration >= MAX_BATCH_ITERATIONS) {
+      console.warn(
+        `[cleanup] enforceMaxLength reached MAX_BATCH_ITERATIONS (${MAX_BATCH_ITERATIONS}); remaining work will be processed on the next invocation.`,
+      )
+    }
+  } catch (error) {
+    aborted = true
+    abortError = error
+    throw error
+  } finally {
+    const elapsedMs = Date.now() - startedAt
+    const totalCount =
+      totalDeleted.timeline_entries +
+      totalDeleted.notifications +
+      totalDeleted.posts
+    const status = aborted ? 'aborted (partial)' : 'completed'
+    const summary = `[cleanup] enforceMaxLength ${status} (mode=${mode}, kind=${kind}, iterations=${iteration}, elapsedMs=${elapsedMs}, deleted: timeline_entries=${totalDeleted.timeline_entries}, notifications=${totalDeleted.notifications}, posts=${totalDeleted.posts}, total=${totalCount})`
+    if (aborted) {
+      console.warn(summary, abortError)
+    } else {
+      console.info(summary)
+    }
   }
-  if (iteration >= MAX_BATCH_ITERATIONS) {
-    console.warn(
-      `[cleanup] enforceMaxLength reached MAX_BATCH_ITERATIONS (${MAX_BATCH_ITERATIONS}); remaining work will be processed on the next invocation.`,
-    )
-  }
-
-  const elapsedMs = Date.now() - startedAt
-  const totalCount =
-    totalDeleted.timeline_entries +
-    totalDeleted.notifications +
-    totalDeleted.posts
-  console.info(
-    `[cleanup] enforceMaxLength completed (mode=${mode}, kind=${kind}, iterations=${iteration}, elapsedMs=${elapsedMs}, deleted: timeline_entries=${totalDeleted.timeline_entries}, notifications=${totalDeleted.notifications}, posts=${totalDeleted.posts}, total=${totalCount})`,
-  )
 }
 
 // ================================================================
@@ -148,14 +160,23 @@ async function runPeriodicCleanup(): Promise<void> {
   isPeriodicRunning = true
   console.info('[cleanup] Periodic cleanup started')
   const startedAt = Date.now()
+  let succeeded = false
   try {
     // 定期クリーンアップも priority キューで処理し、書き込み・タイムライン取得より優先する。
     // other キューで投入すると bulkUpsertStatuses 等と競合して 90s timeout に巻き込まれやすい。
     await enforceMaxLength({ kind: 'priority', mode: 'periodic' })
-    console.info(
-      `[cleanup] Periodic cleanup finished (elapsedMs=${Date.now() - startedAt})`,
-    )
+    succeeded = true
   } finally {
+    const elapsedMs = Date.now() - startedAt
+    if (succeeded) {
+      console.info(
+        `[cleanup] Periodic cleanup finished (elapsedMs=${elapsedMs})`,
+      )
+    } else {
+      console.warn(
+        `[cleanup] Periodic cleanup aborted (elapsedMs=${elapsedMs})`,
+      )
+    }
     isPeriodicRunning = false
   }
 }
@@ -240,7 +261,10 @@ async function triggerEmergencyCleanup(): Promise<void> {
       `[cleanup] Emergency cleanup completed (elapsedMs=${Date.now() - startedAt})`,
     )
   } catch (error) {
-    console.error('[cleanup] Emergency cleanup failed', error)
+    console.error(
+      `[cleanup] Emergency cleanup failed (elapsedMs=${Date.now() - startedAt})`,
+      error,
+    )
   } finally {
     isEmergencyRunning = false
     lastEmergencyFinishedAt = Date.now()


### PR DESCRIPTION
## 概要

#449 対応。`enforceMaxLength` が `sendCommand` の throw（Worker タイムアウト等）で中断された場合でも、**途中まで削除した件数の集計ログが出る**ようにする。

## 背景

#448 でバッチループ完了時に `deletedCounts` の集計を `console.info` するようにしたが、`sendCommand` がタイムアウト等で throw すると **集計ログが一切出ない** という問題があった。

実環境ログ:
```
[cleanup] Periodic cleanup started
Failed to perform periodic cleanup (attempt 1) Error: Worker request timed out (id=108, type=enforceMaxLength)
[cleanup] Periodic cleanup started   ← 1 分後のリトライ
```

バッチ化の利点（途中まで削除は成功している）が可視化されない。

## 変更内容

`src/util/db/sqlite/cleanup.ts`:

1. **`enforceMaxLength`**: バッチループを `try/finally` で囲み、throw 発生時でも `finally` 内で集計ログを出力。
   - 正常完了: `[cleanup] enforceMaxLength completed (...)` (`console.info`)
   - 中断時: `[cleanup] enforceMaxLength aborted (partial) (...)` (`console.warn` + error)
2. **`runPeriodicCleanup`**: 失敗時にも `elapsedMs` 付きの警告ログを出すようにする。
3. **`triggerEmergencyCleanup`**: 失敗時のエラーログに `elapsedMs` を追加。

ログ例 (中断時):
```
[cleanup] enforceMaxLength aborted (partial) (mode=periodic, kind=priority, iterations=3, elapsedMs=90012, deleted: timeline_entries=20000, notifications=0, posts=5000, total=25000) Error: Worker request timed out ...
[cleanup] Periodic cleanup aborted (elapsedMs=90014)
```

## テスト

`src/util/db/sqlite/__tests__/cleanup-batchLoop.test.ts` にケース追加:
- 1 回目は成功（削除件数あり）、2 回目で throw するモックを用意
- `enforceMaxLength()` が re-throw することと、`aborted (partial)` を含むログに集計済み削除件数 (`timeline_entries=10, notifications=3, posts=5, total=18, iterations=2`) が含まれることを検証。

## 動作確認

- `yarn test run src/util/db/sqlite/__tests__/cleanup-batchLoop.test.ts` ✅ (7 passed)
- `yarn check` ✅
- `yarn build` ✅

## 関連

- Parent: #445
- Closes #449
- 関連 PR: #448 (完了ログ), #450 (priority キュー化)