### PR TITLE
[codex] Fix media modal zoom navigation

### DIFF
--- a/src/app/_components/MediaModal.tsx
+++ b/src/app/_components/MediaModal.tsx
@@ -181,6 +181,7 @@ export const MediaModal = () => {
   const [isZoomed, setIsZoomed] = useState(false)
 
   const closeModal = useCallback(() => {
+    setIsZoomed(false)
     setAttachment({
       attachment: [],
       index: null,

--- a/src/app/_components/MediaModal.tsx
+++ b/src/app/_components/MediaModal.tsx
@@ -12,6 +12,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from 'react'
@@ -23,16 +24,27 @@ import {
 import { ZoomableImage } from './ZoomableImage'
 
 const ModalContent = ({
+  onClose,
   onZoomChange,
 }: {
+  onClose: () => void
   onZoomChange: (isZoomed: boolean) => void
 }) => {
   const { attachment, index } = useContext(MediaModalContext)
 
   const [carouselApi, setCarouselApi] = useState<CarouselApi>()
   const [currentSlide, setCurrentSlide] = useState(index ?? 0)
-  const [isCurrentSlideZoomed, setIsCurrentSlideZoomed] = useState(false)
+  const isCurrentSlideZoomedRef = useRef(false)
   const zoomedSlideRef = useRef<Set<number>>(new Set())
+
+  const carouselOpts = useMemo(
+    () => ({
+      loop: true,
+      startIndex: index ?? 0,
+      watchDrag: () => !isCurrentSlideZoomedRef.current,
+    }),
+    [index],
+  )
 
   useEffect(() => {
     if (carouselApi == null) return
@@ -41,7 +53,7 @@ const ModalContent = ({
       const slide = carouselApi.selectedScrollSnap()
       setCurrentSlide(slide)
       const nextSlideZoomed = zoomedSlideRef.current.has(slide)
-      setIsCurrentSlideZoomed(nextSlideZoomed)
+      isCurrentSlideZoomedRef.current = nextSlideZoomed
       onZoomChange(nextSlideZoomed)
     }
 
@@ -57,13 +69,15 @@ const ModalContent = ({
         carouselApi?.scrollPrev()
       } else if (e.code === 'ArrowRight') {
         carouselApi?.scrollNext()
+      } else if (e.code === 'Escape') {
+        onClose()
       }
     }
     document.addEventListener('keydown', onKeyDown)
     return () => {
       document.removeEventListener('keydown', onKeyDown)
     }
-  }, [carouselApi])
+  }, [carouselApi, onClose])
 
   const onClickPrev: MouseEventHandler<HTMLButtonElement> = (e) => {
     e.stopPropagation()
@@ -75,6 +89,11 @@ const ModalContent = ({
     carouselApi?.scrollNext()
   }
 
+  const handleBackgroundClick = useCallback(() => {
+    if (isCurrentSlideZoomedRef.current) return
+    onClose()
+  }, [onClose])
+
   const handleZoomChange = useCallback(
     (slideIndex: number, isZoomed: boolean) => {
       if (isZoomed) {
@@ -83,7 +102,7 @@ const ModalContent = ({
         zoomedSlideRef.current.delete(slideIndex)
       }
       if (slideIndex === currentSlide) {
-        setIsCurrentSlideZoomed(isZoomed)
+        isCurrentSlideZoomedRef.current = isZoomed
         onZoomChange(isZoomed)
       }
     },
@@ -100,14 +119,7 @@ const ModalContent = ({
       {attachment.length > 1 ? (
         <>
           <div className="fixed inset-0 z-50 m-auto h-[90vh] w-[90vw]">
-            <Carousel
-              opts={{
-                loop: true,
-                startIndex: index,
-                watchDrag: !isCurrentSlideZoomed,
-              }}
-              setApi={setCarouselApi}
-            >
+            <Carousel opts={carouselOpts} setApi={setCarouselApi}>
               <CarouselContent>
                 {attachment.map((media, slideIndex) => {
                   return (
@@ -116,6 +128,7 @@ const ModalContent = ({
                         <ZoomableImage
                           className="h-[90vh] w-[90vw]"
                           media={media}
+                          onBackgroundClick={handleBackgroundClick}
                           onZoomChange={(isZoomed) =>
                             handleZoomChange(slideIndex, isZoomed)
                           }
@@ -151,7 +164,8 @@ const ModalContent = ({
             <ZoomableImage
               className="h-[90vh] w-[90vw]"
               media={attachment[index]}
-              onZoomChange={onZoomChange}
+              onBackgroundClick={handleBackgroundClick}
+              onZoomChange={(isZoomed) => handleZoomChange(index, isZoomed)}
             />
           </div>
         )
@@ -166,6 +180,13 @@ export const MediaModal = () => {
   const setAttachment = useContext(SetMediaModalContext)
   const [isZoomed, setIsZoomed] = useState(false)
 
+  const closeModal = useCallback(() => {
+    setAttachment({
+      attachment: [],
+      index: null,
+    })
+  }, [setAttachment])
+
   if (attachment.length === 0 || index == null) return null
 
   if (['video', 'gifv', 'audio'].includes(attachment[index].type)) {
@@ -176,13 +197,10 @@ export const MediaModal = () => {
     <Modal
       onClick={() => {
         if (isZoomed) return
-        setAttachment({
-          attachment: [],
-          index: null,
-        })
+        closeModal()
       }}
     >
-      <ModalContent onZoomChange={setIsZoomed} />
+      <ModalContent onClose={closeModal} onZoomChange={setIsZoomed} />
     </Modal>
   )
 }

--- a/src/app/_components/ZoomableImage.tsx
+++ b/src/app/_components/ZoomableImage.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import type { Entity } from 'megalodon'
-import { useEffect, useRef } from 'react'
+import { type MouseEventHandler, useEffect, useRef } from 'react'
 import { RiAddLine, RiRefreshLine, RiSubtractLine } from 'react-icons/ri'
 import {
   type ReactZoomPanPinchRef,
@@ -12,10 +12,12 @@ import {
 export const ZoomableImage = ({
   media,
   className,
+  onBackgroundClick,
   onZoomChange,
 }: {
   media: Entity.Attachment
   className?: string
+  onBackgroundClick?: () => void
   onZoomChange?: (isZoomed: boolean) => void
 }) => {
   const transformRef = useRef<ReactZoomPanPinchRef>(null)
@@ -37,8 +39,14 @@ export const ZoomableImage = ({
     }
   }
 
+  const handleBackgroundClick: MouseEventHandler<HTMLDivElement> = (e) => {
+    if (e.target instanceof HTMLImageElement) return
+    if (e.target instanceof Element && e.target.closest('button')) return
+    onBackgroundClick?.()
+  }
+
   return (
-    <div className="relative h-full w-full">
+    <div className="relative h-full w-full" onClick={handleBackgroundClick}>
       <TransformWrapper
         doubleClick={{ mode: 'reset' }}
         initialScale={1}
@@ -69,6 +77,9 @@ export const ZoomableImage = ({
                   className,
                 ].join(' ')}
                 draggable={false}
+                onClick={(e) => {
+                  e.stopPropagation()
+                }}
                 src={media.url ?? media.preview_url ?? undefined}
               />
             </TransformComponent>


### PR DESCRIPTION
## Summary
- Keep Embla carousel options stable while zoom state changes so zooming does not reinitialize back to the initial slide.
- Add Escape key closing for the media modal.
- Close the modal when clicking non-image space inside the zoom viewport while preserving image, control, and zoomed/panning interactions.

## Root cause
watchDrag was toggled through the carousel options object. That made Embla reinitialize, and startIndex was reapplied from the originally opened image, so zooming could jump back to that slide.

## Validation
- yarn check passed. Biome reports a schema-version info because the CLI is 2.5.1 and iome.json references 2.5.0, but exits successfully.
- itest run passed: 84 files, 1677 tests.
- Targeted TypeScript check passed for MediaModal.tsx and ZoomableImage.tsx.

Fixes #632