### PR TITLE
通知の絵文字リアクション画像をネイティブ img に変更

### DIFF
--- a/src/app/_parts/Notification.tsx
+++ b/src/app/_parts/Notification.tsx
@@ -285,18 +285,18 @@ export const Notification = ({
                 </p>
               </div>
             </div>
-            <div className="min-w-12  mr-2">
+            <div className="min-w-12 max-w-full mr-2">
               {resolvedReactionUrl != null ? (
                 scrolling ? (
                   <div className="h-12 w-12 flex-none rounded-lg" />
                 ) : (
-                  <ProxyImage
+                  <img
                     alt="emoji"
-                    className="h-12 max-w-full flex-none rounded-lg object-contain"
-                    height={48}
+                    className="max-h-12 max-w-full w-auto rounded-lg object-contain"
+                    decoding="async"
+                    loading="lazy"
                     src={resolvedReactionUrl}
                     title={notification.reaction?.name}
-                    width={48}
                   />
                 )
               ) : (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

`emoji_reaction` 通知のカスタム絵文字画像を `next/image` ラッパーの `ProxyImage` から通常の `<img>` に切り替えました。

## 背景・理由

- リモート絵文字の実寸は事前に分からないため、`next/image` 向けの固定 `width` / `height` は本質的に「表示枠の仮置き」になりがちです。
- ネイティブ `<img>` にすると intrinsic サイズを保ちつつ、親の幅制約でスケールできます。

## 変更内容

- リアクション画像のラッパーに `max-w-full` を付与し、行レイアウト内で横方向に溢れないようにしました。
- 画像には `max-h-12 max-w-full w-auto object-contain` を指定し、高さは最大 48px、幅は親の `max-w-full` 内で自然に収まるようにしました。
- `loading="lazy"` と `decoding="async"` を付与しました。

## 検証

- `yarn check`（Biome の schema version info のみ）
- `yarn test:run`（81 files / 1634 tests）
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://miyulab.slack.com/archives/C0B44SYQSGM/p1778929909573889?thread_ts=1778929909.573889&cid=C0B44SYQSGM)

<div><a href="https://cursor.com/agents/bc-6210b035-c971-5403-9a6d-07933c8b1a54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6210b035-c971-5403-9a6d-07933c8b1a54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

