### PR TITLE
[codex] Sync interactions across timeline copies

### DIFF
--- a/src/util/db/sqlite/__tests__/handlers-interaction.test.ts
+++ b/src/util/db/sqlite/__tests__/handlers-interaction.test.ts
@@ -34,14 +34,30 @@ vi.mock(
 // ─── 型 ─────────────────────────────────────────────────────────
 
 type ExecCall = { sql: string; opts?: Parameters<DbExecCompat['exec']>[1] }
+type SelectRows = unknown[][]
+type SelectResultProvider = (args: {
+  opts?: Parameters<DbExecCompat['exec']>[1]
+  selectIndex: number
+  sql: string
+}) => SelectRows | undefined
+
+type MockPost = {
+  canonicalUrl?: string | null
+  id: number
+  objectUri?: string
+  reblogOfPostId?: number | null
+}
 
 // ─── Mock DB factory ────────────────────────────────────────────
 
 /**
  * DbExecCompat のモックを作成する。
  * SELECT の returnValue === 'resultRows' のとき、selectResults を順番に返す。
+ * 関数を渡すと SQL/bind に応じた SELECT 結果を返せる。
  */
-function createMockDb(selectResults: unknown[][] = []): {
+function createMockDb(
+  selectResults: SelectRows[] | SelectResultProvider = [],
+): {
   db: DbExecCompat
   calls: ExecCall[]
 } {
@@ -52,7 +68,10 @@ function createMockDb(selectResults: unknown[][] = []): {
     exec: vi.fn((sql: string, opts?: Parameters<DbExecCompat['exec']>[1]) => {
       calls.push({ opts, sql })
       if (opts?.returnValue === 'resultRows') {
-        const result = selectResults[selectIndex]
+        const result =
+          typeof selectResults === 'function'
+            ? selectResults({ opts, selectIndex, sql })
+            : selectResults[selectIndex]
         selectIndex++
         return result !== undefined ? result : []
       }
@@ -61,6 +80,56 @@ function createMockDb(selectResults: unknown[][] = []): {
   }
 
   return { calls, db }
+}
+
+function createInteractionSelectProvider(
+  posts: MockPost[],
+  fallback?: SelectResultProvider,
+): SelectResultProvider {
+  return (args) => {
+    const { opts, sql } = args
+    const bind = opts?.bind ?? []
+
+    if (
+      sql.includes(
+        'SELECT object_uri, canonical_url, reblog_of_post_id FROM posts WHERE id = ?',
+      )
+    ) {
+      const post = posts.find(({ id }) => id === bind[0])
+      return post
+        ? [
+            [
+              post.objectUri ?? '',
+              post.canonicalUrl ?? null,
+              post.reblogOfPostId ?? null,
+            ],
+          ]
+        : []
+    }
+
+    if (sql.includes('WHERE id != ?') && sql.includes('canonical_url = ?')) {
+      const [postId, objectUri, canonicalUrl] = bind
+      return posts
+        .filter((post) => post.id !== postId)
+        .filter((post) => {
+          const sameObjectUri = objectUri !== '' && post.objectUri === objectUri
+          const sameCanonicalUrl =
+            canonicalUrl !== null &&
+            canonicalUrl !== '' &&
+            post.canonicalUrl === canonicalUrl
+          return sameObjectUri || sameCanonicalUrl
+        })
+        .map((post) => [post.id])
+    }
+
+    if (sql.includes('SELECT id FROM posts WHERE reblog_of_post_id = ?')) {
+      return posts
+        .filter((post) => post.reblogOfPostId === bind[0])
+        .map((post) => [post.id])
+    }
+
+    return fallback?.(args)
+  }
 }
 
 // ─── セットアップ ───────────────────────────────────────────────
@@ -149,13 +218,16 @@ describe('handleUpdateStatusAction', () => {
   })
 
   it('リブログ元の投稿にもインタラクションを伝播する', () => {
-    // resolvePostIdInternal → post_id=100
-    // SELECT reblog_of_post_id FROM posts WHERE id = 100 → 50 (元投稿)
-    // SELECT id FROM posts WHERE reblog_of_post_id = 100 → [] (この投稿をリブログした他投稿なし)
-    const { db } = createMockDb([
-      [[50]], // reblog_of_post_id for post 100
-      [], // no posts reblogging post 100
-    ])
+    const { db } = createMockDb(
+      createInteractionSelectProvider([
+        { id: 50, objectUri: 'https://example.com/objects/50' },
+        {
+          id: 100,
+          objectUri: 'https://example.com/objects/100',
+          reblogOfPostId: 50,
+        },
+      ]),
+    )
     vi.mocked(resolvePostIdInternal).mockReturnValue(100)
 
     handleUpdateStatusAction(db, 1, '12345', 'favourited', true)
@@ -183,13 +255,21 @@ describe('handleUpdateStatusAction', () => {
   })
 
   it('このポストを reblog している他の投稿にも伝播する', () => {
-    // resolvePostIdInternal → post_id=100
-    // SELECT reblog_of_post_id FROM posts WHERE id = 100 → null (元投稿なし)
-    // SELECT id FROM posts WHERE reblog_of_post_id = 100 → [200, 300]
-    const { db } = createMockDb([
-      [[null]], // reblog_of_post_id = null
-      [[200], [300]], // posts that reblog post 100
-    ])
+    const { db } = createMockDb(
+      createInteractionSelectProvider([
+        { id: 100, objectUri: 'https://example.com/objects/100' },
+        {
+          id: 200,
+          objectUri: 'https://example.com/objects/200',
+          reblogOfPostId: 100,
+        },
+        {
+          id: 300,
+          objectUri: 'https://example.com/objects/300',
+          reblogOfPostId: 100,
+        },
+      ]),
+    )
     vi.mocked(resolvePostIdInternal).mockReturnValue(100)
 
     handleUpdateStatusAction(db, 1, '12345', 'reblogged', true)
@@ -224,6 +304,91 @@ describe('handleUpdateStatusAction', () => {
       { recordLocalAction: true },
     )
   })
+
+  it('同一 canonical_url の別投稿にも favourite を伝播する', () => {
+    const canonicalUrl = 'https://example.com/@alice/posts/1'
+    const { db } = createMockDb(
+      createInteractionSelectProvider([
+        {
+          canonicalUrl,
+          id: 100,
+          objectUri: 'https://example.com/objects/source',
+        },
+        {
+          canonicalUrl,
+          id: 150,
+          objectUri: 'https://mirror.example/objects/equivalent',
+        },
+      ]),
+    )
+    vi.mocked(resolvePostIdInternal).mockReturnValue(100)
+
+    handleUpdateStatusAction(db, 1, '12345', 'favourited', true)
+
+    expect(updateInteraction).toHaveBeenCalledTimes(2)
+    expect(updateInteraction).toHaveBeenCalledWith(
+      db,
+      100,
+      1,
+      'favourite',
+      true,
+      undefined,
+      { recordLocalAction: true },
+    )
+    expect(updateInteraction).toHaveBeenCalledWith(
+      db,
+      150,
+      1,
+      'favourite',
+      true,
+      undefined,
+      { recordLocalAction: true },
+    )
+  })
+
+  it('同一 canonical_url の元投稿とそれぞれの reblog にも favourite を伝播する', () => {
+    const canonicalUrl = 'https://example.com/@alice/posts/1'
+    const { db } = createMockDb(
+      createInteractionSelectProvider([
+        {
+          canonicalUrl,
+          id: 100,
+          objectUri: 'https://example.com/objects/source',
+        },
+        {
+          canonicalUrl,
+          id: 150,
+          objectUri: 'https://mirror.example/objects/equivalent',
+        },
+        {
+          id: 200,
+          objectUri: 'https://example.com/objects/reblog-source',
+          reblogOfPostId: 100,
+        },
+        {
+          id: 250,
+          objectUri: 'https://mirror.example/objects/reblog-equivalent',
+          reblogOfPostId: 150,
+        },
+      ]),
+    )
+    vi.mocked(resolvePostIdInternal).mockReturnValue(200)
+
+    handleUpdateStatusAction(db, 1, '12345', 'favourited', true)
+
+    expect(updateInteraction).toHaveBeenCalledTimes(4)
+    for (const postId of [200, 100, 150, 250]) {
+      expect(updateInteraction).toHaveBeenCalledWith(
+        db,
+        postId,
+        1,
+        'favourite',
+        true,
+        undefined,
+        { recordLocalAction: true },
+      )
+    }
+  })
 })
 
 // ================================================================
@@ -244,10 +409,11 @@ describe('handleToggleReaction', () => {
 
   it('カスタム絵文字のリアクションを設定する（shortcode → url 解決）', () => {
     // SELECT id, url FROM custom_emojis WHERE server_id = ? AND shortcode = ?
-    const { db } = createMockDb([
-      [],
-      [[42, 'https://example.com/emoji/blobcat.png']],
-    ])
+    const { db } = createMockDb(({ sql }) =>
+      sql.includes('custom_emojis')
+        ? [[42, 'https://example.com/emoji/blobcat.png']]
+        : [],
+    )
     vi.mocked(resolvePostIdInternal).mockReturnValue(100)
 
     const result = handleToggleReaction(db, 1, '12345', true, ':blobcat:')
@@ -285,7 +451,21 @@ describe('handleToggleReaction', () => {
   })
 
   it('reblog からのリアクションを元投稿と同じ元投稿の reblog に伝播する', () => {
-    const { db } = createMockDb([[[50]], [[100], [200]]])
+    const { db } = createMockDb(
+      createInteractionSelectProvider([
+        { id: 50, objectUri: 'https://example.com/objects/50' },
+        {
+          id: 100,
+          objectUri: 'https://example.com/objects/100',
+          reblogOfPostId: 50,
+        },
+        {
+          id: 200,
+          objectUri: 'https://example.com/objects/200',
+          reblogOfPostId: 50,
+        },
+      ]),
+    )
     vi.mocked(resolvePostIdInternal).mockReturnValue(100)
 
     handleToggleReaction(db, 1, '12345', true, '👍')
@@ -297,7 +477,21 @@ describe('handleToggleReaction', () => {
   })
 
   it('元投稿からのリアクションを reblog 投稿にも伝播する', () => {
-    const { db } = createMockDb([[[null]], [[200], [300]]])
+    const { db } = createMockDb(
+      createInteractionSelectProvider([
+        { id: 100, objectUri: 'https://example.com/objects/100' },
+        {
+          id: 200,
+          objectUri: 'https://example.com/objects/200',
+          reblogOfPostId: 100,
+        },
+        {
+          id: 300,
+          objectUri: 'https://example.com/objects/300',
+          reblogOfPostId: 100,
+        },
+      ]),
+    )
     vi.mocked(resolvePostIdInternal).mockReturnValue(100)
 
     handleToggleReaction(db, 1, '12345', true, '👍')
@@ -306,6 +500,31 @@ describe('handleToggleReaction', () => {
     expect(toggleReaction).toHaveBeenCalledWith(db, 100, 1, '👍', null)
     expect(toggleReaction).toHaveBeenCalledWith(db, 200, 1, '👍', null)
     expect(toggleReaction).toHaveBeenCalledWith(db, 300, 1, '👍', null)
+  })
+
+  it('同一 canonical_url の別投稿にもリアクションを伝播する', () => {
+    const canonicalUrl = 'https://example.com/@alice/posts/1'
+    const { db } = createMockDb(
+      createInteractionSelectProvider([
+        {
+          canonicalUrl,
+          id: 100,
+          objectUri: 'https://example.com/objects/source',
+        },
+        {
+          canonicalUrl,
+          id: 150,
+          objectUri: 'https://mirror.example/objects/equivalent',
+        },
+      ]),
+    )
+    vi.mocked(resolvePostIdInternal).mockReturnValue(100)
+
+    handleToggleReaction(db, 1, '12345', true, '👍')
+
+    expect(toggleReaction).toHaveBeenCalledTimes(2)
+    expect(toggleReaction).toHaveBeenCalledWith(db, 100, 1, '👍', null)
+    expect(toggleReaction).toHaveBeenCalledWith(db, 150, 1, '👍', null)
   })
 
   it('投稿が見つからない場合は何もしない', () => {

--- a/src/util/db/sqlite/__tests__/schema.test.ts
+++ b/src/util/db/sqlite/__tests__/schema.test.ts
@@ -231,10 +231,11 @@ describe('スキーマ定義', () => {
       expect(sqlContainsTable(execCalls, 'post_stats')).toBe(true)
     })
 
-    it('posts テーブルに object_uri, author, created, reblog_of, quote_of, reply, origin_server インデックスを作成する', () => {
+    it('posts テーブルに object_uri, canonical_url, author, created, reblog_of, quote_of, reply, origin_server インデックスを作成する', () => {
       const { db, execCalls } = createMockDb()
       createPostTables(db)
       expect(sqlContainsIndex(execCalls, 'idx_posts_object_uri')).toBe(true)
+      expect(sqlContainsIndex(execCalls, 'idx_posts_canonical_url')).toBe(true)
       expect(sqlContainsIndex(execCalls, 'idx_posts_author')).toBe(true)
       expect(sqlContainsIndex(execCalls, 'idx_posts_created')).toBe(true)
       expect(sqlContainsIndex(execCalls, 'idx_posts_reblog_of')).toBe(true)

--- a/src/util/db/sqlite/__tests__/v2-0-7-migration.test.ts
+++ b/src/util/db/sqlite/__tests__/v2-0-7-migration.test.ts
@@ -1,0 +1,85 @@
+import { v2_0_7_migration } from 'util/db/sqlite/migrations/v2.0.7'
+import type { SchemaDbHandle } from 'util/db/sqlite/worker/workerSchema'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+function createMockDb(indexExists: boolean) {
+  const execCalls: { sql: string; opts?: Record<string, unknown> }[] = []
+  const db = {
+    exec: vi.fn((sql: string, opts?: Record<string, unknown>) => {
+      execCalls.push({ opts, sql })
+      if (
+        typeof sql === 'string' &&
+        sql.includes('sqlite_master') &&
+        sql.includes("name='idx_posts_canonical_url'") &&
+        opts?.returnValue === 'resultRows'
+      ) {
+        return indexExists
+          ? [['CREATE INDEX idx_posts_canonical_url ON posts(canonical_url)']]
+          : []
+      }
+      return undefined
+    }),
+  }
+  return { db, execCalls, handle: { db } as SchemaDbHandle }
+}
+
+describe('v2.0.7 マイグレーション', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('メタデータ', () => {
+    it('バージョンが {major: 2, minor: 0, patch: 7} である', () => {
+      expect(v2_0_7_migration.version).toEqual({
+        major: 2,
+        minor: 0,
+        patch: 7,
+      })
+    })
+
+    it('説明文が定義されている', () => {
+      expect(v2_0_7_migration.description).toBeDefined()
+      expect(v2_0_7_migration.description.length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('up()', () => {
+    it('posts(canonical_url) に CREATE INDEX IF NOT EXISTS を実行する', () => {
+      const { handle, execCalls } = createMockDb(false)
+      v2_0_7_migration.up(handle)
+
+      const createIndexCall = execCalls.find(
+        (c) =>
+          c.sql.includes('CREATE INDEX') &&
+          c.sql.includes('idx_posts_canonical_url'),
+      )
+      expect(createIndexCall).toBeDefined()
+      expect(createIndexCall?.sql).toContain('IF NOT EXISTS')
+      expect(createIndexCall?.sql).toContain('posts(canonical_url)')
+      expect(createIndexCall?.sql).toContain('canonical_url IS NOT NULL')
+      expect(createIndexCall?.sql).toContain("canonical_url != ''")
+    })
+
+    it('冪等性: 既にインデックスが存在しても IF NOT EXISTS でエラーにならない', () => {
+      const { handle } = createMockDb(true)
+      expect(() => v2_0_7_migration.up(handle)).not.toThrow()
+    })
+  })
+
+  describe('validate()', () => {
+    it('idx_posts_canonical_url が存在すれば true を返す', () => {
+      const { handle } = createMockDb(true)
+      expect(v2_0_7_migration.validate?.(handle)).toBe(true)
+    })
+
+    it('idx_posts_canonical_url が存在しない場合は false を返す', () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const { handle } = createMockDb(false)
+      expect(v2_0_7_migration.validate?.(handle)).toBe(false)
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('idx_posts_canonical_url'),
+      )
+      consoleSpy.mockRestore()
+    })
+  })
+})

--- a/src/util/db/sqlite/__tests__/v2-migration.test.ts
+++ b/src/util/db/sqlite/__tests__/v2-migration.test.ts
@@ -321,7 +321,7 @@ describe('v2.0.0 マイグレーション', () => {
       migrations.push(...savedMigrations)
     })
 
-    it('v2.0.0 DB に対して v2.0.1 ~ v2.0.6 マイグレーションが適用される', () => {
+    it('v2.0.0 DB に対して v2.0.1 ~ v2.0.7 マイグレーションが適用される', () => {
       const v2Encoded = encodeSemVer({ major: 2, minor: 0, patch: 0 })
       const { db, handle } = createV2MigrationMockDb(v2Encoded)
       runMigrations(handle, mockDropAll, mockCreateFresh)

--- a/src/util/db/sqlite/__tests__/version.test.ts
+++ b/src/util/db/sqlite/__tests__/version.test.ts
@@ -172,10 +172,10 @@ describe('normalizeLegacyVersion', () => {
 })
 
 describe('LATEST_VERSION', () => {
-  it('2.0.6 である', () => {
-    expect(LATEST_VERSION).toEqual({ major: 2, minor: 0, patch: 6 })
+  it('2.0.7 である', () => {
+    expect(LATEST_VERSION).toEqual({ major: 2, minor: 0, patch: 7 })
   })
-  it('20006 にエンコードされる', () => {
-    expect(encodeSemVer(LATEST_VERSION)).toBe(20006)
+  it('20007 にエンコードされる', () => {
+    expect(encodeSemVer(LATEST_VERSION)).toBe(20007)
   })
 })

--- a/src/util/db/sqlite/migrations/index.ts
+++ b/src/util/db/sqlite/migrations/index.ts
@@ -24,6 +24,7 @@ import { v2_0_3_migration } from './v2.0.3'
 import { v2_0_4_migration } from './v2.0.4'
 import { v2_0_5_migration } from './v2.0.5'
 import { v2_0_6_migration } from './v2.0.6'
+import { v2_0_7_migration } from './v2.0.7'
 
 export const migrations: Migration[] = [
   v2_0_0_migration,
@@ -33,6 +34,7 @@ export const migrations: Migration[] = [
   v2_0_4_migration,
   v2_0_5_migration,
   v2_0_6_migration,
+  v2_0_7_migration,
 ]
 
 export function runMigrations(

--- a/src/util/db/sqlite/migrations/v2.0.7/index.ts
+++ b/src/util/db/sqlite/migrations/v2.0.7/index.ts
@@ -1,0 +1,40 @@
+import type { SchemaDbHandle } from '../../worker/workerSchema'
+import type { Migration } from '../types'
+
+/**
+ * v2.0.7 マイグレーション — posts(canonical_url) にインデックスを追加
+ *
+ * タイムライン間で同じ投稿が別 rows として保持されている場合、インタラクション
+ * 同期時に canonical_url から同等投稿を探す。投稿数が増えても同期処理が全件
+ * スキャンにならないよう、非空 canonical_url に部分インデックスを追加する。
+ */
+export const v2_0_7_migration: Migration = {
+  description:
+    'Add idx_posts_canonical_url index for cross-timeline interaction sync',
+
+  up(handle: SchemaDbHandle) {
+    const { db } = handle
+
+    db.exec(
+      "CREATE INDEX IF NOT EXISTS idx_posts_canonical_url ON posts(canonical_url) WHERE canonical_url IS NOT NULL AND canonical_url != '';",
+    )
+  },
+
+  validate(handle: SchemaDbHandle): boolean {
+    const { db } = handle
+
+    const rows = db.exec(
+      "SELECT sql FROM sqlite_master WHERE type='index' AND name='idx_posts_canonical_url';",
+      { returnValue: 'resultRows' },
+    ) as string[][]
+    if (rows.length === 0) {
+      console.error(
+        'Validation failed: idx_posts_canonical_url index not found',
+      )
+      return false
+    }
+    return true
+  },
+
+  version: { major: 2, minor: 0, patch: 7 },
+}

--- a/src/util/db/sqlite/schema/tables/posts.ts
+++ b/src/util/db/sqlite/schema/tables/posts.ts
@@ -37,6 +37,9 @@ export function createPostTables(db: DbExec): void {
     `CREATE UNIQUE INDEX IF NOT EXISTS idx_posts_object_uri ON posts(object_uri) WHERE object_uri != '';`,
   )
   db.exec(
+    `CREATE INDEX IF NOT EXISTS idx_posts_canonical_url ON posts(canonical_url) WHERE canonical_url IS NOT NULL AND canonical_url != '';`,
+  )
+  db.exec(
     `CREATE INDEX IF NOT EXISTS idx_posts_author ON posts(author_profile_id);`,
   )
   db.exec(

--- a/src/util/db/sqlite/schema/version.ts
+++ b/src/util/db/sqlite/schema/version.ts
@@ -41,7 +41,7 @@ export function compareSemVer(a: SemVer, b: SemVer): -1 | 0 | 1 {
   return ea < eb ? -1 : ea > eb ? 1 : 0
 }
 
-export const LATEST_VERSION: SemVer = { major: 2, minor: 0, patch: 6 }
+export const LATEST_VERSION: SemVer = { major: 2, minor: 0, patch: 7 }
 
 export function normalizeLegacyVersion(pragmaValue: number): SemVer {
   if (pragmaValue === 0) {

--- a/src/util/db/sqlite/worker/handlers/interactionHandlers.ts
+++ b/src/util/db/sqlite/worker/handlers/interactionHandlers.ts
@@ -19,32 +19,101 @@ const ACTION_NAME_MAP: Record<string, string> = {
   reblogged: 'reblog',
 }
 
+type PostIdentity = {
+  canonicalUrl: string | null
+  objectUri: string
+  reblogOfPostId: number | null
+}
+
+function resolvePostIdentity(db: DbExec, postId: number): PostIdentity | null {
+  const rows = db.exec(
+    'SELECT object_uri, canonical_url, reblog_of_post_id FROM posts WHERE id = ?;',
+    { bind: [postId], returnValue: 'resultRows' },
+  ) as (string | number | null)[][]
+
+  if (rows.length === 0) return null
+
+  return {
+    canonicalUrl: rows[0][1] as string | null,
+    objectUri: (rows[0][0] as string | null) ?? '',
+    reblogOfPostId: rows[0][2] as number | null,
+  }
+}
+
+function resolveEquivalentPostIds(
+  db: DbExec,
+  postId: number,
+  identity: PostIdentity,
+): number[] {
+  const rows = db.exec(
+    `SELECT id FROM posts
+     WHERE id != ?
+       AND (
+         (object_uri != '' AND object_uri = ?)
+         OR (canonical_url IS NOT NULL AND canonical_url != '' AND canonical_url = ?)
+       );`,
+    {
+      bind: [postId, identity.objectUri, identity.canonicalUrl],
+      returnValue: 'resultRows',
+    },
+  ) as number[][]
+
+  return rows.map((row) => row[0])
+}
+
 function resolveRelatedInteractionPostIds(
   db: DbExec,
   postId: number,
 ): number[] {
-  const related = new Set<number>([postId])
-  const postInfo = db.exec(
-    'SELECT reblog_of_post_id FROM posts WHERE id = ?;',
-    { bind: [postId], returnValue: 'resultRows' },
-  ) as (number | null)[][]
+  const related = new Set<number>()
+  const pendingPostIds: number[] = []
+  const sourcePostIds = new Set<number>()
+  const processedSourcePostIds = new Set<number>()
 
-  if (postInfo.length === 0) {
-    return [...related]
+  function enqueue(candidatePostId: number): void {
+    if (related.has(candidatePostId)) return
+    related.add(candidatePostId)
+    pendingPostIds.push(candidatePostId)
   }
 
-  const reblogOfPostId = postInfo[0][0]
-  const sourcePostId = reblogOfPostId ?? postId
-  if (reblogOfPostId != null) {
-    related.add(reblogOfPostId)
-  }
+  enqueue(postId)
 
-  const reblogRows = db.exec(
-    'SELECT id FROM posts WHERE reblog_of_post_id = ?;',
-    { bind: [sourcePostId], returnValue: 'resultRows' },
-  ) as number[][]
-  for (const row of reblogRows) {
-    related.add(row[0])
+  while (pendingPostIds.length > 0 || sourcePostIds.size > 0) {
+    const nextPostId = pendingPostIds.shift()
+    if (nextPostId !== undefined) {
+      const identity = resolvePostIdentity(db, nextPostId)
+      if (!identity) continue
+
+      if (identity.reblogOfPostId != null) {
+        sourcePostIds.add(identity.reblogOfPostId)
+        enqueue(identity.reblogOfPostId)
+      } else {
+        sourcePostIds.add(nextPostId)
+      }
+
+      for (const equivalentPostId of resolveEquivalentPostIds(
+        db,
+        nextPostId,
+        identity,
+      )) {
+        enqueue(equivalentPostId)
+      }
+      continue
+    }
+
+    const sourcePostId = [...sourcePostIds].find(
+      (id) => !processedSourcePostIds.has(id),
+    )
+    if (sourcePostId === undefined) break
+    processedSourcePostIds.add(sourcePostId)
+
+    const reblogRows = db.exec(
+      'SELECT id FROM posts WHERE reblog_of_post_id = ?;',
+      { bind: [sourcePostId], returnValue: 'resultRows' },
+    ) as number[][]
+    for (const row of reblogRows) {
+      enqueue(row[0])
+    }
   }
 
   return [...related]


### PR DESCRIPTION
## Summary
- Sync favorite/reblog/bookmark and reaction updates across equivalent `posts` rows by resolving matching `canonical_url` / `object_uri` records.
- Preserve existing propagation between original posts and reblog rows while traversing equivalent originals and their reblogs without duplicate writes.
- Add `idx_posts_canonical_url` via SQLite schema + v2.0.7 migration so cross-timeline lookup does not require a full scan.
- Expand interaction and migration tests for equivalent timeline copies and mixed canonical/reblog graphs.

## Why
Issue #631 requires timeline interactions to remain reflected not only after refresh, but also when the same post appears in other timelines. The previous fix covered the currently resolved post and reblog-linked rows, but separate `posts` rows representing the same status could still diverge.

## Validation
- `yarn vitest run src/util/db/sqlite/__tests__/handlers-interaction.test.ts`
- `yarn vitest run src/util/db/sqlite/__tests__/v2-0-7-migration.test.ts src/util/db/sqlite/__tests__/version.test.ts src/util/db/sqlite/__tests__/schema.test.ts src/util/db/sqlite/__tests__/v2-migration.test.ts`
- `yarn check`
- `yarn test:run --coverage`
- commit hook: `yarn check` and `yarn build`
- `git diff --check`

## Review Loop
- Subagent implementation pass updated the interaction tests.
- Review round 1 found duplicate root queue work and requested a combined canonical + reblog graph test; both were fixed.
- Review rounds 2 and 3 found no blocking issues.