### PR TITLE
feat(ci): Cursor[bot] PR の必須チェック完了時に Cursor Automation Webhook を起動

### DIFF
--- a/.github/workflows/cursor-automation-trigger.md
+++ b/.github/workflows/cursor-automation-trigger.md
@@ -1,0 +1,44 @@
+# Trigger Cursor Automation
+
+マージに必須な GitHub Checks がすべて成功し、PR の `mergeStateStatus` が `CLEAN` になったときに、Cursor Automations の Webhook を呼び出します。
+
+## 実行条件
+
+- 対象ブランチに紐づく **オープンな PR** がある
+- PR の作成者が **`cursor[bot]`**（Cursor Cloud Agent が作成した PR）
+- PR が **ドラフトではない**
+- **マージ必須のチェックがすべて完了**（`mergeStateStatus == CLEAN`）
+
+## GitHub Actions の設定
+
+リポジトリの Settings → Secrets and variables → Actions で次を設定します。
+
+| 種別 | 名前 | 内容 |
+| --- | --- | --- |
+| Variable | `CURSOR_AUTOMATION_WEBHOOK_URL` | Automations の Webhook トリガー URL（保存後に表示） |
+| Secret | `CURSOR_AUTOMATION_WEBHOOK_API_KEY` | Webhook 用 API キー（`crsr_...`。`Authorization: Bearer` で送信） |
+
+Webhook URL と API キーは [cursor.com/automations](https://cursor.com/automations) で Automation を保存したあと、Webhook トリガーから取得します。
+
+## Webhook ペイロード
+
+```json
+{
+  "event": "github.required_checks.completed",
+  "repository": "owner/repo",
+  "pull_request": {
+    "number": 123,
+    "url": "https://github.com/owner/repo/pull/123"
+  },
+  "head_sha": "...",
+  "head_branch": "cursor/..."
+}
+```
+
+Automation 側のプロンプトで `pull_request.url` などを参照できます。
+
+## 動作の補足
+
+- `check_suite` の `completed` ごとに評価します。最後の必須チェックが通るまで `mergeStateStatus` は `CLEAN` にならないため、通常はそのタイミングで 1 回だけ Webhook が送られます。
+- 同一コミット向けの実行は `concurrency` で直列化し、レースを抑えます。
+- 環境変数が未設定の場合は **失敗せずスキップ** します（他ワークフローと同様）。

--- a/.github/workflows/cursor-automation-trigger.md
+++ b/.github/workflows/cursor-automation-trigger.md
@@ -1,13 +1,13 @@
 # Trigger Cursor Automation
 
-マージに必須な GitHub Checks がすべて成功し、PR の `mergeStateStatus` が `CLEAN` になったときに、Cursor Automations の Webhook を呼び出します。
+マージに必須な GitHub Checks がすべて**実行完了**したときに、Cursor Automations の Webhook を呼び出します。成功・失敗どちらでもトリガーします（実行中のチェックが残っている間は送りません）。
 
 ## 実行条件
 
 - 対象ブランチに紐づく **オープンな PR** がある
 - PR の作成者が **`cursor[bot]`**（Cursor Cloud Agent が作成した PR）
 - PR が **ドラフトではない**
-- **マージ必須のチェックがすべて完了**（`mergeStateStatus == CLEAN`）
+- **マージ必須のチェックがすべて実行完了**（`gh pr checks --required` で pending がないこと。失敗していても可）
 
 ## GitHub Actions の設定
 
@@ -31,14 +31,20 @@ Webhook URL と API キーは [cursor.com/automations](https://cursor.com/automa
     "url": "https://github.com/owner/repo/pull/123"
   },
   "head_sha": "...",
-  "head_branch": "cursor/..."
+  "head_branch": "cursor/...",
+  "required_checks": {
+    "completed": true,
+    "passed": false
+  }
 }
 ```
+
+`required_checks.passed` が `false` のときは必須チェックのいずれかが失敗しています。
 
 Automation 側のプロンプトで `pull_request.url` などを参照できます。
 
 ## 動作の補足
 
-- `check_suite` の `completed` ごとに評価します。最後の必須チェックが通るまで `mergeStateStatus` は `CLEAN` にならないため、通常はそのタイミングで 1 回だけ Webhook が送られます。
+- `check_suite` の `completed` ごとに評価します。最後の必須チェックが完了するまで pending が残るため、通常はそのタイミングで 1 回だけ Webhook が送られます。
 - 同一コミット向けの実行は `concurrency` で直列化し、レースを抑えます。
 - 環境変数が未設定の場合は **失敗せずスキップ** します（他ワークフローと同様）。

--- a/.github/workflows/cursor-automation-trigger.yml
+++ b/.github/workflows/cursor-automation-trigger.yml
@@ -1,7 +1,7 @@
 name: Trigger Cursor Automation
 
 # Fires when any check suite on a commit completes. The job re-evaluates whether
-# all merge-required checks on the PR are satisfied (mergeStateStatus == CLEAN).
+# all merge-required checks on the PR have finished (pass or fail).
 on:
   check_suite:
     types: [completed]
@@ -16,10 +16,10 @@ permissions:
   checks: read
 
 jobs:
-  trigger-on-required-checks-passed:
+  trigger-on-required-checks-completed:
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger Cursor Automation when merge checks pass
+      - name: Trigger Cursor Automation when required checks finish
         env:
           GH_TOKEN: ${{ github.token }}
           HEAD_SHA: ${{ github.event.check_suite.head_sha }}
@@ -38,7 +38,7 @@ jobs:
             --repo "${GITHUB_REPOSITORY}" \
             --head "${HEAD_BRANCH}" \
             --state open \
-            --json number,author,isDraft,url,mergeStateStatus \
+            --json number,author,isDraft,url \
             --limit 1)
 
           if [ "$(echo "$PR_JSON" | jq 'length')" -eq 0 ]; then
@@ -50,10 +50,9 @@ jobs:
           PR_AUTHOR=$(echo "$PR_JSON" | jq -r '.[0].author.login')
           PR_URL=$(echo "$PR_JSON" | jq -r '.[0].url')
           IS_DRAFT=$(echo "$PR_JSON" | jq -r '.[0].isDraft')
-          MERGE_STATE=$(echo "$PR_JSON" | jq -r '.[0].mergeStateStatus')
 
           echo "PR #${PR_NUMBER} (${PR_URL})"
-          echo "Author: ${PR_AUTHOR}, draft: ${IS_DRAFT}, mergeStateStatus: ${MERGE_STATE}"
+          echo "Author: ${PR_AUTHOR}, draft: ${IS_DRAFT}"
 
           if [ "$PR_AUTHOR" != "cursor[bot]" ]; then
             echo "Pull request was not created by cursor[bot]. Skipping."
@@ -65,10 +64,39 @@ jobs:
             exit 0
           fi
 
-          if [ "$MERGE_STATE" != "CLEAN" ]; then
-            echo "Merge-required checks are not all satisfied yet. Skipping."
+          REQUIRED_COUNT=$(gh pr checks "${PR_NUMBER}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --required \
+            --json name \
+            -q 'length')
+
+          if [ "${REQUIRED_COUNT}" -eq 0 ]; then
+            echo "No required checks configured for this PR. Skipping."
             exit 0
           fi
+
+          set +e
+          gh pr checks "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" --required
+          CHECKS_EXIT=$?
+          set -e
+
+          # gh pr checks: 0 = all passed, 1 = some failed (completed), 8 = still pending
+          if [ "${CHECKS_EXIT}" -eq 8 ]; then
+            echo "Required checks are still in progress. Skipping."
+            exit 0
+          fi
+
+          if [ "${CHECKS_EXIT}" -ne 0 ] && [ "${CHECKS_EXIT}" -ne 1 ]; then
+            echo "Unexpected gh pr checks exit code: ${CHECKS_EXIT}"
+            exit 1
+          fi
+
+          CHECKS_PASSED="false"
+          if [ "${CHECKS_EXIT}" -eq 0 ]; then
+            CHECKS_PASSED="true"
+          fi
+
+          echo "All ${REQUIRED_COUNT} required check(s) completed (passed=${CHECKS_PASSED})"
 
           if [ -z "${CURSOR_AUTOMATION_WEBHOOK_URL:-}" ] || [ -z "${CURSOR_AUTOMATION_WEBHOOK_API_KEY:-}" ]; then
             echo "CURSOR_AUTOMATION_WEBHOOK_URL or CURSOR_AUTOMATION_WEBHOOK_API_KEY is not configured. Skipping."
@@ -82,12 +110,17 @@ jobs:
             --arg pr_url "$PR_URL" \
             --arg head_sha "$HEAD_SHA" \
             --arg head_branch "$HEAD_BRANCH" \
+            --argjson required_checks_passed "${CHECKS_PASSED}" \
             '{
               event: $event,
               repository: $repository,
               pull_request: {number: $pr_number, url: $pr_url},
               head_sha: $head_sha,
-              head_branch: $head_branch
+              head_branch: $head_branch,
+              required_checks: {
+                completed: true,
+                passed: $required_checks_passed
+              }
             }')
 
           HTTP_CODE=$(curl -sS -o /tmp/cursor-automation-response.json -w "%{http_code}" \

--- a/.github/workflows/cursor-automation-trigger.yml
+++ b/.github/workflows/cursor-automation-trigger.yml
@@ -1,0 +1,105 @@
+name: Trigger Cursor Automation
+
+# Fires when any check suite on a commit completes. The job re-evaluates whether
+# all merge-required checks on the PR are satisfied (mergeStateStatus == CLEAN).
+on:
+  check_suite:
+    types: [completed]
+
+concurrency:
+  group: cursor-automation-${{ github.event.check_suite.head_sha }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pull-requests: read
+  checks: read
+
+jobs:
+  trigger-on-required-checks-passed:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Cursor Automation when merge checks pass
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.check_suite.head_sha }}
+          HEAD_BRANCH: ${{ github.event.check_suite.head_branch }}
+          CURSOR_AUTOMATION_WEBHOOK_URL: ${{ vars.CURSOR_AUTOMATION_WEBHOOK_URL }}
+          CURSOR_AUTOMATION_WEBHOOK_API_KEY: ${{ secrets.CURSOR_AUTOMATION_WEBHOOK_API_KEY }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${HEAD_BRANCH:-}" ]; then
+            echo "No head branch on check_suite. Skipping."
+            exit 0
+          fi
+
+          PR_JSON=$(gh pr list \
+            --repo "${GITHUB_REPOSITORY}" \
+            --head "${HEAD_BRANCH}" \
+            --state open \
+            --json number,author,isDraft,url,mergeStateStatus \
+            --limit 1)
+
+          if [ "$(echo "$PR_JSON" | jq 'length')" -eq 0 ]; then
+            echo "No open pull request for branch ${HEAD_BRANCH}. Skipping."
+            exit 0
+          fi
+
+          PR_NUMBER=$(echo "$PR_JSON" | jq -r '.[0].number')
+          PR_AUTHOR=$(echo "$PR_JSON" | jq -r '.[0].author.login')
+          PR_URL=$(echo "$PR_JSON" | jq -r '.[0].url')
+          IS_DRAFT=$(echo "$PR_JSON" | jq -r '.[0].isDraft')
+          MERGE_STATE=$(echo "$PR_JSON" | jq -r '.[0].mergeStateStatus')
+
+          echo "PR #${PR_NUMBER} (${PR_URL})"
+          echo "Author: ${PR_AUTHOR}, draft: ${IS_DRAFT}, mergeStateStatus: ${MERGE_STATE}"
+
+          if [ "$PR_AUTHOR" != "cursor[bot]" ]; then
+            echo "Pull request was not created by cursor[bot]. Skipping."
+            exit 0
+          fi
+
+          if [ "$IS_DRAFT" = "true" ]; then
+            echo "Pull request is a draft. Skipping."
+            exit 0
+          fi
+
+          if [ "$MERGE_STATE" != "CLEAN" ]; then
+            echo "Merge-required checks are not all satisfied yet. Skipping."
+            exit 0
+          fi
+
+          if [ -z "${CURSOR_AUTOMATION_WEBHOOK_URL:-}" ] || [ -z "${CURSOR_AUTOMATION_WEBHOOK_API_KEY:-}" ]; then
+            echo "CURSOR_AUTOMATION_WEBHOOK_URL or CURSOR_AUTOMATION_WEBHOOK_API_KEY is not configured. Skipping."
+            exit 0
+          fi
+
+          PAYLOAD=$(jq -n \
+            --arg event "github.required_checks.completed" \
+            --arg repository "${GITHUB_REPOSITORY}" \
+            --argjson pr_number "$PR_NUMBER" \
+            --arg pr_url "$PR_URL" \
+            --arg head_sha "$HEAD_SHA" \
+            --arg head_branch "$HEAD_BRANCH" \
+            '{
+              event: $event,
+              repository: $repository,
+              pull_request: {number: $pr_number, url: $pr_url},
+              head_sha: $head_sha,
+              head_branch: $head_branch
+            }')
+
+          HTTP_CODE=$(curl -sS -o /tmp/cursor-automation-response.json -w "%{http_code}" \
+            -X POST "${CURSOR_AUTOMATION_WEBHOOK_URL}" \
+            -H "Authorization: Bearer ${CURSOR_AUTOMATION_WEBHOOK_API_KEY}" \
+            -H "Content-Type: application/json" \
+            -d "${PAYLOAD}")
+
+          if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+            echo "Cursor Automation webhook failed (HTTP ${HTTP_CODE})"
+            cat /tmp/cursor-automation-response.json
+            exit 1
+          fi
+
+          echo "Cursor Automation triggered successfully (HTTP ${HTTP_CODE})"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

マージに必須な GitHub Checks がすべて**実行完了**したタイミングで、Cursor Automations を Webhook 経由で実行する GitHub Actions ワークフローを追加します。**成功・失敗どちらでも**トリガーします。

## 実行条件

- 対象ブランチに紐づくオープンな PR がある
- PR の作成者が `cursor[bot]`（Cursor Cloud Agent が作成した PR）
- PR がドラフトではない
- マージ必須のチェックがすべて**実行完了**（`gh pr checks --required` で pending がないこと。失敗していても可）

## 設定（マージ後に必要）

| 種別 | 名前 |
| --- | --- |
| Variable | `CURSOR_AUTOMATION_WEBHOOK_URL` |
| Secret | `CURSOR_AUTOMATION_WEBHOOK_API_KEY` |

詳細は `.github/workflows/cursor-automation-trigger.md` を参照してください。

## Webhook ペイロード例

```json
{
  "event": "github.required_checks.completed",
  "repository": "owner/repo",
  "pull_request": { "number": 123, "url": "https://github.com/..." },
  "head_sha": "...",
  "head_branch": "cursor/...",
  "required_checks": {
    "completed": true,
    "passed": false
  }
}
```

`required_checks.passed` が `false` のときは必須チェックのいずれかが失敗しています。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a81e0e0-9446-4b66-981f-b02773e4278b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a81e0e0-9446-4b66-981f-b02773e4278b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

