### PR TITLE
fix(ci): ドラフトPR対応と Vercel commit status トリガー

### DIFF
--- a/.github/workflows/cursor-automation-trigger.yml
+++ b/.github/workflows/cursor-automation-trigger.yml
@@ -1,13 +1,15 @@
 name: Trigger Cursor Automation
 
-# Fires when any check suite on a commit completes. The job re-evaluates whether
-# all merge-required checks on the PR have finished (pass or fail), including draft PRs.
+# Re-evaluates required PR checks when CI or external commit statuses finish.
+# - check_suite: GitHub Actions and other Check Run integrations
+# - status: Vercel (and similar) commit statuses without Check Run UI
 on:
   check_suite:
     types: [completed]
+  status:
 
 concurrency:
-  group: cursor-automation-${{ github.event.check_suite.head_sha }}
+  group: cursor-automation-${{ github.event.check_suite.head_sha || github.event.sha }}
   cancel-in-progress: false
 
 permissions:
@@ -22,15 +24,75 @@ jobs:
       - name: Trigger Cursor Automation when required checks finish
         env:
           GH_TOKEN: ${{ github.token }}
-          HEAD_SHA: ${{ github.event.check_suite.head_sha }}
-          HEAD_BRANCH: ${{ github.event.check_suite.head_branch }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          CHECK_SUITE_HEAD_SHA: ${{ github.event.check_suite.head_sha }}
+          CHECK_SUITE_HEAD_BRANCH: ${{ github.event.check_suite.head_branch }}
+          STATUS_SHA: ${{ github.event.sha }}
+          STATUS_STATE: ${{ github.event.state }}
+          STATUS_CONTEXT: ${{ github.event.context }}
           CURSOR_AUTOMATION_WEBHOOK_URL: ${{ vars.CURSOR_AUTOMATION_WEBHOOK_URL }}
           CURSOR_AUTOMATION_WEBHOOK_API_KEY: ${{ secrets.CURSOR_AUTOMATION_WEBHOOK_API_KEY }}
         run: |
           set -euo pipefail
 
-          if [ -z "${HEAD_BRANCH:-}" ]; then
-            echo "No head branch on check_suite. Skipping."
+          HEAD_SHA=""
+          HEAD_BRANCH=""
+          TRIGGER_SOURCE=""
+
+          case "${GITHUB_EVENT_NAME}" in
+            check_suite)
+              HEAD_SHA="${CHECK_SUITE_HEAD_SHA:-}"
+              HEAD_BRANCH="${CHECK_SUITE_HEAD_BRANCH:-}"
+              TRIGGER_SOURCE="check_suite"
+              ;;
+            status)
+              HEAD_SHA="${STATUS_SHA:-}"
+              TRIGGER_SOURCE="status"
+
+              if [ "${STATUS_STATE:-}" = "pending" ]; then
+                echo "Commit status still pending (context: ${STATUS_CONTEXT:-unknown}). Skipping."
+                exit 0
+              fi
+
+              # Vercel uses commit statuses (e.g. "Vercel" or "Vercel – project-name"), not Check Runs.
+              CONTEXT_LOWER=$(printf '%s' "${STATUS_CONTEXT:-}" | tr '[:upper:]' '[:lower:]')
+              if ! printf '%s' "$CONTEXT_LOWER" | grep -q '^vercel'; then
+                echo "Status context '${STATUS_CONTEXT:-}' is not Vercel. Skipping."
+                exit 0
+              fi
+
+              echo "Vercel commit status finished: context='${STATUS_CONTEXT}' state='${STATUS_STATE}'"
+              ;;
+            *)
+              echo "Unsupported event: ${GITHUB_EVENT_NAME}"
+              exit 1
+              ;;
+          esac
+
+          if [ -z "${HEAD_SHA}" ]; then
+            echo "No head SHA resolved from ${TRIGGER_SOURCE} event. Skipping."
+            exit 0
+          fi
+
+          echo "Trigger source: ${TRIGGER_SOURCE} (sha=${HEAD_SHA})"
+
+          if [ -z "${HEAD_BRANCH}" ]; then
+            HEAD_BRANCH=$(gh api \
+              "/repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/pulls" \
+              --jq '.[0].head.ref // empty' 2>/dev/null || true)
+          fi
+
+          if [ -z "${HEAD_BRANCH}" ]; then
+            HEAD_BRANCH=$(gh pr list \
+              --repo "${GITHUB_REPOSITORY}" \
+              --state open \
+              --json headRefName,headRefOid \
+              --jq ".[] | select(.headRefOid==\"${HEAD_SHA}\") | .headRefName" \
+              | head -n1)
+          fi
+
+          if [ -z "${HEAD_BRANCH}" ]; then
+            echo "No pull request branch found for commit ${HEAD_SHA}. Skipping."
             exit 0
           fi
 
@@ -110,6 +172,7 @@ jobs:
             --arg pr_url "$PR_URL" \
             --arg head_sha "$HEAD_SHA" \
             --arg head_branch "$HEAD_BRANCH" \
+            --arg trigger_source "$TRIGGER_SOURCE" \
             --argjson required_checks_passed "${CHECKS_PASSED}" \
             '{
               event: $event,
@@ -117,6 +180,7 @@ jobs:
               pull_request: {number: $pr_number, url: $pr_url},
               head_sha: $head_sha,
               head_branch: $head_branch,
+              trigger_source: $trigger_source,
               required_checks: {
                 completed: true,
                 passed: $required_checks_passed

--- a/.github/workflows/cursor-automation-trigger.yml
+++ b/.github/workflows/cursor-automation-trigger.yml
@@ -1,7 +1,7 @@
 name: Trigger Cursor Automation
 
 # Fires when any check suite on a commit completes. The job re-evaluates whether
-# all merge-required checks on the PR have finished (pass or fail).
+# all merge-required checks on the PR have finished (pass or fail), including draft PRs.
 on:
   check_suite:
     types: [completed]
@@ -63,11 +63,6 @@ jobs:
           fi
 
           echo "Author check passed."
-
-          if [ "$IS_DRAFT" = "true" ]; then
-            echo "Pull request is a draft. Skipping."
-            exit 0
-          fi
 
           REQUIRED_COUNT=$(gh pr checks "${PR_NUMBER}" \
             --repo "${GITHUB_REPOSITORY}" \


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

Cursor Automation トリガーが、次の2点で発火しない問題を修正します。

1. **ドラフト PR** を意図的にスキップしていた
2. **Vercel** が Commit Status API のみを使い、`check_suite: completed` が来ない（必須チェックは付いているが、Vercel 完了時にワークフローが走らない）

## 変更内容

### ドラフト PR
- `isDraft` による早期終了を削除

### Vercel（commit status）
- `on.status` を追加
- `context` が `vercel` で始まる（大文字小文字無視）かつ `state != pending` のときだけ評価
- `status` イベントには `head_branch` がないため、commit SHA から PR ブランチを解決
- Webhook payload に `trigger_source`（`check_suite` / `status`）を追加

## 動作イメージ

```mermaid
sequenceDiagram
  participant GA as GitHub Actions
  participant V as Vercel
  participant WF as cursor-automation-trigger
  participant CA as Cursor Automation

  GA->>WF: check_suite completed
  WF->>WF: gh pr checks --required
  Note over WF: Vercel pending → skip

  V->>WF: status success (context Vercel – …)
  WF->>WF: gh pr checks --required
  WF->>CA: webhook (all required done)
```

## 確認してほしいこと

マージ後、Cursor PR で Vercel の commit status が `success` / `failure` になったタイミングで Actions の `Trigger Cursor Automation` が走るか確認してください。`context` が `Vercel` 以外（例: カスタム consolidated status）の場合は、ログの context 名を共有いただければフィルタを調整できます。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-adeba636-1e2f-47fd-bece-058a18900d70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-adeba636-1e2f-47fd-bece-058a18900d70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

