### PR TITLE
[codex] Sync interactions across timeline columns

### DIFF
--- a/src/app/_parts/Actions.tsx
+++ b/src/app/_parts/Actions.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { EmojiReactionPicker } from 'app/_parts/EmojiReactionPicker'
-import { useCallback, useContext, useRef, useState } from 'react'
+import { useCallback, useContext, useEffect, useRef, useState } from 'react'
 import { FaLock } from 'react-icons/fa'
 import {
   RiBookmark2Fill,
@@ -43,6 +43,18 @@ export const Actions = ({
   const [showReactionPicker, setShowReactionPicker] = useState(false)
   const [triggerRect, setTriggerRect] = useState<DOMRect | null>(null)
   const reactionBtnRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    setReblogged(status.reblogged)
+  }, [status.reblogged])
+
+  useEffect(() => {
+    setFavourited(status.favourited)
+  }, [status.favourited])
+
+  useEffect(() => {
+    setBookmarked(status.bookmarked)
+  }, [status.bookmarked])
 
   const handleReaction = useCallback(
     (emoji: string) => {

--- a/src/util/db/sqlite/__tests__/handlers-interaction.test.ts
+++ b/src/util/db/sqlite/__tests__/handlers-interaction.test.ts
@@ -159,7 +159,7 @@ describe('handleUpdateStatusAction', () => {
       undefined,
       { recordLocalAction: true },
     )
-    expect(result).toEqual({ changedTables: ['posts', 'post_interactions'] })
+    expect(result).toEqual({ changedTables: ['post_interactions'] })
   })
 
   it('reblog アクションを処理する', () => {
@@ -178,7 +178,7 @@ describe('handleUpdateStatusAction', () => {
       undefined,
       { recordLocalAction: true },
     )
-    expect(result).toEqual({ changedTables: ['posts', 'post_interactions'] })
+    expect(result).toEqual({ changedTables: ['post_interactions'] })
   })
 
   it('bookmark アクションを処理する', () => {
@@ -197,7 +197,7 @@ describe('handleUpdateStatusAction', () => {
       undefined,
       { recordLocalAction: true },
     )
-    expect(result).toEqual({ changedTables: ['posts', 'post_interactions'] })
+    expect(result).toEqual({ changedTables: ['post_interactions'] })
   })
 
   it('投稿が見つからない場合は何もしない', () => {
@@ -404,7 +404,7 @@ describe('handleToggleReaction', () => {
 
     expect(resolvePostIdInternal).toHaveBeenCalledWith(db, 1, '12345')
     expect(toggleReaction).toHaveBeenCalledWith(db, 100, 1, '👍', null)
-    expect(result).toEqual({ changedTables: ['posts', 'post_interactions'] })
+    expect(result).toEqual({ changedTables: ['post_interactions'] })
   })
 
   it('カスタム絵文字のリアクションを設定する（shortcode → url 解決）', () => {
@@ -436,7 +436,7 @@ describe('handleToggleReaction', () => {
       'blobcat',
       'https://example.com/emoji/blobcat.png',
     )
-    expect(result).toEqual({ changedTables: ['posts', 'post_interactions'] })
+    expect(result).toEqual({ changedTables: ['post_interactions'] })
   })
 
   it('リアクションをクリアする（value=false）', () => {
@@ -447,7 +447,7 @@ describe('handleToggleReaction', () => {
 
     expect(resolvePostIdInternal).toHaveBeenCalledWith(db, 1, '12345')
     expect(toggleReaction).toHaveBeenCalledWith(db, 100, 1, null, null)
-    expect(result).toEqual({ changedTables: ['posts', 'post_interactions'] })
+    expect(result).toEqual({ changedTables: ['post_interactions'] })
   })
 
   it('reblog からのリアクションを元投稿と同じ元投稿の reblog に伝播する', () => {

--- a/src/util/db/sqlite/initSqlite.ts
+++ b/src/util/db/sqlite/initSqlite.ts
@@ -55,6 +55,7 @@ function buildChangeHint(command: SendCommandPayload): ChangeHint | undefined {
       }
     case 'updateStatus':
     case 'updateStatusAction':
+    case 'toggleReaction':
     case 'addNotification':
     case 'bulkAddNotifications':
     case 'updateNotificationStatusAction':

--- a/src/util/db/sqlite/worker/handlers/interactionHandlers.ts
+++ b/src/util/db/sqlite/worker/handlers/interactionHandlers.ts
@@ -144,7 +144,7 @@ export function handleUpdateStatusAction(
     )
   }
 
-  return { changedTables: ['posts', 'post_interactions'] }
+  return { changedTables: ['post_interactions'] }
 }
 
 export function handleToggleReaction(
@@ -163,7 +163,7 @@ export function handleToggleReaction(
     for (const relatedPostId of relatedPostIds) {
       toggleReaction(db, relatedPostId, localAccountId, null, null)
     }
-    return { changedTables: ['posts', 'post_interactions'] }
+    return { changedTables: ['post_interactions'] }
   }
 
   const isCustom = emoji.startsWith(':') && emoji.endsWith(':')
@@ -187,5 +187,5 @@ export function handleToggleReaction(
     }
   }
 
-  return { changedTables: ['posts', 'post_interactions'] }
+  return { changedTables: ['post_interactions'] }
 }

--- a/src/util/db/sqlite/worker/sqlite.worker.ts
+++ b/src/util/db/sqlite/worker/sqlite.worker.ts
@@ -309,7 +309,9 @@ function dispatchWorkerRequest(msg: WorkerRequest, db: WorkerDb): void {
         msg.value,
         msg.emoji,
       )
-      sendResponse(msg.id, { ok: true }, r.changedTables)
+      sendResponse(msg.id, { ok: true }, r.changedTables, undefined, {
+        backendUrl: msg.backendUrl,
+      })
       break
     }
 

--- a/src/util/hooks/timelineList/__tests__/reducer.test.ts
+++ b/src/util/hooks/timelineList/__tests__/reducer.test.ts
@@ -42,7 +42,7 @@ describe('createInitialState', () => {
     expect(s.initialized).toBe(false)
     expect(s.isScrollbackRunning).toBe(false)
     expect(s.hasMoreOlder).toBe(true)
-    expect(s.deferredStreaming).toBe(false)
+    expect(s.deferredChangedTables).toBeNull()
     expect(s.exhaustedResources.size).toBe(0)
   })
 })
@@ -137,25 +137,31 @@ describe('STREAMING_FETCH_SUCCEEDED', () => {
 })
 
 describe('STREAMING_DEFERRED', () => {
-  it('deferredStreaming=true になる', () => {
+  it('changedTables が保持される', () => {
     const s0 = createInitialState()
-    const s1 = dispatch(s0, { type: 'STREAMING_DEFERRED' })
+    const s1 = dispatch(s0, {
+      changedTables: new Set(['post_interactions']),
+      type: 'STREAMING_DEFERRED',
+    })
 
-    expect(s1.deferredStreaming).toBe(true)
+    expect(s1.deferredChangedTables).toEqual(new Set(['post_interactions']))
   })
 })
 
 describe('DEFERRED_STREAMING_FLUSH_SUCCEEDED', () => {
-  it('アイテムがマージされ deferredStreaming=false になる', () => {
+  it('アイテムがマージされ deferredChangedTables=null になる', () => {
     const s0 = createInitialState()
     const items = [makeStatus('1', 100)]
     const s1 = dispatch(
       s0,
-      { type: 'STREAMING_DEFERRED' },
+      {
+        changedTables: new Set(['post_interactions']),
+        type: 'STREAMING_DEFERRED',
+      },
       { items, type: 'DEFERRED_STREAMING_FLUSH_SUCCEEDED' },
     )
 
-    expect(s1.deferredStreaming).toBe(false)
+    expect(s1.deferredChangedTables).toBeNull()
     expect(s1.itemMap.size).toBe(1)
   })
 })
@@ -199,16 +205,19 @@ describe('SCROLLBACK_COMPLETED', () => {
     expect(s1.hasMoreOlder).toBe(false)
   })
 
-  it('deferredStreaming がリセットされる', () => {
+  it('deferredChangedTables がリセットされる', () => {
     const s0 = createInitialState()
     const s1 = dispatch(
       s0,
-      { type: 'STREAMING_DEFERRED' },
+      {
+        changedTables: new Set(['post_interactions']),
+        type: 'STREAMING_DEFERRED',
+      },
       { type: 'SCROLLBACK_STARTED' },
       { hasMoreOlder: true, type: 'SCROLLBACK_COMPLETED' },
     )
 
-    expect(s1.deferredStreaming).toBe(false)
+    expect(s1.deferredChangedTables).toBeNull()
   })
 })
 
@@ -369,7 +378,10 @@ describe('複合シナリオ', () => {
       s0,
       { items: [makeStatus('1', 100)], type: 'INITIAL_FETCH_SUCCEEDED' },
       { type: 'SCROLLBACK_STARTED' },
-      { type: 'STREAMING_DEFERRED' },
+      {
+        changedTables: new Set(['post_interactions']),
+        type: 'STREAMING_DEFERRED',
+      },
       { items: [makeStatus('0', 50)], type: 'SCROLLBACK_DB_SUCCEEDED' },
       { hasMoreOlder: true, type: 'SCROLLBACK_COMPLETED' },
       {
@@ -378,25 +390,33 @@ describe('複合シナリオ', () => {
       },
     )
 
-    expect(s.deferredStreaming).toBe(false)
+    expect(s.deferredChangedTables).toBeNull()
     expect(s.isScrollbackRunning).toBe(false)
     expect(s.itemMap.size).toBe(3)
     expect(s.newestMs).toBe(200)
     expect(s.oldestMs).toBe(50)
   })
 
-  it('scrollback中に複数回 STREAMING_DEFERRED が来ても deferredStreaming は true のまま', () => {
+  it('scrollback中に複数回 STREAMING_DEFERRED が来ると changedTables が union される', () => {
     const s0 = createInitialState()
     const s = dispatch(
       s0,
       { items: [makeStatus('1', 100)], type: 'INITIAL_FETCH_SUCCEEDED' },
       { type: 'SCROLLBACK_STARTED' },
-      { type: 'STREAMING_DEFERRED' },
-      { type: 'STREAMING_DEFERRED' },
-      { type: 'STREAMING_DEFERRED' },
+      {
+        changedTables: new Set(['post_interactions']),
+        type: 'STREAMING_DEFERRED',
+      },
+      { changedTables: new Set(['posts']), type: 'STREAMING_DEFERRED' },
+      {
+        changedTables: new Set(['timeline_entries']),
+        type: 'STREAMING_DEFERRED',
+      },
     )
 
-    expect(s.deferredStreaming).toBe(true)
+    expect(s.deferredChangedTables).toEqual(
+      new Set(['post_interactions', 'posts', 'timeline_entries']),
+    )
     expect(s.isScrollbackRunning).toBe(true)
   })
 
@@ -452,7 +472,10 @@ describe('複合シナリオ', () => {
       // 1回目 scrollback
       { type: 'SCROLLBACK_STARTED' },
       // scrollback 中に streaming 通知
-      { type: 'STREAMING_DEFERRED' },
+      {
+        changedTables: new Set(['post_interactions']),
+        type: 'STREAMING_DEFERRED',
+      },
       // scrollback DB 成功
       { items: [makeStatus('3', 300)], type: 'SCROLLBACK_DB_SUCCEEDED' },
       // scrollback 完了
@@ -479,7 +502,7 @@ describe('複合シナリオ', () => {
     expect(s.oldestMs).toBe(100)
     expect(s.isScrollbackRunning).toBe(false)
     expect(s.hasMoreOlder).toBe(false)
-    expect(s.deferredStreaming).toBe(false)
+    expect(s.deferredChangedTables).toBeNull()
 
     const timestamps = s.sortedItems.map((i) => itemTimestamp(i))
     expect(timestamps).toEqual([800, 700, 600, 500, 400, 300, 200, 100])

--- a/src/util/hooks/timelineList/__tests__/streamingController.test.ts
+++ b/src/util/hooks/timelineList/__tests__/streamingController.test.ts
@@ -5,6 +5,8 @@ import { CURSOR_MARGIN_MS } from '../itemHelpers'
 import {
   aggregateChangedTables,
   buildStreamingCursor,
+  resolveStreamingFetchWindow,
+  shouldBypassStreamingCursor,
 } from '../streamingHelpers'
 
 // --------------- aggregateChangedTables ---------------
@@ -80,5 +82,86 @@ describe('buildStreamingCursor', () => {
     const cursor = buildStreamingCursor({ newestId: 0, newestMs: 5000 })
     expect(cursor).toBeDefined()
     expect(cursor?.value).toBe(5000 - 1)
+  })
+})
+
+// --------------- shouldBypassStreamingCursor ---------------
+
+describe('shouldBypassStreamingCursor', () => {
+  it('post_interactions 単独変更では既存 column item 更新のため cursor を使わない', () => {
+    expect(shouldBypassStreamingCursor(new Set(['post_interactions']))).toBe(
+      true,
+    )
+  })
+
+  it('posts / timeline_entries だけの変更では cursor 差分取得を維持する', () => {
+    expect(
+      shouldBypassStreamingCursor(new Set(['posts', 'timeline_entries'])),
+    ).toBe(false)
+  })
+
+  it('post_interactions が通常 upsert と一緒に来た場合は cursor 差分取得を維持する', () => {
+    expect(
+      shouldBypassStreamingCursor(new Set(['posts', 'post_interactions'])),
+    ).toBe(false)
+  })
+})
+
+// --------------- resolveStreamingFetchWindow ---------------
+
+describe('resolveStreamingFetchWindow', () => {
+  it('post_interactions 単独変更では cursor なしで表示件数より広い window を取得する', () => {
+    const result = resolveStreamingFetchWindow(
+      new Set(['post_interactions']),
+      {
+        newestId: 20,
+        newestMs: 5000,
+        sortedItems: Array.from({ length: 80 }),
+      },
+      40,
+    )
+
+    expect(result).toEqual({
+      cursor: undefined,
+      limit: 120,
+    })
+  })
+
+  it('post_interactions 単独変更で表示中 item がない場合は PAGE_SIZE を維持する', () => {
+    const result = resolveStreamingFetchWindow(
+      new Set(['post_interactions']),
+      {
+        newestId: 20,
+        newestMs: 5000,
+        sortedItems: [],
+      },
+      40,
+    )
+
+    expect(result).toEqual({
+      cursor: undefined,
+      limit: 40,
+    })
+  })
+
+  it('通常 upsert では cursor 付き PAGE_SIZE 取得を維持する', () => {
+    const result = resolveStreamingFetchWindow(
+      new Set(['posts', 'post_interactions']),
+      {
+        newestId: 20,
+        newestMs: 5000,
+        sortedItems: Array.from({ length: 80 }),
+      },
+      40,
+    )
+
+    expect(result).toEqual({
+      cursor: {
+        direction: 'after',
+        field: 'created_at_ms',
+        value: 5000 - CURSOR_MARGIN_MS,
+      },
+      limit: 40,
+    })
   })
 })

--- a/src/util/hooks/timelineList/reducer.ts
+++ b/src/util/hooks/timelineList/reducer.ts
@@ -39,8 +39,8 @@ export type TimelineListState = {
   /** 過去方向にまだ取得可能か */
   hasMoreOlder: boolean
 
-  /** scrollback 中にストリーミング通知が保留されたか */
-  deferredStreaming: boolean
+  /** scrollback 中に保留されたストリーミング通知の changedTables */
+  deferredChangedTables: ReadonlySet<string> | null
 
   /** API フォールバックで枯渇したリソース (バックエンドURL → リソース種別) */
   exhaustedResources: Map<string, { notifications: boolean; statuses: boolean }>
@@ -48,7 +48,7 @@ export type TimelineListState = {
 
 export function createInitialState(): TimelineListState {
   return {
-    deferredStreaming: false,
+    deferredChangedTables: null,
     exhaustedResources: new Map(),
     hasMoreOlder: true,
     initialized: false,
@@ -67,7 +67,7 @@ export type TimelineListEvent =
   | { items: TimelineItem[]; type: 'INITIAL_FETCH_SUCCEEDED' }
   | { type: 'INITIAL_FETCH_EMPTY' }
   | { items: TimelineItem[]; type: 'STREAMING_FETCH_SUCCEEDED' }
-  | { type: 'STREAMING_DEFERRED' }
+  | { changedTables: ReadonlySet<string>; type: 'STREAMING_DEFERRED' }
   | { items: TimelineItem[]; type: 'DEFERRED_STREAMING_FLUSH_SUCCEEDED' }
   | { type: 'SCROLLBACK_STARTED' }
   | { items: TimelineItem[]; type: 'SCROLLBACK_DB_SUCCEEDED' }
@@ -93,10 +93,16 @@ export function timelineListReducer(
       return mergeItems(state, event.items)
 
     case 'STREAMING_DEFERRED':
-      return { ...state, deferredStreaming: true }
+      return {
+        ...state,
+        deferredChangedTables: mergeChangedTables(
+          state.deferredChangedTables,
+          event.changedTables,
+        ),
+      }
 
     case 'DEFERRED_STREAMING_FLUSH_SUCCEEDED':
-      return mergeItems({ ...state, deferredStreaming: false }, event.items)
+      return mergeItems({ ...state, deferredChangedTables: null }, event.items)
 
     case 'SCROLLBACK_STARTED':
       return { ...state, isScrollbackRunning: true }
@@ -107,7 +113,7 @@ export function timelineListReducer(
     case 'SCROLLBACK_COMPLETED':
       return {
         ...state,
-        deferredStreaming: false,
+        deferredChangedTables: null,
         hasMoreOlder: event.hasMoreOlder,
         isScrollbackRunning: false,
       }
@@ -133,6 +139,18 @@ export function timelineListReducer(
 }
 
 // --------------- ヘルパー ---------------
+
+function mergeChangedTables(
+  current: ReadonlySet<string> | null,
+  next: ReadonlySet<string>,
+): ReadonlySet<string> {
+  if (!current) return new Set(next)
+  const merged = new Set(current)
+  for (const table of next) {
+    merged.add(table)
+  }
+  return merged
+}
 
 /** アイテムを Map にマージし、カーソルを更新して sortedItems を再生成 */
 function mergeItems(

--- a/src/util/hooks/timelineList/streamingHelpers.ts
+++ b/src/util/hooks/timelineList/streamingHelpers.ts
@@ -11,6 +11,8 @@ import type { ChangeHint } from 'util/db/sqlite/connection'
 
 import { CURSOR_MARGIN_MS } from './itemHelpers'
 
+const INTERACTION_ONLY_TABLE = 'post_interactions'
+
 /**
  * ChangeHint 配列から changedTables を集約して Set にまとめる。
  *
@@ -57,4 +59,32 @@ export function buildStreamingCursor(state: {
     }
   }
   return undefined
+}
+
+export function shouldBypassStreamingCursor(
+  changedTables: ReadonlySet<string>,
+): boolean {
+  return changedTables.size === 1 && changedTables.has(INTERACTION_ONLY_TABLE)
+}
+
+export function resolveStreamingFetchWindow(
+  changedTables: ReadonlySet<string>,
+  state: {
+    newestId: number
+    newestMs: number
+    sortedItems: readonly unknown[]
+  },
+  pageSize: number,
+): { cursor?: PaginationCursor; limit: number } {
+  if (shouldBypassStreamingCursor(changedTables)) {
+    return {
+      cursor: undefined,
+      limit: Math.max(pageSize, state.sortedItems.length + pageSize),
+    }
+  }
+
+  return {
+    cursor: buildStreamingCursor(state),
+    limit: pageSize,
+  }
 }

--- a/src/util/hooks/timelineList/useTimelineScrollbackController.ts
+++ b/src/util/hooks/timelineList/useTimelineScrollbackController.ts
@@ -28,7 +28,7 @@ import {
 } from 'util/timelineFetcher'
 
 import type { TimelineListEvent, TimelineListState } from './reducer'
-import { buildStreamingCursor } from './streamingHelpers'
+import { resolveStreamingFetchWindow } from './streamingHelpers'
 
 const PAGE_SIZE = TIMELINE_QUERY_LIMIT
 
@@ -132,16 +132,24 @@ export function useTimelineScrollbackController({
     } finally {
       // scrollback 完了
       if (stateRef.current.isScrollbackRunning) {
-        const hasDeferredStreaming = stateRef.current.deferredStreaming
+        const flushState = stateRef.current
+        const deferredChangedTables = flushState.deferredChangedTables
         dispatch({
-          hasMoreOlder: stateRef.current.hasMoreOlder,
+          hasMoreOlder: flushState.hasMoreOlder,
           type: 'SCROLLBACK_COMPLETED',
         })
 
-        // 保留されたストリーミング更新を回収（カーソル付き差分取得）
-        if (hasDeferredStreaming) {
-          const cursor = buildStreamingCursor(stateRef.current)
-          fetchPage({ cursor, limit: PAGE_SIZE }).then((result) => {
+        if (deferredChangedTables) {
+          const { cursor, limit } = resolveStreamingFetchWindow(
+            deferredChangedTables,
+            flushState,
+            PAGE_SIZE,
+          )
+          fetchPage({
+            changedTables: deferredChangedTables,
+            cursor,
+            limit,
+          }).then((result) => {
             if (!result) return
             recordDuration(result.durationMs)
             dispatch({

--- a/src/util/hooks/timelineList/useTimelineStreamingController.ts
+++ b/src/util/hooks/timelineList/useTimelineStreamingController.ts
@@ -27,7 +27,7 @@ import type {
 } from 'util/hooks/useTimelineDataSource'
 
 import type { TimelineListEvent, TimelineListState } from './reducer'
-import { buildStreamingCursor } from './streamingHelpers'
+import { resolveStreamingFetchWindow } from './streamingHelpers'
 
 const PAGE_SIZE = TIMELINE_QUERY_LIMIT
 
@@ -64,32 +64,34 @@ export function useTimelineStreamingController({
     const doFetch = (changedTables: ReadonlySet<string>) => {
       pendingFetch = true
       const s = stateRef.current
-      const cursor = buildStreamingCursor(s)
+      const { cursor, limit } = resolveStreamingFetchWindow(
+        changedTables,
+        s,
+        PAGE_SIZE,
+      )
       tlDebug(
         '[TL] onMatched: fetching latest page',
         cursor ? 'with cursor' : 'full',
       )
 
-      fetchPage({ changedTables, cursor, limit: PAGE_SIZE, sessionTag }).then(
-        (result) => {
-          tlDebug(
-            '[TL] onMatched: fetch result',
-            result ? result.items.length : 'null',
-          )
-          if (result) {
-            recordDuration(result.durationMs)
-            dispatch({ items: result.items, type: 'STREAMING_FETCH_SUCCEEDED' })
-          }
+      fetchPage({ changedTables, cursor, limit, sessionTag }).then((result) => {
+        tlDebug(
+          '[TL] onMatched: fetch result',
+          result ? result.items.length : 'null',
+        )
+        if (result) {
+          recordDuration(result.durationMs)
+          dispatch({ items: result.items, type: 'STREAMING_FETCH_SUCCEEDED' })
+        }
 
-          pendingFetch = false
-          // 保留中の変更があればまとめてフェッチ
-          if (coalescedChangedTables) {
-            const merged = coalescedChangedTables
-            coalescedChangedTables = null
-            doFetch(merged)
-          }
-        },
-      )
+        pendingFetch = false
+        // 保留中の変更があればまとめてフェッチ
+        if (coalescedChangedTables) {
+          const merged = coalescedChangedTables
+          coalescedChangedTables = null
+          doFetch(merged)
+        }
+      })
     }
 
     const onMatched = (changedTables: ReadonlySet<string>) => {
@@ -97,7 +99,7 @@ export function useTimelineStreamingController({
       // scrollback 中は保留
       if (s.isScrollbackRunning) {
         tlDebug('[TL] onMatched: deferred (scrollback running)')
-        dispatch({ type: 'STREAMING_DEFERRED' })
+        dispatch({ changedTables, type: 'STREAMING_DEFERRED' })
         return
       }
       // 初期ロード完了前はスキップ

--- a/src/util/hooks/useTimelineDataSource.ts
+++ b/src/util/hooks/useTimelineDataSource.ts
@@ -133,6 +133,7 @@ export function useTimelineDataSource(
       tables.add('notifications')
     } else {
       tables.add('posts')
+      tables.add('post_interactions')
       tables.add('timeline_entries')
     }
     if (basePlan && isQueryPlanV2(basePlan)) {


### PR DESCRIPTION
## Summary
- subscribe status timelines to `post_interactions` so local interaction updates refresh every matching column
- treat interaction-only changes as a full visible-window refresh while keeping normal post upserts on cursor-based streaming
- preserve deferred `changedTables` through scrollback flushes and sync `Actions` local button state from updated status props

## Verification
- biome check .
- vitest run src/util/hooks/timelineList/__tests__/streamingController.test.ts src/util/hooks/timelineList/__tests__/reducer.test.ts src/util/hooks/timelineList/__tests__/hintMatching.test.ts src/util/db/sqlite/__tests__/handlers-interaction.test.ts
- vitest run --coverage

Fixes #631