### PR TITLE
Hashtag付き非Public投稿の確認導線を追加する

### DIFF
--- a/src/app/_components/MainPanel.tsx
+++ b/src/app/_components/MainPanel.tsx
@@ -8,6 +8,7 @@ import { UserInfo } from 'app/_parts/UserInfo'
 import type { Entity } from 'megalodon'
 import { useCallback, useContext, useEffect, useState } from 'react'
 import { RiCloseCircleLine, RiPlayFill } from 'react-icons/ri'
+import { containsHashtag } from 'util/containsHashtag'
 import { replaceEmojis } from 'util/emojiReplacer'
 import { GetClient } from 'util/GetClient'
 import { canPlay } from 'util/PlayerUtils'
@@ -58,6 +59,7 @@ export const MainPanel = () => {
 
   const [mediaLink, setMediaLink] = useState('')
   const [isPlay, setIsPlay] = useState(false)
+  const [showPublicConfirm, setShowPublicConfirm] = useState(false)
 
   const resetForm = () => {
     setVisibility(defaultStatusVisibility)
@@ -66,6 +68,7 @@ export const MainPanel = () => {
     setContent('')
     setReplyTo(undefined)
     setAttachments([])
+    setShowPublicConfirm(false)
   }
 
   const getContentFormatted = (status: Entity.Status) =>
@@ -83,7 +86,9 @@ export const MainPanel = () => {
     return getContentFormatted(replyTo)
   }
 
-  const clickPost = () => {
+  const submitPost = (visibilityOverride?: Entity.StatusVisibility) => {
+    setShowPublicConfirm(false)
+
     if (apps.length <= 0) return
     if (content === '') return
     if (apps[selectedAppIndex] == null) return
@@ -97,13 +102,26 @@ export const MainPanel = () => {
         media_ids:
           attachments.length > 0 ? attachments.map((a) => a.id) : undefined,
         spoiler_text: isCW ? spoilerText : undefined,
-        visibility: visibility,
+        visibility: visibilityOverride ?? visibility,
       })
       .catch((error) => {
         console.error('Failed to post status:', error)
       })
 
     resetForm()
+  }
+
+  const clickPost = () => {
+    if (apps.length <= 0) return
+    if (content === '') return
+    if (apps[selectedAppIndex] == null) return
+
+    if (containsHashtag(content) && visibility !== 'public') {
+      setShowPublicConfirm(true)
+      return
+    }
+
+    submitPost()
   }
 
   useEffect(() => {
@@ -337,6 +355,44 @@ export const MainPanel = () => {
             </button>
           </div>
         </div>
+        {showPublicConfirm && (
+          <div className="absolute inset-0 z-10">
+            <button
+              aria-label="Close"
+              className="absolute inset-0 h-full w-full bg-black/60"
+              onClick={() => setShowPublicConfirm(false)}
+              type="button"
+            />
+            <div className="absolute left-1/2 top-1/2 w-[min(100%-1rem,20rem)] -translate-x-1/2 -translate-y-1/2 rounded-md border bg-gray-600 p-6 text-center">
+              <div className="pb-4">Publicに変更しますか？</div>
+              <div className="flex flex-col gap-2">
+                <button
+                  className="rounded-md border bg-gray-900 px-4 py-2"
+                  onClick={() => setShowPublicConfirm(false)}
+                  type="button"
+                >
+                  戻る
+                </button>
+                <button
+                  className="rounded-md border bg-gray-900 px-4 py-2"
+                  onClick={() => submitPost()}
+                  type="button"
+                >
+                  そのまま送信
+                </button>
+                {visibility !== 'direct' && (
+                  <button
+                    className="rounded-md border bg-gray-900 px-4 py-2"
+                    onClick={() => submitPost('public')}
+                    type="button"
+                  >
+                    Publicで送信
+                  </button>
+                )}
+              </div>
+            </div>
+          </div>
+        )}
       </div>
     </Panel>
   )

--- a/src/util/__tests__/containsHashtag.test.ts
+++ b/src/util/__tests__/containsHashtag.test.ts
@@ -1,0 +1,28 @@
+import { containsHashtag } from 'util/containsHashtag'
+import { describe, expect, it } from 'vitest'
+
+describe('containsHashtag', () => {
+  it('#tag を含む本文は true', () => {
+    expect(containsHashtag('hello #tag')).toBe(true)
+  })
+
+  it('複数タグを含む本文は true', () => {
+    expect(containsHashtag('#foo and #bar')).toBe(true)
+  })
+
+  it('# のみは false', () => {
+    expect(containsHashtag('#')).toBe(false)
+  })
+
+  it('空白のみは false', () => {
+    expect(containsHashtag('   ')).toBe(false)
+  })
+
+  it('メンションのみは false', () => {
+    expect(containsHashtag('@user hello')).toBe(false)
+  })
+
+  it('空文字は false', () => {
+    expect(containsHashtag('')).toBe(false)
+  })
+})

--- a/src/util/containsHashtag.ts
+++ b/src/util/containsHashtag.ts
@@ -1,0 +1,14 @@
+import { TAG_HIGHLIGHT_REG } from 'app/_parts/statusRichTextareaConstants'
+
+/**
+ * Returns true when the text contains at least one hashtag token
+ * matching the same pattern used by StatusRichTextarea highlighting.
+ * A bare `#` (empty tag name) does not count.
+ */
+export const containsHashtag = (text: string): boolean => {
+  TAG_HIGHLIGHT_REG.lastIndex = 0
+  for (const match of text.matchAll(TAG_HIGHLIGHT_REG)) {
+    if (match[1] != null && match[1].length > 0) return true
+  }
+  return false
+}


### PR DESCRIPTION
## Summary
- Hashtag を含む投稿を unlisted / private / direct で送ろうとしたとき、投稿パネル上で確認オーバーレイを表示する (#643)
- `戻る` / `そのまま送信` / `Publicで送信` を用意し、`direct` では誤公開防止のため Public 送信を出さない
- Hashtag 判定ヘルパーと単体テストを追加する

## Test plan
- [ ] `#tag` + public で送信すると確認なしで投稿される
- [ ] `#tag` + unlisted/private で送信すると確認が出る
- [ ] `戻る` で送信されず、本文・添付・CW・公開範囲が保持される
- [ ] `そのまま送信` で現在の公開範囲のまま投稿される
- [ ] `Publicで送信` で public 投稿され、default visibility 設定は変わらない
- [ ] `direct` では「Publicで送信」が出ない
- [ ] `./node_modules/.bin/vitest run src/util/__tests__/containsHashtag.test.ts` が通る