### PR TITLE
[codex] Fix timeline interaction persistence

### DIFF
--- a/src/util/db/sqlite/__tests__/handlers-interaction.test.ts
+++ b/src/util/db/sqlite/__tests__/handlers-interaction.test.ts
@@ -87,8 +87,10 @@ describe('handleUpdateStatusAction', () => {
       1,
       'favourite',
       true,
+      undefined,
+      { recordLocalAction: true },
     )
-    expect(result).toEqual({ changedTables: ['posts'] })
+    expect(result).toEqual({ changedTables: ['posts', 'post_interactions'] })
   })
 
   it('reblog アクションを処理する', () => {
@@ -98,8 +100,16 @@ describe('handleUpdateStatusAction', () => {
     const result = handleUpdateStatusAction(db, 2, '67890', 'reblogged', true)
 
     expect(resolvePostIdInternal).toHaveBeenCalledWith(db, 2, '67890')
-    expect(updateInteraction).toHaveBeenCalledWith(db, 200, 2, 'reblog', true)
-    expect(result).toEqual({ changedTables: ['posts'] })
+    expect(updateInteraction).toHaveBeenCalledWith(
+      db,
+      200,
+      2,
+      'reblog',
+      true,
+      undefined,
+      { recordLocalAction: true },
+    )
+    expect(result).toEqual({ changedTables: ['posts', 'post_interactions'] })
   })
 
   it('bookmark アクションを処理する', () => {
@@ -115,8 +125,10 @@ describe('handleUpdateStatusAction', () => {
       3,
       'bookmark',
       false,
+      undefined,
+      { recordLocalAction: true },
     )
-    expect(result).toEqual({ changedTables: ['posts'] })
+    expect(result).toEqual({ changedTables: ['posts', 'post_interactions'] })
   })
 
   it('投稿が見つからない場合は何もしない', () => {
@@ -156,8 +168,18 @@ describe('handleUpdateStatusAction', () => {
       1,
       'favourite',
       true,
+      undefined,
+      { recordLocalAction: true },
     )
-    expect(updateInteraction).toHaveBeenCalledWith(db, 50, 1, 'favourite', true)
+    expect(updateInteraction).toHaveBeenCalledWith(
+      db,
+      50,
+      1,
+      'favourite',
+      true,
+      undefined,
+      { recordLocalAction: true },
+    )
   })
 
   it('このポストを reblog している他の投稿にも伝播する', () => {
@@ -174,9 +196,33 @@ describe('handleUpdateStatusAction', () => {
 
     // 自身 + リブログ2件 = 3回
     expect(updateInteraction).toHaveBeenCalledTimes(3)
-    expect(updateInteraction).toHaveBeenCalledWith(db, 100, 1, 'reblog', true)
-    expect(updateInteraction).toHaveBeenCalledWith(db, 200, 1, 'reblog', true)
-    expect(updateInteraction).toHaveBeenCalledWith(db, 300, 1, 'reblog', true)
+    expect(updateInteraction).toHaveBeenCalledWith(
+      db,
+      100,
+      1,
+      'reblog',
+      true,
+      undefined,
+      { recordLocalAction: true },
+    )
+    expect(updateInteraction).toHaveBeenCalledWith(
+      db,
+      200,
+      1,
+      'reblog',
+      true,
+      undefined,
+      { recordLocalAction: true },
+    )
+    expect(updateInteraction).toHaveBeenCalledWith(
+      db,
+      300,
+      1,
+      'reblog',
+      true,
+      undefined,
+      { recordLocalAction: true },
+    )
   })
 })
 
@@ -193,12 +239,13 @@ describe('handleToggleReaction', () => {
 
     expect(resolvePostIdInternal).toHaveBeenCalledWith(db, 1, '12345')
     expect(toggleReaction).toHaveBeenCalledWith(db, 100, 1, '👍', null)
-    expect(result).toEqual({ changedTables: ['posts'] })
+    expect(result).toEqual({ changedTables: ['posts', 'post_interactions'] })
   })
 
   it('カスタム絵文字のリアクションを設定する（shortcode → url 解決）', () => {
     // SELECT id, url FROM custom_emojis WHERE server_id = ? AND shortcode = ?
     const { db } = createMockDb([
+      [],
       [[42, 'https://example.com/emoji/blobcat.png']],
     ])
     vi.mocked(resolvePostIdInternal).mockReturnValue(100)
@@ -223,7 +270,7 @@ describe('handleToggleReaction', () => {
       'blobcat',
       'https://example.com/emoji/blobcat.png',
     )
-    expect(result).toEqual({ changedTables: ['posts'] })
+    expect(result).toEqual({ changedTables: ['posts', 'post_interactions'] })
   })
 
   it('リアクションをクリアする（value=false）', () => {
@@ -234,7 +281,31 @@ describe('handleToggleReaction', () => {
 
     expect(resolvePostIdInternal).toHaveBeenCalledWith(db, 1, '12345')
     expect(toggleReaction).toHaveBeenCalledWith(db, 100, 1, null, null)
-    expect(result).toEqual({ changedTables: ['posts'] })
+    expect(result).toEqual({ changedTables: ['posts', 'post_interactions'] })
+  })
+
+  it('reblog からのリアクションを元投稿と同じ元投稿の reblog に伝播する', () => {
+    const { db } = createMockDb([[[50]], [[100], [200]]])
+    vi.mocked(resolvePostIdInternal).mockReturnValue(100)
+
+    handleToggleReaction(db, 1, '12345', true, '👍')
+
+    expect(toggleReaction).toHaveBeenCalledTimes(3)
+    expect(toggleReaction).toHaveBeenCalledWith(db, 100, 1, '👍', null)
+    expect(toggleReaction).toHaveBeenCalledWith(db, 50, 1, '👍', null)
+    expect(toggleReaction).toHaveBeenCalledWith(db, 200, 1, '👍', null)
+  })
+
+  it('元投稿からのリアクションを reblog 投稿にも伝播する', () => {
+    const { db } = createMockDb([[[null]], [[200], [300]]])
+    vi.mocked(resolvePostIdInternal).mockReturnValue(100)
+
+    handleToggleReaction(db, 1, '12345', true, '👍')
+
+    expect(toggleReaction).toHaveBeenCalledTimes(3)
+    expect(toggleReaction).toHaveBeenCalledWith(db, 100, 1, '👍', null)
+    expect(toggleReaction).toHaveBeenCalledWith(db, 200, 1, '👍', null)
+    expect(toggleReaction).toHaveBeenCalledWith(db, 300, 1, '👍', null)
   })
 
   it('投稿が見つからない場合は何もしない', () => {

--- a/src/util/db/sqlite/__tests__/handlers-status.test.ts
+++ b/src/util/db/sqlite/__tests__/handlers-status.test.ts
@@ -369,6 +369,7 @@ describe('handleUpsertStatus', () => {
       'favourite',
       false,
       expect.anything(),
+      { preserveRecentLocalTrueMs: 60_000 },
     )
     expect(helpersModule.updateInteraction).toHaveBeenCalledWith(
       db,
@@ -377,6 +378,7 @@ describe('handleUpsertStatus', () => {
       'reblog',
       false,
       expect.anything(),
+      { preserveRecentLocalTrueMs: 60_000 },
     )
     expect(helpersModule.updateInteraction).toHaveBeenCalledWith(
       db,
@@ -385,6 +387,7 @@ describe('handleUpsertStatus', () => {
       'bookmark',
       false,
       expect.anything(),
+      { preserveRecentLocalTrueMs: 60_000 },
     )
   })
 

--- a/src/util/db/sqlite/__tests__/handlers-statusUpdate.test.ts
+++ b/src/util/db/sqlite/__tests__/handlers-statusUpdate.test.ts
@@ -332,6 +332,7 @@ describe('handleUpdateStatus', () => {
       'favourite',
       false,
       expect.anything(),
+      { preserveRecentLocalTrueMs: 60_000 },
     )
     expect(helpersModule.updateInteraction).toHaveBeenCalledWith(
       db,
@@ -340,6 +341,7 @@ describe('handleUpdateStatus', () => {
       'reblog',
       false,
       expect.anything(),
+      { preserveRecentLocalTrueMs: 60_000 },
     )
     expect(helpersModule.updateInteraction).toHaveBeenCalledWith(
       db,
@@ -348,6 +350,7 @@ describe('handleUpdateStatus', () => {
       'bookmark',
       false,
       expect.anything(),
+      { preserveRecentLocalTrueMs: 60_000 },
     )
   })
 

--- a/src/util/db/sqlite/__tests__/helpers-interaction.test.ts
+++ b/src/util/db/sqlite/__tests__/helpers-interaction.test.ts
@@ -95,6 +95,34 @@ describe('updateInteraction', () => {
     expect(calls[1].opts?.bind).toEqual([100, 1, 0, expect.any(Number)])
   })
 
+  it('preserveRecentLocalTrueMs 指定時は記録済み同一 action の stale false を書き込まない', () => {
+    const { calls, db } = createMockDb()
+
+    updateInteraction(db, 100, 1, 'favourite', true, undefined, {
+      recordLocalAction: true,
+    })
+    updateInteraction(db, 100, 1, 'favourite', false, undefined, {
+      preserveRecentLocalTrueMs: 60_000,
+    })
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0].opts?.bind).toEqual([100, 1, 1, expect.any(Number)])
+  })
+
+  it('recent local 記録は action ごとに分離される', () => {
+    const { calls, db } = createMockDb()
+
+    updateInteraction(db, 101, 1, 'bookmark', true, undefined, {
+      recordLocalAction: true,
+    })
+    updateInteraction(db, 101, 1, 'favourite', false, undefined, {
+      preserveRecentLocalTrueMs: 60_000,
+    })
+
+    expect(calls).toHaveLength(2)
+    expect(calls[1].opts?.bind).toEqual([101, 1, 0, expect.any(Number)])
+  })
+
   it('不明なアクション名の場合何もしない', () => {
     const { db, calls } = createMockDb()
 

--- a/src/util/db/sqlite/__tests__/queries-statusMapper.test.ts
+++ b/src/util/db/sqlite/__tests__/queries-statusMapper.test.ts
@@ -27,7 +27,7 @@ import { describe, expect, it } from 'vitest'
  *   [16] author_display   [17] author_avatar    [18] author_header
  *   [19] author_locked    [20] author_bot       [21] author_url
  *   [22] replies_count    [23] reblogs_count    [24] favourites_count
- *   [25] engagements_csv  [26] media_json       [27] mentions_json
+ *   [25] interactions_json [26] media_json      [27] mentions_json
  *   [28] timelineTypes    [29] belongingTags
  *   [30] status_emojis_json [31] account_emojis_json
  *   [32] poll_json
@@ -39,7 +39,7 @@ import { describe, expect, it } from 'vitest'
  *   [46] rb_author_display [47] rb_author_avatar [48] rb_author_header
  *   [49] rb_author_locked [50] rb_author_bot    [51] rb_author_url
  *   [52] rb_replies_count [53] rb_reblogs_count [54] rb_favourites_count
- *   [55] rb_engagements_csv [56] rb_media_json  [57] rb_mentions_json
+ *   [55] rb_interactions_json [56] rb_media_json [57] rb_mentions_json
  *   [58] rb_status_emojis_json [59] rb_account_emojis_json
  *   [60] rb_poll_json     [61] rb_local_id
  *   [62] author_account_id [63] rb_author_account_id
@@ -73,7 +73,7 @@ function makeRow(): (string | number | null)[] {
   row[22] = 3 // replies_count
   row[23] = 5 // reblogs_count
   row[24] = 10 // favourites_count
-  row[25] = null // engagements_csv
+  row[25] = null // interactions_json
   row[62] = '' // author_account_id
   return row
 }
@@ -233,6 +233,39 @@ describe('rowToStoredStatus', () => {
 
     expect(result.visibility).toBe('unlisted')
   })
+
+  it('rowToStoredStatus が local reaction を emoji_reactions に反映する', () => {
+    const row = makeRow()
+    row[25] = JSON.stringify({
+      is_bookmarked: 0,
+      is_favourited: 1,
+      is_muted: 0,
+      is_pinned: 0,
+      is_reblogged: 0,
+      my_reaction_name: '👍',
+      my_reaction_url: null,
+    })
+    row[64] = JSON.stringify([
+      {
+        account_ids: [],
+        count: 2,
+        me: false,
+        name: '👍',
+      },
+    ])
+
+    const result = rowToStoredStatus(row)
+
+    expect(result.favourited).toBe(true)
+    expect(result.emoji_reactions).toEqual([
+      {
+        account_ids: [],
+        count: 2,
+        me: true,
+        name: '👍',
+      },
+    ])
+  })
 })
 
 // ─── assembleStatusFromBatch ────────────────────────────────────
@@ -261,6 +294,123 @@ describe('assembleStatusFromBatch', () => {
     expect(result.favourited).toBe(true)
     expect(result.reblogged).toBe(false)
     expect(result.bookmarked).toBe(true)
+  })
+
+  it('ローカル reaction を既存 emoji_reactions に反映する', () => {
+    const row = makeBaseRow()
+    const postId = row[0] as number
+    row[50] = JSON.stringify([
+      {
+        account_ids: [],
+        count: 2,
+        me: false,
+        name: '👍',
+      },
+    ])
+
+    const interactionsJson = JSON.stringify({
+      is_bookmarked: 0,
+      is_favourited: 0,
+      is_muted: 0,
+      is_pinned: 0,
+      is_reblogged: 0,
+      my_reaction_name: '👍',
+      my_reaction_url: null,
+    })
+    const maps = makeMaps({
+      interactionsMap: new Map([[postId, interactionsJson]]),
+    })
+
+    const result = assembleStatusFromBatch(row, maps)
+
+    expect(result.emoji_reactions).toEqual([
+      {
+        account_ids: [],
+        count: 2,
+        me: true,
+        name: '👍',
+      },
+    ])
+  })
+
+  it('ローカル reaction が payload にない場合 emoji_reactions に追加する', () => {
+    const row = makeBaseRow()
+    const postId = row[0] as number
+    row[50] = '[]'
+
+    const interactionsJson = JSON.stringify({
+      is_bookmarked: 0,
+      is_favourited: 0,
+      is_muted: 0,
+      is_pinned: 0,
+      is_reblogged: 0,
+      my_reaction_name: 'blobcat',
+      my_reaction_url: 'https://example.com/emoji/blobcat.png',
+    })
+    const maps = makeMaps({
+      interactionsMap: new Map([[postId, interactionsJson]]),
+    })
+
+    const result = assembleStatusFromBatch(row, maps)
+
+    expect(result.emoji_reactions).toEqual([
+      {
+        account_ids: [],
+        count: 1,
+        me: true,
+        name: 'blobcat',
+        static_url: 'https://example.com/emoji/blobcat.png',
+        url: 'https://example.com/emoji/blobcat.png',
+      },
+    ])
+  })
+
+  it('reblog 元のローカル reaction を reblog.emoji_reactions に反映する', () => {
+    const row = makeBaseRow()
+    row[11] = 1
+    row[25] = 77
+    row[26] = '<p>Reblogged</p>'
+    row[27] = ''
+    row[28] = 'https://example.com/@bob/777'
+    row[29] = 'en'
+    row[30] = 'public'
+    row[31] = 0
+    row[32] = null
+    row[33] = null
+    row[34] = 1700000100000
+    row[35] = 'https://example.com/users/bob/statuses/777'
+    row[36] = 'bob'
+    row[37] = 'bob'
+    row[38] = 'Bob'
+    row[39] = 'https://example.com/bob-avatar.png'
+    row[40] = 'https://example.com/bob-header.png'
+    row[41] = 0
+    row[42] = 0
+    row[43] = 'https://example.com/@bob'
+    row[44] = 0
+    row[45] = 0
+    row[46] = 0
+    row[47] = '777'
+    row[51] = JSON.stringify([{ count: 1, me: false, name: '🔥' }])
+
+    const interactionsJson = JSON.stringify({
+      is_bookmarked: 0,
+      is_favourited: 0,
+      is_muted: 0,
+      is_pinned: 0,
+      is_reblogged: 0,
+      my_reaction_name: '🔥',
+      my_reaction_url: null,
+    })
+    const maps = makeMaps({
+      interactionsMap: new Map([[77, interactionsJson]]),
+    })
+
+    const result = assembleStatusFromBatch(row, maps)
+
+    expect(result.reblog?.emoji_reactions).toEqual([
+      { count: 1, me: true, name: '🔥' },
+    ])
   })
 
   it('assembleStatusFromBatch が mentions に username と url を含める', () => {

--- a/src/util/db/sqlite/__tests__/queries-statusSelect.test.ts
+++ b/src/util/db/sqlite/__tests__/queries-statusSelect.test.ts
@@ -1,4 +1,5 @@
 import {
+  buildScopedEngagementsSql,
   STATUS_BASE_JOINS,
   STATUS_BASE_SELECT,
   STATUS_SELECT,
@@ -171,6 +172,22 @@ describe('statusSelect — 新スキーマ対応', () => {
 
     it('STATUS_SELECT に engagement_types が含まれていない', () => {
       expect(STATUS_SELECT).not.toContain('engagement_types')
+    })
+
+    it('スコープ付き interactions SQL が reaction 情報を JSON で返す', () => {
+      const sql = buildScopedEngagementsSql(['https://example.com'])
+
+      expect(sql).toContain('json_object')
+      expect(sql).toContain('my_reaction_name')
+      expect(sql).toContain('my_reaction_url')
+      expect(sql).toContain('interactions_json')
+      expect(sql).not.toContain('engagements_csv')
+    })
+
+    it('STATUS_SELECT の interactions_json は選択中 local account にスコープする', () => {
+      expect(STATUS_SELECT).toContain(
+        'pi2.local_account_id = spb.local_account_id',
+      )
     })
   })
 

--- a/src/util/db/sqlite/helpers/interaction.ts
+++ b/src/util/db/sqlite/helpers/interaction.ts
@@ -14,6 +14,21 @@ const ACTION_COLUMN_MAP: Record<string, string> = {
   reblog: 'is_reblogged',
 }
 
+type UpdateInteractionOptions = {
+  preserveRecentLocalTrueMs?: number
+  recordLocalAction?: boolean
+}
+
+const recentLocalTrueInteractions = new Map<string, number>()
+
+function interactionKey(
+  postId: number,
+  localAccountId: number,
+  action: string,
+): string {
+  return `${postId}:${localAccountId}:${action}`
+}
+
 /**
  * post_interactions テーブルの対応するブーリアンカラムを更新する。
  * レコードがなければ INSERT、あれば UPDATE（UPSERT）。
@@ -25,19 +40,40 @@ export function updateInteraction(
   action: string,
   value: boolean,
   collector?: WrittenTableCollector,
+  options?: UpdateInteractionOptions,
 ): void {
   const column = ACTION_COLUMN_MAP[action]
   if (!column) return
 
   const now = Date.now()
+  const key = interactionKey(postId, localAccountId, action)
+  const recentLocalTrueAt = recentLocalTrueInteractions.get(key)
+  if (
+    !value &&
+    options?.preserveRecentLocalTrueMs !== undefined &&
+    recentLocalTrueAt !== undefined &&
+    now - recentLocalTrueAt <= options.preserveRecentLocalTrueMs
+  ) {
+    return
+  }
+
+  const updateClause = `${column} = excluded.${column},
+       updated_at = excluded.updated_at`
+
   db.exec(
     `INSERT INTO post_interactions (post_id, local_account_id, ${column}, updated_at)
      VALUES (?, ?, ?, ?)
      ON CONFLICT(post_id, local_account_id) DO UPDATE SET
-       ${column} = excluded.${column},
-       updated_at = excluded.updated_at;`,
+       ${updateClause};`,
     { bind: [postId, localAccountId, value ? 1 : 0, now] },
   )
+  if (options?.recordLocalAction) {
+    if (value) {
+      recentLocalTrueInteractions.set(key, now)
+    } else {
+      recentLocalTrueInteractions.delete(key)
+    }
+  }
   collector?.add('post_interactions')
 }
 
@@ -51,6 +87,7 @@ export function toggleReaction(
   localAccountId: number,
   name: string | null,
   url: string | null,
+  collector?: WrittenTableCollector,
 ): void {
   const now = Date.now()
   db.exec(
@@ -62,4 +99,5 @@ export function toggleReaction(
        updated_at = excluded.updated_at;`,
     { bind: [postId, localAccountId, name, url, now] },
   )
+  collector?.add('post_interactions')
 }

--- a/src/util/db/sqlite/queries/assembleStatusFromBatch.ts
+++ b/src/util/db/sqlite/queries/assembleStatusFromBatch.ts
@@ -30,6 +30,7 @@ import type { Entity } from 'megalodon'
 import type { BatchMaps } from './statusBatch'
 import {
   editedAtMsToIso,
+  mergeLocalReaction,
   parseBatchPoll,
   parseEmojiReactions,
   parseEmojis,
@@ -112,7 +113,10 @@ export function assembleStatusFromBatch(
       content: (row[26] as string) ?? '',
       created_at: row[34] ? new Date(row[34] as number).toISOString() : '',
       edited_at: editedAtMsToIso(rbEditedAtMs),
-      emoji_reactions: parseEmojiReactions(rbEmojiReactionsJson),
+      emoji_reactions: mergeLocalReaction(
+        parseEmojiReactions(rbEmojiReactionsJson),
+        rbInteractions,
+      ),
       emojis: parseEmojis(rbCustomEmojisJson),
       favourited: rbInteractions?.is_favourited === 1,
       favourites_count: (row[46] as number) ?? 0,
@@ -180,7 +184,10 @@ export function assembleStatusFromBatch(
     created_at_ms: row[3] as number,
     edited_at: editedAtMsToIso(editedAtMs),
     edited_at_ms: editedAtMs,
-    emoji_reactions: parseEmojiReactions(emojiReactionsJson),
+    emoji_reactions: mergeLocalReaction(
+      parseEmojiReactions(emojiReactionsJson),
+      interactions,
+    ),
     emojis: parseEmojis(customEmojisJson),
     favourited: interactions?.is_favourited === 1,
     favourites_count: (row[24] as number) ?? 0,

--- a/src/util/db/sqlite/queries/rowToStoredStatus.ts
+++ b/src/util/db/sqlite/queries/rowToStoredStatus.ts
@@ -11,7 +11,7 @@
  *   [16] author_display  [17] author_avatar    [18] author_header
  *   [19] author_locked   [20] author_bot       [21] author_url
  *   [22] replies_count   [23] reblogs_count    [24] favourites_count
- *   [25] engagements_csv [26] media_json       [27] mentions_json
+ *   [25] interactions_json [26] media_json     [27] mentions_json
  *   [28] timelineTypes   [29] belongingTags
  *   [30] status_emojis_json [31] account_emojis_json
  *   [32] poll_json
@@ -25,7 +25,7 @@
  *   [46] rb_author_display [47] rb_author_avatar [48] rb_author_header
  *   [49] rb_author_locked [50] rb_author_bot    [51] rb_author_url
  *   [52] rb_replies_count [53] rb_reblogs_count [54] rb_favourites_count
- *   [55] rb_engagements_csv [56] rb_media_json  [57] rb_mentions_json
+ *   [55] rb_interactions_json [56] rb_media_json [57] rb_mentions_json
  *   [58] rb_status_emojis_json [59] rb_account_emojis_json
  *   [60] rb_poll_json     [61] rb_local_id
  *
@@ -37,20 +37,46 @@
 import type { Entity } from 'megalodon'
 import {
   editedAtMsToIso,
+  mergeLocalReaction,
   parseEmojiReactions,
   parseEmojis,
   parseInlinePoll,
+  parseInteractions,
   parseMediaAttachments,
   parseMentions,
 } from './statusMapperParsers'
-import type { SqliteStoredStatus, TimelineType } from './statusMapperTypes'
+import type {
+  InteractionsJson,
+  SqliteStoredStatus,
+  TimelineType,
+} from './statusMapperTypes'
+
+function parseLegacyEngagements(jsonOrCsv: string | null): string[] {
+  if (!jsonOrCsv || jsonOrCsv.trimStart().startsWith('{')) return []
+  return jsonOrCsv.split(',')
+}
+
+function hasInteraction(
+  interactions: InteractionsJson | null,
+  engagements: string[],
+  column: keyof Pick<
+    InteractionsJson,
+    'is_bookmarked' | 'is_favourited' | 'is_reblogged'
+  >,
+  legacyName: string,
+): boolean {
+  return interactions
+    ? interactions[column] === 1
+    : engagements.includes(legacyName)
+}
 
 export function rowToStoredStatus(
   row: (string | number | null)[],
 ): SqliteStoredStatus {
   // ── サブクエリ結果の取り出し ──
-  const engagementsCsv = row[25] as string | null
-  const engagements = engagementsCsv ? engagementsCsv.split(',') : []
+  const interactionsJson = row[25] as string | null
+  const interactions = parseInteractions(interactionsJson)
+  const engagements = parseLegacyEngagements(interactionsJson)
   const mediaJson = row[26] as string | null
   const mentionsJson = row[27] as string | null
   const timelineTypesJson = row[28] as string | null
@@ -73,8 +99,9 @@ export function rowToStoredStatus(
   let reblog: Entity.Status | null = null
 
   if (isReblog && rbPostId !== null) {
-    const rbEngagementsCsv = row[55] as string | null
-    const rbEngagements = rbEngagementsCsv ? rbEngagementsCsv.split(',') : []
+    const rbInteractionsJson = row[55] as string | null
+    const rbInteractions = parseInteractions(rbInteractionsJson)
+    const rbEngagements = parseLegacyEngagements(rbInteractionsJson)
     const rbMediaJson = row[56] as string | null
     const rbMentionsJson = row[57] as string | null
     const rbStatusEmojisJson = row[58] as string | null
@@ -110,14 +137,27 @@ export function rowToStoredStatus(
         username: (row[45] as string) ?? '',
       },
       application: null,
-      bookmarked: rbEngagements.includes('bookmark'),
+      bookmarked: hasInteraction(
+        rbInteractions,
+        rbEngagements,
+        'is_bookmarked',
+        'bookmark',
+      ),
       card: null,
       content: (row[34] as string) ?? '',
       created_at: row[42] ? new Date(row[42] as number).toISOString() : '',
       edited_at: editedAtMsToIso(rbEditedAtMs),
-      emoji_reactions: parseEmojiReactions(rbEmojiReactionsJson),
+      emoji_reactions: mergeLocalReaction(
+        parseEmojiReactions(rbEmojiReactionsJson),
+        rbInteractions,
+      ),
       emojis: parseEmojis(rbStatusEmojisJson),
-      favourited: rbEngagements.includes('favourite'),
+      favourited: hasInteraction(
+        rbInteractions,
+        rbEngagements,
+        'is_favourited',
+        'favourite',
+      ),
       favourites_count: (row[54] as number) ?? 0,
       id: (row[61] as string) ?? '',
       in_reply_to_account_id: null,
@@ -132,7 +172,12 @@ export function rowToStoredStatus(
       quote: null,
       quote_approval: { automatic: [], current_user: '', manual: [] },
       reblog: null,
-      reblogged: rbEngagements.includes('reblog'),
+      reblogged: hasInteraction(
+        rbInteractions,
+        rbEngagements,
+        'is_reblogged',
+        'reblog',
+      ),
       reblogs_count: (row[53] as number) ?? 0,
       replies_count: (row[52] as number) ?? 0,
       sensitive: (row[39] as number) === 1,
@@ -176,16 +221,29 @@ export function rowToStoredStatus(
     application: null,
     backendUrl: (row[1] as string) ?? '',
     belongingTags,
-    bookmarked: engagements.includes('bookmark'),
+    bookmarked: hasInteraction(
+      interactions,
+      engagements,
+      'is_bookmarked',
+      'bookmark',
+    ),
     card: null,
     content: (row[5] as string) ?? '',
     created_at: new Date(row[3] as number).toISOString(),
     created_at_ms: row[3] as number,
     edited_at: editedAtMsToIso(editedAtMs),
     edited_at_ms: editedAtMs,
-    emoji_reactions: parseEmojiReactions(emojiReactionsJson),
+    emoji_reactions: mergeLocalReaction(
+      parseEmojiReactions(emojiReactionsJson),
+      interactions,
+    ),
     emojis: parseEmojis(statusEmojisJson),
-    favourited: engagements.includes('favourite'),
+    favourited: hasInteraction(
+      interactions,
+      engagements,
+      'is_favourited',
+      'favourite',
+    ),
     favourites_count: (row[24] as number) ?? 0,
     id: (row[2] as string) ?? '',
     in_reply_to_account_id: null,
@@ -202,7 +260,12 @@ export function rowToStoredStatus(
     quote: null,
     quote_approval: { automatic: [], current_user: '', manual: [] },
     reblog,
-    reblogged: engagements.includes('reblog'),
+    reblogged: hasInteraction(
+      interactions,
+      engagements,
+      'is_reblogged',
+      'reblog',
+    ),
     reblogs_count: (row[23] as number) ?? 0,
     replies_count: (row[22] as number) ?? 0,
     sensitive: (row[10] as number) === 1,

--- a/src/util/db/sqlite/queries/statusMapperParsers.ts
+++ b/src/util/db/sqlite/queries/statusMapperParsers.ts
@@ -20,6 +20,69 @@ export function parseEmojiReactions(json: string | null): Entity.Reaction[] {
   }
 }
 
+function normalizeReactionName(name: string): string {
+  return name.startsWith(':') && name.endsWith(':') ? name.slice(1, -1) : name
+}
+
+function isSameReaction(
+  reaction: Entity.Reaction,
+  localName: string,
+  localUrl: string | null,
+): boolean {
+  if (
+    normalizeReactionName(reaction.name) !== normalizeReactionName(localName)
+  ) {
+    return false
+  }
+
+  if (!localUrl) return true
+  const reactionUrl = reaction.url ?? reaction.static_url ?? null
+  return reactionUrl === null || reactionUrl === localUrl
+}
+
+export function mergeLocalReaction(
+  reactions: Entity.Reaction[],
+  interactions: InteractionsJson | null,
+): Entity.Reaction[] {
+  const localName = interactions?.my_reaction_name
+  if (!localName) return reactions
+
+  let found = false
+  const merged = reactions.map((reaction) => {
+    if (!isSameReaction(reaction, localName, interactions.my_reaction_url)) {
+      return reaction
+    }
+    found = true
+    const staticUrl =
+      reaction.static_url ?? interactions.my_reaction_url ?? undefined
+    const url = reaction.url ?? interactions.my_reaction_url ?? undefined
+    return {
+      ...reaction,
+      me: true,
+      ...(staticUrl ? { static_url: staticUrl } : {}),
+      ...(url ? { url } : {}),
+    }
+  })
+
+  if (found) return merged
+
+  return [
+    ...merged,
+    {
+      account_ids: [],
+      count: 1,
+      me: true,
+      name: localName,
+      ...(interactions.my_reaction_url
+        ? {
+            static_url: interactions.my_reaction_url,
+            url: interactions.my_reaction_url,
+          }
+        : {}),
+    },
+  ]
+}
+
 /** カスタム絵文字 JSON をパースする */
 export function parseEmojis(json: string | null): Entity.Emoji[] {
   if (!json) return []

--- a/src/util/db/sqlite/queries/statusSelect.ts
+++ b/src/util/db/sqlite/queries/statusSelect.ts
@@ -32,20 +32,21 @@ import { BATCH_INTERACTIONS_SQL, BATCH_SQL_TEMPLATES } from './statusBatch'
 export const MAX_QUERY_LIMIT = 2147483647
 
 // ================================================================
-// エンゲージメント CSV ビルダー (SQL 断片)
+// インタラクション JSON ビルダー (SQL 断片)
 // ================================================================
 
 /**
- * post_interactions の boolean フラグから engagements_csv を構築する SQL 式。
- * SUBSTR(..., 2) で先頭のカンマを除去し、NULLIF で空文字を NULL に変換する。
+ * post_interactions のフラグとローカル reaction 情報を JSON にする SQL 式。
  */
-const ENGAGEMENTS_CSV_EXPR = `NULLIF(SUBSTR(
-      CASE WHEN pi2.is_favourited = 1 THEN ',favourite' ELSE '' END ||
-      CASE WHEN pi2.is_reblogged = 1 THEN ',reblog' ELSE '' END ||
-      CASE WHEN pi2.is_bookmarked = 1 THEN ',bookmark' ELSE '' END ||
-      CASE WHEN pi2.is_muted = 1 THEN ',mute' ELSE '' END ||
-      CASE WHEN pi2.is_pinned = 1 THEN ',pin' ELSE '' END
-    , 2), '')`
+const INTERACTIONS_JSON_EXPR = `json_object(
+      'is_favourited', pi2.is_favourited,
+      'is_reblogged', pi2.is_reblogged,
+      'is_bookmarked', pi2.is_bookmarked,
+      'is_muted', pi2.is_muted,
+      'is_pinned', pi2.is_pinned,
+      'my_reaction_name', pi2.my_reaction_name,
+      'my_reaction_url', pi2.my_reaction_url
+    )`
 
 // ================================================================
 // SELECT 句
@@ -81,7 +82,7 @@ export const STATUS_SELECT = `
   COALESCE(ps.replies_count, 0) AS replies_count,
   COALESCE(ps.reblogs_count, 0) AS reblogs_count,
   COALESCE(ps.favourites_count, 0) AS favourites_count,
-  (SELECT ${ENGAGEMENTS_CSV_EXPR} FROM post_interactions pi2 WHERE pi2.post_id = p.id LIMIT 1) AS engagements_csv,
+  (SELECT ${INTERACTIONS_JSON_EXPR} FROM post_interactions pi2 WHERE pi2.post_id = p.id AND pi2.local_account_id = spb.local_account_id LIMIT 1) AS interactions_json,
   (SELECT json_group_array(json_object('id', pm.media_local_id, 'type', COALESCE((SELECT mt.name FROM media_types mt WHERE mt.id = pm.media_type_id), 'unknown'), 'url', pm.url, 'preview_url', pm.preview_url, 'description', pm.description, 'blurhash', pm.blurhash, 'remote_url', pm.remote_url)) FROM post_media pm WHERE pm.post_id = p.id ORDER BY pm.sort_order) AS media_json,
   (SELECT json_group_array(json_object('acct', pme.acct, 'username', pme.username, 'url', pme.url)) FROM post_mentions pme WHERE pme.post_id = p.id) AS mentions_json,
   (SELECT json_group_array(tk) FROM (SELECT DISTINCT te.timeline_key AS tk FROM timeline_entries te WHERE te.post_id = p.id)) AS timelineTypes,
@@ -112,9 +113,9 @@ export const STATUS_SELECT = `
   COALESCE(rps.reblogs_count, 0) AS rb_reblogs_count,
   COALESCE(rps.favourites_count, 0) AS rb_favourites_count,
   CASE WHEN rs.id IS NOT NULL
-    THEN (SELECT ${ENGAGEMENTS_CSV_EXPR} FROM post_interactions pi2 WHERE pi2.post_id = rs.id LIMIT 1)
+    THEN (SELECT ${INTERACTIONS_JSON_EXPR} FROM post_interactions pi2 WHERE pi2.post_id = rs.id AND pi2.local_account_id = spb.local_account_id LIMIT 1)
     ELSE NULL
-  END AS rb_engagements_csv,
+  END AS rb_interactions_json,
   CASE WHEN rs.id IS NOT NULL
     THEN (SELECT json_group_array(json_object('id', pm.media_local_id, 'type', COALESCE((SELECT mt.name FROM media_types mt WHERE mt.id = pm.media_type_id), 'unknown'), 'url', pm.url, 'preview_url', pm.preview_url, 'description', pm.description, 'blurhash', pm.blurhash, 'remote_url', pm.remote_url)) FROM post_media pm WHERE pm.post_id = rs.id ORDER BY pm.sort_order)
     ELSE NULL
@@ -290,13 +291,15 @@ export function buildScopedEngagementsSql(
   const quoted = backendUrls.map((u) => `'${u.replace(/'/g, "''")}'`).join(',')
   return `
   SELECT pi.post_id,
-    NULLIF(SUBSTR(
-      CASE WHEN pi.is_favourited = 1 THEN ',favourite' ELSE '' END ||
-      CASE WHEN pi.is_reblogged = 1 THEN ',reblog' ELSE '' END ||
-      CASE WHEN pi.is_bookmarked = 1 THEN ',bookmark' ELSE '' END ||
-      CASE WHEN pi.is_muted = 1 THEN ',mute' ELSE '' END ||
-      CASE WHEN pi.is_pinned = 1 THEN ',pin' ELSE '' END
-    , 2), '') AS engagements_csv
+    json_object(
+      'is_favourited', pi.is_favourited,
+      'is_reblogged', pi.is_reblogged,
+      'is_bookmarked', pi.is_bookmarked,
+      'is_muted', pi.is_muted,
+      'is_pinned', pi.is_pinned,
+      'my_reaction_name', pi.my_reaction_name,
+      'my_reaction_url', pi.my_reaction_url
+    ) AS interactions_json
   FROM post_interactions pi
   WHERE pi.post_id IN (${placeholder})
     AND pi.local_account_id IN (

--- a/src/util/db/sqlite/worker/handlers/interactionHandlers.ts
+++ b/src/util/db/sqlite/worker/handlers/interactionHandlers.ts
@@ -19,6 +19,37 @@ const ACTION_NAME_MAP: Record<string, string> = {
   reblogged: 'reblog',
 }
 
+function resolveRelatedInteractionPostIds(
+  db: DbExec,
+  postId: number,
+): number[] {
+  const related = new Set<number>([postId])
+  const postInfo = db.exec(
+    'SELECT reblog_of_post_id FROM posts WHERE id = ?;',
+    { bind: [postId], returnValue: 'resultRows' },
+  ) as (number | null)[][]
+
+  if (postInfo.length === 0) {
+    return [...related]
+  }
+
+  const reblogOfPostId = postInfo[0][0]
+  const sourcePostId = reblogOfPostId ?? postId
+  if (reblogOfPostId != null) {
+    related.add(reblogOfPostId)
+  }
+
+  const reblogRows = db.exec(
+    'SELECT id FROM posts WHERE reblog_of_post_id = ?;',
+    { bind: [sourcePostId], returnValue: 'resultRows' },
+  ) as number[][]
+  for (const row of reblogRows) {
+    related.add(row[0])
+  }
+
+  return [...related]
+}
+
 export function handleUpdateStatusAction(
   db: DbExec,
   localAccountId: number,
@@ -32,40 +63,19 @@ export function handleUpdateStatusAction(
   const normalizedAction = ACTION_NAME_MAP[action]
   if (!normalizedAction) return { changedTables: [] }
 
-  // 自分自身のインタラクションを更新
-  updateInteraction(db, postId, localAccountId, normalizedAction, value)
-
-  // リブログチェーン: reblog_of_post_id から関連投稿を更新
-  const postInfo = db.exec(
-    'SELECT reblog_of_post_id FROM posts WHERE id = ?;',
-    { bind: [postId], returnValue: 'resultRows' },
-  ) as (number | null)[][]
-
-  if (postInfo.length > 0) {
-    const reblogOfPostId = postInfo[0][0]
-
-    // リブログ元の投稿もインタラクションを伝播
-    if (reblogOfPostId != null) {
-      updateInteraction(
-        db,
-        reblogOfPostId,
-        localAccountId,
-        normalizedAction,
-        value,
-      )
-    }
-
-    // このポストを reblog している他の投稿にも伝播
-    const reblogRows = db.exec(
-      'SELECT id FROM posts WHERE reblog_of_post_id = ?;',
-      { bind: [postId], returnValue: 'resultRows' },
-    ) as number[][]
-    for (const row of reblogRows) {
-      updateInteraction(db, row[0], localAccountId, normalizedAction, value)
-    }
+  for (const relatedPostId of resolveRelatedInteractionPostIds(db, postId)) {
+    updateInteraction(
+      db,
+      relatedPostId,
+      localAccountId,
+      normalizedAction,
+      value,
+      undefined,
+      { recordLocalAction: true },
+    )
   }
 
-  return { changedTables: ['posts'] }
+  return { changedTables: ['posts', 'post_interactions'] }
 }
 
 export function handleToggleReaction(
@@ -77,11 +87,14 @@ export function handleToggleReaction(
 ): HandlerResult {
   const postId = resolvePostIdInternal(db, localAccountId, localId)
   if (postId === undefined) return { changedTables: [] }
+  const relatedPostIds = resolveRelatedInteractionPostIds(db, postId)
 
   // value=false の場合はリアクションをクリア
   if (!value) {
-    toggleReaction(db, postId, localAccountId, null, null)
-    return { changedTables: ['posts'] }
+    for (const relatedPostId of relatedPostIds) {
+      toggleReaction(db, relatedPostId, localAccountId, null, null)
+    }
+    return { changedTables: ['posts', 'post_interactions'] }
   }
 
   const isCustom = emoji.startsWith(':') && emoji.endsWith(':')
@@ -95,11 +108,15 @@ export function handleToggleReaction(
     ) as (number | string)[][]
 
     const url = rows.length > 0 ? (rows[0][1] as string) : null
-    toggleReaction(db, postId, localAccountId, shortcode, url)
+    for (const relatedPostId of relatedPostIds) {
+      toggleReaction(db, relatedPostId, localAccountId, shortcode, url)
+    }
   } else {
     // Unicode 絵文字
-    toggleReaction(db, postId, localAccountId, emoji, null)
+    for (const relatedPostId of relatedPostIds) {
+      toggleReaction(db, relatedPostId, localAccountId, emoji, null)
+    }
   }
 
-  return { changedTables: ['posts'] }
+  return { changedTables: ['posts', 'post_interactions'] }
 }

--- a/src/util/db/sqlite/worker/handlers/postSync.ts
+++ b/src/util/db/sqlite/worker/handlers/postSync.ts
@@ -35,6 +35,8 @@ import {
 } from './statusHelpers'
 import type { DbExec, WrittenTableCollector } from './types'
 
+const STALE_INTERACTION_FALSE_PROTECTION_MS = 60_000
+
 // ================================================================
 // メンション同期
 // ================================================================
@@ -418,17 +420,39 @@ function syncReblogOriginalInteractions(
   if (originalStatus.favourited === true) {
     updateInteraction(db, postId, localAccountId, 'favourite', true, collector)
   } else if (originalStatus.favourited === false) {
-    updateInteraction(db, postId, localAccountId, 'favourite', false, collector)
+    updateInteraction(
+      db,
+      postId,
+      localAccountId,
+      'favourite',
+      false,
+      collector,
+      {
+        preserveRecentLocalTrueMs: STALE_INTERACTION_FALSE_PROTECTION_MS,
+      },
+    )
   }
   if (originalStatus.reblogged === true) {
     updateInteraction(db, postId, localAccountId, 'reblog', true, collector)
   } else if (originalStatus.reblogged === false) {
-    updateInteraction(db, postId, localAccountId, 'reblog', false, collector)
+    updateInteraction(db, postId, localAccountId, 'reblog', false, collector, {
+      preserveRecentLocalTrueMs: STALE_INTERACTION_FALSE_PROTECTION_MS,
+    })
   }
   if (originalStatus.bookmarked === true) {
     updateInteraction(db, postId, localAccountId, 'bookmark', true, collector)
   } else if (originalStatus.bookmarked === false) {
-    updateInteraction(db, postId, localAccountId, 'bookmark', false, collector)
+    updateInteraction(
+      db,
+      postId,
+      localAccountId,
+      'bookmark',
+      false,
+      collector,
+      {
+        preserveRecentLocalTrueMs: STALE_INTERACTION_FALSE_PROTECTION_MS,
+      },
+    )
   }
 }
 

--- a/src/util/db/sqlite/worker/handlers/statusHandlers.ts
+++ b/src/util/db/sqlite/worker/handlers/statusHandlers.ts
@@ -48,6 +48,8 @@ import {
 } from './statusHelpers'
 import type { DbExec, HandlerResult, WrittenTableCollector } from './types'
 
+const STALE_INTERACTION_FALSE_PROTECTION_MS = 60_000
+
 // ================================================================
 // 内部ヘルパー: エンゲージメント同期
 // ================================================================
@@ -66,17 +68,39 @@ function syncInteractions(
   if (status.favourited === true) {
     updateInteraction(db, postId, localAccountId, 'favourite', true, collector)
   } else if (status.favourited === false) {
-    updateInteraction(db, postId, localAccountId, 'favourite', false, collector)
+    updateInteraction(
+      db,
+      postId,
+      localAccountId,
+      'favourite',
+      false,
+      collector,
+      {
+        preserveRecentLocalTrueMs: STALE_INTERACTION_FALSE_PROTECTION_MS,
+      },
+    )
   }
   if (status.reblogged === true) {
     updateInteraction(db, postId, localAccountId, 'reblog', true, collector)
   } else if (status.reblogged === false) {
-    updateInteraction(db, postId, localAccountId, 'reblog', false, collector)
+    updateInteraction(db, postId, localAccountId, 'reblog', false, collector, {
+      preserveRecentLocalTrueMs: STALE_INTERACTION_FALSE_PROTECTION_MS,
+    })
   }
   if (status.bookmarked === true) {
     updateInteraction(db, postId, localAccountId, 'bookmark', true, collector)
   } else if (status.bookmarked === false) {
-    updateInteraction(db, postId, localAccountId, 'bookmark', false, collector)
+    updateInteraction(
+      db,
+      postId,
+      localAccountId,
+      'bookmark',
+      false,
+      collector,
+      {
+        preserveRecentLocalTrueMs: STALE_INTERACTION_FALSE_PROTECTION_MS,
+      },
+    )
   }
 }
 

--- a/src/util/db/sqlite/worker/handlers/statusUpdateHandler.ts
+++ b/src/util/db/sqlite/worker/handlers/statusUpdateHandler.ts
@@ -39,6 +39,8 @@ import {
 } from './statusHelpers'
 import type { DbExec, HandlerResult, WrittenTableCollector } from './types'
 
+const STALE_INTERACTION_FALSE_PROTECTION_MS = 60_000
+
 function resolveUpdateTargetPostId(
   db: DbExec,
   status: Entity.Status,
@@ -90,17 +92,39 @@ function syncStatusInteractions(
   if (status.favourited === true) {
     updateInteraction(db, postId, localAccountId, 'favourite', true, collector)
   } else if (status.favourited === false) {
-    updateInteraction(db, postId, localAccountId, 'favourite', false, collector)
+    updateInteraction(
+      db,
+      postId,
+      localAccountId,
+      'favourite',
+      false,
+      collector,
+      {
+        preserveRecentLocalTrueMs: STALE_INTERACTION_FALSE_PROTECTION_MS,
+      },
+    )
   }
   if (status.reblogged === true) {
     updateInteraction(db, postId, localAccountId, 'reblog', true, collector)
   } else if (status.reblogged === false) {
-    updateInteraction(db, postId, localAccountId, 'reblog', false, collector)
+    updateInteraction(db, postId, localAccountId, 'reblog', false, collector, {
+      preserveRecentLocalTrueMs: STALE_INTERACTION_FALSE_PROTECTION_MS,
+    })
   }
   if (status.bookmarked === true) {
     updateInteraction(db, postId, localAccountId, 'bookmark', true, collector)
   } else if (status.bookmarked === false) {
-    updateInteraction(db, postId, localAccountId, 'bookmark', false, collector)
+    updateInteraction(
+      db,
+      postId,
+      localAccountId,
+      'bookmark',
+      false,
+      collector,
+      {
+        preserveRecentLocalTrueMs: STALE_INTERACTION_FALSE_PROTECTION_MS,
+      },
+    )
   }
 }
 


### PR DESCRIPTION
Fixes #631

## Summary
- Preserve recent local favourite/reblog/bookmark toggles from stale server false payloads using action-scoped local freshness tracking.
- Rehydrate local reactions from post_interactions into assembled status emoji_reactions for inline and batched status mapping.
- Propagate favourite/reaction state across original and reblog rows so other timelines reflect the local action.
- Scope inline interaction selects to the selected local account and add regression coverage for persistence, reaction merge, and changed table hints.

## Validation
- yarn check
- yarn test:run --coverage
- git diff --check
- commit hook also ran yarn check and yarn build