### PR TITLE
Add AGENTS.md with Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,43 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+miyulab-fe is a Fediverse (Pleroma/Mastodon/Friendica/Firefish/Misskey) web client built with Next.js 16, React 19, and TypeScript 6. It uses browser-side SQLite WASM for local data storage and WebSocket streaming for real-time timeline updates.
+
+### Development Commands
+
+See `package.json` scripts and `.github/copilot-instructions.md` for the full reference. Key commands:
+
+- `yarn check` — Biome lint & format (must pass before commit)
+- `yarn test:run` — Vitest tests (83 files, 1639 tests)
+- `yarn dev` — Dev server with HTTPS (runs `copy:sqlite-wasm` then `next dev --experimental-https`)
+- `yarn build` — Production build
+
+### Running the Dev Server
+
+The `yarn dev` script uses `--experimental-https` which generates a self-signed cert. For headless/CI environments where HTTPS is not needed, use the local `next` binary directly:
+
+```bash
+./node_modules/.bin/next dev --port 3000
+```
+
+Run `yarn copy:sqlite-wasm` first if SQLite WASM assets are missing from `public/`.
+
+### Node.js Version
+
+This project requires **Node.js 24** (matching CI). The VM has nvm installed; use:
+
+```bash
+export PATH="/home/ubuntu/.nvm/versions/node/v24.16.0/bin:$PATH"
+```
+
+to ensure the correct version is on PATH (the `/exec-daemon/node` binary is v22 and should not be used).
+
+### Caveats
+
+- The `prebuild` script (`zenstack generate && zenstack migrate deploy`) requires `DATABASE_URL` for PostgreSQL. It only applies to production builds and query-log features — the dev server runs fine without it.
+- SQLite WASM requires COOP/COEP headers (configured in `next.config.mjs`). The app will not function correctly in browsers that don't support SharedArrayBuffer/OPFS.
+- The Fediverse backend URL defaults to `https://pl.waku.dev`. No local backend server is needed — the app connects to remote Fediverse instances.
+- Husky pre-commit hook runs `yarn check` and `yarn build`. For cloud agent commits, these hooks do not run automatically since the `.git/hooks` path is not configured in the CI-like environment.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud specific instructions to help future cloud agents quickly set up and work with this codebase.

## Changes

- Created `AGENTS.md` with:
  - Overview of the project (Fediverse web client)
  - Key development commands reference
  - Dev server startup instructions (with HTTPS caveat for headless environments)
  - Node.js 24 version requirement and PATH setup
  - Caveats about `prebuild`, SQLite WASM headers, and Fediverse backend defaults

## Verification

The development environment was fully set up and validated:

- ✅ `yarn install` — 653 packages installed successfully
- ✅ `yarn check` — Biome lint passed (441 files, no issues)
- ✅ `yarn test:run` — All 1639 tests passed (83 files)
- ✅ Dev server started on port 3000 and served the login page correctly
- ✅ OAuth flow tested — app correctly redirected to Pleroma instance for authentication

<a href="https://cursor.com/agents/bc-3234aa9f-8dfa-4476-86b5-2c5a8de64476/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmiyulab_fe_login_oauth_flow_demo.mp4"><img src="https://cursor.com/artifacts/c/art-a205d3ff-de4c-4b98-b1e2-8fbf2b0d83ef" alt="miyulab_fe_login_oauth_flow_demo.mp4" /></a>

![Login page](https://cursor.com/artifacts/c/art-8a2d19c9-f590-4ad5-9a46-1b72febb7025)
![OAuth authorization page](https://cursor.com/artifacts/c/art-2286f1ee-51e9-4c9f-b6d7-93fdfbeb7111)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3234aa9f-8dfa-4476-86b5-2c5a8de64476"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3234aa9f-8dfa-4476-86b5-2c5a8de64476"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

