### PR TITLE
fix(player): VideoPlayer コントロールをメディアモードに合わせて修正 (#649)

### DIFF
--- a/src/app/_components/Player.tsx
+++ b/src/app/_components/Player.tsx
@@ -5,7 +5,6 @@ import type { Entity } from 'megalodon'
 import React, {
   type ChangeEventHandler,
   type MouseEventHandler,
-  useCallback,
   useContext,
   useEffect,
   useEffectEvent,
@@ -19,6 +18,15 @@ import { RiCloseCircleLine, RiPauseFill, RiPlayFill } from 'react-icons/ri'
 import ReactPlayer from 'react-player'
 
 import {
+  getPlayerControlCapabilities,
+  getPlayerSizeTokens,
+  isPlayableAttachmentType,
+  type PlayerMediaMode,
+  type PlayerSizeTokens,
+  resolvePlayerMediaMode,
+  shouldIgnorePlayerKeydownTarget,
+} from 'util/playerMediaMode'
+import {
   PlayerContext,
   PlayerSettingContext,
   SetPlayerContext,
@@ -26,42 +34,7 @@ import {
 } from 'util/provider/PlayerProvider'
 import { SettingContext } from 'util/provider/SettingProvider'
 import { toSecureResourceUrl } from 'util/secureResourceUrl'
-import {
-  extractYouTubeVideoId,
-  getDirectEmbedUrl,
-  isExternalVideo,
-} from 'util/videoEmbed'
-
-const playableTypes = ['audio', 'video', 'gifv'] as Readonly<
-  Entity.Attachment['type'][]
->
-
-function isEditableKeyboardTarget(target: EventTarget | null): boolean {
-  return (
-    target instanceof HTMLInputElement ||
-    target instanceof HTMLSelectElement ||
-    target instanceof HTMLTextAreaElement
-  )
-}
-
-function shouldIgnorePlayerKeydown(
-  event: KeyboardEvent,
-  playerRoot: HTMLElement | null,
-): boolean {
-  const target = event.target
-  if (!(target instanceof Node)) return true
-  if (isEditableKeyboardTarget(target)) return true
-  if (
-    target instanceof HTMLElement &&
-    target.closest('[data-autocomplete-menu]') != null
-  ) {
-    return true
-  }
-  if (!playerRoot?.contains(target)) return true
-  // Space はフォーカス中のボタンに任せる（二重トグル防止）
-  if (event.code === 'Space' && target instanceof HTMLButtonElement) return true
-  return false
-}
+import { extractYouTubeVideoId, getDirectEmbedUrl } from 'util/videoEmbed'
 
 function seekPlayed(
   player: React.RefObject<HTMLVideoElement | null>,
@@ -78,57 +51,71 @@ function seekPlayed(
   })
 }
 
-type PlayerSizeClasses = { h: string; w: string }
+function toggleNativePlayback(
+  player: React.RefObject<HTMLVideoElement | null>,
+  setPlaying: React.Dispatch<React.SetStateAction<boolean>>,
+) {
+  const el = player.current
+  if (el == null) return
+  if (el.paused) {
+    void el.play()
+    setPlaying(true)
+  } else {
+    el.pause()
+    setPlaying(false)
+  }
+}
 
 function renderPlayableMedia({
   attachment,
   classNamePlayerSize,
   currentUrl,
   currentYouTubeVideoId,
-  externalEmbedFailed,
   handleProgress,
+  mediaMode,
   onExternalEmbedError,
   player,
   playing,
   volume,
 }: {
   attachment: Entity.Attachment
-  classNamePlayerSize: PlayerSizeClasses
+  classNamePlayerSize: PlayerSizeTokens
   currentUrl: string
   currentYouTubeVideoId: string | null
-  externalEmbedFailed: boolean
   handleProgress: (event: React.SyntheticEvent<HTMLVideoElement>) => void
+  mediaMode: PlayerMediaMode
   onExternalEmbedError: () => void
   player: React.RefObject<HTMLVideoElement | null>
   playing: boolean
   volume: number
 }): React.ReactNode {
-  if (!playableTypes.includes(attachment.type)) {
+  if (!isPlayableAttachmentType(attachment.type)) {
     return null
   }
 
-  if (!isExternalVideo(currentUrl)) {
+  if (mediaMode === 'native') {
     return (
       <ReactPlayer
         className="aspect-video"
-        height={attachment.type === 'audio' ? 0 : classNamePlayerSize.h}
+        height={attachment.type === 'audio' ? 0 : classNamePlayerSize.hPx}
         loop
         onTimeUpdate={handleProgress}
         playing={playing}
         ref={player}
         src={currentUrl}
         volume={volume}
-        width={'100%'}
+        width="100%"
       />
     )
   }
 
-  if (externalEmbedFailed) {
+  if (mediaMode === 'fallback') {
     return (
       <div
-        className={['relative aspect-video w-full', classNamePlayerSize.h].join(
-          ' ',
-        )}
+        className={[
+          'relative aspect-video w-full',
+          classNamePlayerSize.hClass,
+        ].join(' ')}
       >
         {currentYouTubeVideoId == null ? (
           <div className="h-full w-full bg-black" />
@@ -154,19 +141,25 @@ function renderPlayableMedia({
     )
   }
 
-  return (
-    <iframe
-      allow="autoplay; encrypted-media; fullscreen; picture-in-picture"
-      allowFullScreen
-      className={['aspect-video w-full', classNamePlayerSize.h].join(' ')}
-      // @ts-expect-error -- credentialless is a valid HTML attribute but not yet in React's type definitions
-      credentialless=""
-      onError={onExternalEmbedError}
-      src={getDirectEmbedUrl(currentUrl) ?? currentUrl}
-      style={{ border: 'none' }}
-      title="Video player"
-    />
-  )
+  if (mediaMode === 'iframe') {
+    return (
+      <iframe
+        allow="autoplay; encrypted-media; fullscreen; picture-in-picture"
+        allowFullScreen
+        className={['aspect-video w-full', classNamePlayerSize.hClass].join(
+          ' ',
+        )}
+        // @ts-expect-error -- credentialless is a valid HTML attribute but not yet in React's type definitions
+        credentialless=""
+        onError={onExternalEmbedError}
+        src={getDirectEmbedUrl(currentUrl) ?? currentUrl}
+        style={{ border: 'none' }}
+        title="Video player"
+      />
+    )
+  }
+
+  return null
 }
 
 const PlayerController = () => {
@@ -178,33 +171,38 @@ const PlayerController = () => {
 
   const player = useRef<HTMLVideoElement>(null)
   const playerRootRef = useRef<HTMLDivElement>(null)
-  const [playing, setPlaying] = useState<boolean>(false)
-  const [played, setPlayed] = useState<number>(0)
-  const [seeking, setSeeking] = useState<boolean>(false)
+  const [playing, setPlaying] = useState(false)
+  const [played, setPlayed] = useState(0)
+  const [seeking, setSeeking] = useState(false)
   const [externalEmbedFailed, setExternalEmbedFailed] = useState(false)
 
-  const classNamePlayerSize = useMemo(() => {
-    switch (playerSize) {
-      case 'small':
-        return { h: 'h-[180px]', w: 'w-[320px]' }
-      case 'medium':
-        return { h: 'h-[360px]', w: 'w-[640px]' }
-      case 'large':
-        return { h: 'h-[460px]', w: 'w-[820px]' }
-    }
-  }, [playerSize])
+  const classNamePlayerSize = useMemo(
+    () => getPlayerSizeTokens(playerSize),
+    [playerSize],
+  )
+
+  const currentAttachment = index == null ? null : attachment[index]
+  const currentUrl = toSecureResourceUrl(currentAttachment?.url) ?? ''
+  const currentYouTubeVideoId = extractYouTubeVideoId(currentUrl)
+  const mediaMode = resolvePlayerMediaMode({
+    attachmentType: currentAttachment?.type,
+    currentUrl,
+    externalEmbedFailed,
+  })
+  const controls = getPlayerControlCapabilities(mediaMode, attachment.length)
 
   const onClickPlay = () => {
-    setPlaying((prev) => !prev)
+    if (!controls.canPlayPause) return
+    toggleNativePlayback(player, setPlaying)
   }
 
-  const onClickClose = useCallback(() => {
+  const onClickClose = () => {
     setPlaying(false)
     setAttachment({
       attachment: [],
       index: null,
     })
-  }, [setAttachment])
+  }
 
   const handleSeekMouseDown: MouseEventHandler<HTMLInputElement> = () => {
     setSeeking(true)
@@ -215,35 +213,39 @@ const PlayerController = () => {
   }
 
   const onKeyDown = useEffectEvent((e: KeyboardEvent) => {
-    if (shouldIgnorePlayerKeydown(e, playerRootRef.current)) return
-
-    const canSeekNativePlayer =
-      currentAttachment != null &&
-      playableTypes.includes(currentAttachment.type) &&
-      (!isExternalVideo(currentUrl) || externalEmbedFailed)
+    if (shouldIgnorePlayerKeydownTarget(e.target)) return
+    // Space はフォーカス中のボタンに任せる（二重トグル防止）
+    if (e.code === 'Space' && e.target instanceof HTMLButtonElement) return
 
     switch (e.code) {
-      case 'Space':
+      case 'Escape':
         e.preventDefault()
-        setPlaying((prev) => !prev)
+        onClickClose()
+        break
+      case 'Space':
+        if (!controls.canPlayPause) break
+        e.preventDefault()
+        toggleNativePlayback(player, setPlaying)
         break
       case 'ArrowLeft':
-        if (!canSeekNativePlayer) break
+        if (!controls.canSeek) break
         e.preventDefault()
         seekPlayed(player, -0.1, setPlayed)
         break
       case 'ArrowRight':
-        if (!canSeekNativePlayer) break
+        if (!controls.canSeek) break
         e.preventDefault()
         seekPlayed(player, 0.1, setPlayed)
         break
       case 'ArrowUp':
+        if (!controls.canVolume) break
         e.preventDefault()
         setPlayerSetting((prev) => ({
           volume: Math.min(1, prev.volume + 0.05),
         }))
         break
       case 'ArrowDown':
+        if (!controls.canVolume) break
         e.preventDefault()
         setPlayerSetting((prev) => ({
           volume: Math.max(0, prev.volume - 0.05),
@@ -259,6 +261,14 @@ const PlayerController = () => {
     }
   }, [])
 
+  useEffect(() => {
+    if (currentUrl === '') return
+    setExternalEmbedFailed(false)
+    setPlayed(0)
+    setPlaying(false)
+    playerRootRef.current?.focus({ preventScroll: true })
+  }, [currentUrl])
+
   const handleSeekMouseUp: MouseEventHandler<HTMLInputElement> = () => {
     setSeeking(false)
     if (player.current != null && player.current.duration > 0) {
@@ -270,8 +280,7 @@ const PlayerController = () => {
     if (!seeking && event.currentTarget != null) {
       const video = event.currentTarget
       if (video.duration > 0) {
-        const played = video.currentTime / video.duration
-        setPlayed(played)
+        setPlayed(video.currentTime / video.duration)
       }
     }
   }
@@ -292,28 +301,15 @@ const PlayerController = () => {
     })
   }
 
-  const currentAttachment = index == null ? null : attachment[index]
-  const currentUrl = toSecureResourceUrl(currentAttachment?.url) ?? ''
-  const currentYouTubeVideoId = extractYouTubeVideoId(currentUrl)
-
-  useEffect(() => {
-    if (currentUrl === '') return
-    setExternalEmbedFailed(false)
-  }, [currentUrl])
-
   if (currentAttachment == null) return null
-
-  const canSeekNativePlayer =
-    playableTypes.includes(currentAttachment.type) &&
-    (!isExternalVideo(currentUrl) || externalEmbedFailed)
 
   const playableMedia = renderPlayableMedia({
     attachment: currentAttachment,
     classNamePlayerSize,
     currentUrl,
     currentYouTubeVideoId,
-    externalEmbedFailed,
     handleProgress,
+    mediaMode,
     onExternalEmbedError: () => {
       setExternalEmbedFailed(true)
     },
@@ -325,15 +321,19 @@ const PlayerController = () => {
   return (
     <div
       className={[
-        'fixed bottom-0 right-0 z-40 max-w-full',
-        classNamePlayerSize.w,
+        'fixed bottom-0 right-0 z-40 max-w-full outline-none',
+        classNamePlayerSize.wClass,
       ].join(' ')}
       data-player
       ref={playerRootRef}
+      tabIndex={-1}
     >
-      <div className=" bg-black" onClick={onClickPlay}>
+      <div
+        className="bg-black"
+        onClick={controls.canPlayPause ? onClickPlay : undefined}
+      >
         {playableMedia}
-        {'image' === currentAttachment.type && (
+        {currentAttachment.type === 'image' && (
           <img
             alt={currentAttachment.description ?? ''}
             className="h-full w-full object-contain"
@@ -343,13 +343,19 @@ const PlayerController = () => {
       </div>
       <div className="box-border flex h-12 items-center space-x-px bg-gray-500 pt-[2px]">
         <button
-          className="flex h-12 w-12 shrink-0 items-center justify-center bg-gray-800 hover:bg-gray-500"
+          className="flex h-12 w-12 shrink-0 items-center justify-center bg-gray-800 hover:bg-gray-500 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-gray-800"
+          disabled={!controls.canPlayPause}
           onClick={onClickPlay}
+          title={
+            controls.canPlayPause
+              ? undefined
+              : 'Use the embedded player controls'
+          }
           type="button"
         >
           {playing ? <RiPauseFill size={30} /> : <RiPlayFill size={30} />}
         </button>
-        {attachment.length > 1 && (
+        {controls.canPrevNext && (
           <>
             <button
               className="flex h-12 w-12 shrink-0 items-center justify-center bg-gray-800 hover:bg-gray-500"
@@ -369,8 +375,8 @@ const PlayerController = () => {
         )}
         <div className="flex h-12 w-full shrink bg-gray-800">
           <input
-            className="w-full"
-            disabled={!canSeekNativePlayer}
+            className="w-full disabled:cursor-not-allowed disabled:opacity-40"
+            disabled={!controls.canSeek}
             max="0.9999999"
             min="0"
             onChange={handleSeekChange}
@@ -383,7 +389,8 @@ const PlayerController = () => {
         </div>
         <div className="flex h-12 w-32 shrink-0 bg-gray-800">
           <input
-            className="w-32"
+            className="w-32 disabled:cursor-not-allowed disabled:opacity-40"
+            disabled={!controls.canVolume}
             max="1"
             min="0"
             onChange={(e) => {

--- a/src/app/_components/Player.tsx
+++ b/src/app/_components/Player.tsx
@@ -56,7 +56,12 @@ function toggleNativePlayback(
   setPlaying: React.Dispatch<React.SetStateAction<boolean>>,
 ) {
   const el = player.current
-  if (el == null) return
+  if (el == null) {
+    // Ref may be unset on first paint or right after src change; fall back
+    // to the controlled `playing` prop so the gesture still toggles playback.
+    setPlaying((prev) => !prev)
+    return
+  }
   if (el.paused) {
     void el.play()
     setPlaying(true)
@@ -183,6 +188,7 @@ const PlayerController = () => {
 
   const currentAttachment = index == null ? null : attachment[index]
   const currentUrl = toSecureResourceUrl(currentAttachment?.url) ?? ''
+  const [trackedUrl, setTrackedUrl] = useState(currentUrl)
   const currentYouTubeVideoId = extractYouTubeVideoId(currentUrl)
   const mediaMode = resolvePlayerMediaMode({
     attachmentType: currentAttachment?.type,
@@ -190,6 +196,17 @@ const PlayerController = () => {
     externalEmbedFailed,
   })
   const controls = getPlayerControlCapabilities(mediaMode, attachment.length)
+
+  // Reset playback state while rendering so the first paint after a track
+  // switch never keeps `playing={true}` with the new src (avoids a blip).
+  if (currentUrl !== trackedUrl) {
+    setTrackedUrl(currentUrl)
+    if (currentUrl !== '') {
+      setExternalEmbedFailed(false)
+      setPlayed(0)
+      setPlaying(false)
+    }
+  }
 
   const onClickPlay = () => {
     if (!controls.canPlayPause) return
@@ -263,9 +280,6 @@ const PlayerController = () => {
 
   useEffect(() => {
     if (currentUrl === '') return
-    setExternalEmbedFailed(false)
-    setPlayed(0)
-    setPlaying(false)
     playerRootRef.current?.focus({ preventScroll: true })
   }, [currentUrl])
 

--- a/src/util/playerMediaMode.test.ts
+++ b/src/util/playerMediaMode.test.ts
@@ -1,0 +1,134 @@
+import {
+  getPlayerControlCapabilities,
+  getPlayerSizeTokens,
+  isPlayableAttachmentType,
+  resolvePlayerMediaMode,
+  shouldIgnorePlayerKeydownTarget,
+} from 'util/playerMediaMode'
+import { describe, expect, it } from 'vitest'
+
+describe('isPlayableAttachmentType', () => {
+  it('accepts audio/video/gifv', () => {
+    expect(isPlayableAttachmentType('audio')).toBe(true)
+    expect(isPlayableAttachmentType('video')).toBe(true)
+    expect(isPlayableAttachmentType('gifv')).toBe(true)
+  })
+
+  it('rejects image and unknown', () => {
+    expect(isPlayableAttachmentType('image')).toBe(false)
+    expect(isPlayableAttachmentType('unknown')).toBe(false)
+  })
+})
+
+describe('resolvePlayerMediaMode', () => {
+  it('returns native for direct media URLs', () => {
+    expect(
+      resolvePlayerMediaMode({
+        attachmentType: 'video',
+        currentUrl: 'https://cdn.example.com/clip.mp4',
+        externalEmbedFailed: false,
+      }),
+    ).toBe('native')
+  })
+
+  it('returns iframe for YouTube URLs when embed has not failed', () => {
+    expect(
+      resolvePlayerMediaMode({
+        attachmentType: 'video',
+        currentUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+        externalEmbedFailed: false,
+      }),
+    ).toBe('iframe')
+  })
+
+  it('returns fallback for YouTube URLs when embed failed', () => {
+    expect(
+      resolvePlayerMediaMode({
+        attachmentType: 'video',
+        currentUrl: 'https://youtu.be/dQw4w9WgXcQ',
+        externalEmbedFailed: true,
+      }),
+    ).toBe('fallback')
+  })
+
+  it('returns image for image attachments', () => {
+    expect(
+      resolvePlayerMediaMode({
+        attachmentType: 'image',
+        currentUrl: 'https://cdn.example.com/photo.jpg',
+        externalEmbedFailed: false,
+      }),
+    ).toBe('image')
+  })
+
+  it('returns none for missing attachment or empty URL', () => {
+    expect(
+      resolvePlayerMediaMode({
+        attachmentType: null,
+        currentUrl: 'https://cdn.example.com/clip.mp4',
+        externalEmbedFailed: false,
+      }),
+    ).toBe('none')
+    expect(
+      resolvePlayerMediaMode({
+        attachmentType: 'video',
+        currentUrl: '',
+        externalEmbedFailed: false,
+      }),
+    ).toBe('none')
+  })
+})
+
+describe('getPlayerControlCapabilities', () => {
+  it('enables playback controls only for native mode', () => {
+    expect(getPlayerControlCapabilities('native', 1)).toEqual({
+      canClose: true,
+      canPlayPause: true,
+      canPrevNext: false,
+      canSeek: true,
+      canVolume: true,
+    })
+  })
+
+  it('disables playback/seek/volume for iframe and fallback', () => {
+    for (const mode of ['iframe', 'fallback'] as const) {
+      expect(getPlayerControlCapabilities(mode, 1)).toEqual({
+        canClose: true,
+        canPlayPause: false,
+        canPrevNext: false,
+        canSeek: false,
+        canVolume: false,
+      })
+    }
+  })
+
+  it('enables prev/next when multiple tracks exist', () => {
+    expect(getPlayerControlCapabilities('iframe', 3).canPrevNext).toBe(true)
+    expect(getPlayerControlCapabilities('fallback', 2).canPrevNext).toBe(true)
+    expect(getPlayerControlCapabilities('native', 2).canPrevNext).toBe(true)
+    expect(getPlayerControlCapabilities('none', 2).canPrevNext).toBe(false)
+  })
+
+  it('does not enable seek on fallback (regression for #649)', () => {
+    expect(getPlayerControlCapabilities('fallback', 1).canSeek).toBe(false)
+  })
+})
+
+describe('getPlayerSizeTokens', () => {
+  it('returns matching Tailwind classes and pixel heights', () => {
+    expect(getPlayerSizeTokens('small')).toEqual({
+      hClass: 'h-[180px]',
+      hPx: '180px',
+      wClass: 'w-[320px]',
+    })
+    expect(getPlayerSizeTokens('medium').hPx).toBe('360px')
+    expect(getPlayerSizeTokens('large').hPx).toBe('460px')
+  })
+})
+
+describe('shouldIgnorePlayerKeydownTarget', () => {
+  it('ignores null / non-Node targets', () => {
+    expect(shouldIgnorePlayerKeydownTarget(null)).toBe(true)
+    expect(shouldIgnorePlayerKeydownTarget({} as EventTarget)).toBe(true)
+  })
+})

--- a/src/util/playerMediaMode.ts
+++ b/src/util/playerMediaMode.ts
@@ -1,0 +1,127 @@
+import type { Entity } from 'megalodon'
+
+import { isExternalVideo } from 'util/videoEmbed'
+
+export const PLAYABLE_ATTACHMENT_TYPES = ['audio', 'video', 'gifv'] as const
+
+export type PlayableAttachmentType = (typeof PLAYABLE_ATTACHMENT_TYPES)[number]
+
+export type PlayerMediaMode =
+  | 'native'
+  | 'iframe'
+  | 'fallback'
+  | 'image'
+  | 'none'
+
+export type PlayerControlCapabilities = {
+  canPlayPause: boolean
+  canSeek: boolean
+  canVolume: boolean
+  canPrevNext: boolean
+  canClose: boolean
+}
+
+export function isPlayableAttachmentType(
+  type: Entity.Attachment['type'],
+): type is PlayableAttachmentType {
+  return (PLAYABLE_ATTACHMENT_TYPES as readonly string[]).includes(type)
+}
+
+/**
+ * Derive how the current attachment should be rendered / controlled.
+ * - native: ReactPlayer (direct media)
+ * - iframe: credentialless external embed (YouTube etc.)
+ * - fallback: embed failed; thumbnail + external link only
+ * - image: still image attachment
+ * - none: missing / unsupported
+ */
+export function resolvePlayerMediaMode({
+  attachmentType,
+  currentUrl,
+  externalEmbedFailed,
+}: {
+  attachmentType: Entity.Attachment['type'] | null | undefined
+  currentUrl: string
+  externalEmbedFailed: boolean
+}): PlayerMediaMode {
+  if (attachmentType == null) return 'none'
+  if (attachmentType === 'image') return 'image'
+  if (!isPlayableAttachmentType(attachmentType)) return 'none'
+  if (currentUrl === '') return 'none'
+
+  if (!isExternalVideo(currentUrl)) return 'native'
+  if (externalEmbedFailed) return 'fallback'
+  return 'iframe'
+}
+
+export function getPlayerControlCapabilities(
+  mediaMode: PlayerMediaMode,
+  trackCount: number,
+): PlayerControlCapabilities {
+  const isNative = mediaMode === 'native'
+  return {
+    canClose: mediaMode !== 'none',
+    canPlayPause: isNative,
+    canPrevNext: trackCount > 1 && mediaMode !== 'none',
+    canSeek: isNative,
+    canVolume: isNative,
+  }
+}
+
+export type PlayerSizeTokens = {
+  hClass: string
+  hPx: string
+  wClass: string
+}
+
+export function getPlayerSizeTokens(
+  playerSize: 'small' | 'medium' | 'large',
+): PlayerSizeTokens {
+  switch (playerSize) {
+    case 'small':
+      return { hClass: 'h-[180px]', hPx: '180px', wClass: 'w-[320px]' }
+    case 'medium':
+      return { hClass: 'h-[360px]', hPx: '360px', wClass: 'w-[640px]' }
+    case 'large':
+      return { hClass: 'h-[460px]', hPx: '460px', wClass: 'w-[820px]' }
+  }
+}
+
+/**
+ * Whether player keyboard shortcuts should be ignored for editable /
+ * autocomplete targets. Focus outside `[data-player]` is intentionally allowed
+ * while the player is open (portal-rendered UI).
+ */
+export function shouldIgnorePlayerKeydownTarget(
+  target: EventTarget | null,
+): boolean {
+  if (target == null) return true
+  // Node/HTML*Element are browser globals; keep this safe for node unit tests.
+  if (typeof Node === 'undefined' || !(target instanceof Node)) return true
+  if (
+    typeof HTMLInputElement !== 'undefined' &&
+    target instanceof HTMLInputElement
+  ) {
+    return true
+  }
+  if (
+    typeof HTMLSelectElement !== 'undefined' &&
+    target instanceof HTMLSelectElement
+  ) {
+    return true
+  }
+  if (
+    typeof HTMLTextAreaElement !== 'undefined' &&
+    target instanceof HTMLTextAreaElement
+  ) {
+    return true
+  }
+  if (
+    typeof HTMLElement !== 'undefined' &&
+    target instanceof HTMLElement &&
+    target.closest('[data-autocomplete-menu]') != null
+  ) {
+    return true
+  }
+  return false
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- `PlayerMediaMode`（`native` / `iframe` / `fallback`）を導入し、制御可能なコントロールだけを有効化
- iframe / fallback では再生・シーク・音量を無効化（#649 の誤解を招く UI を解消）
- ReactPlayer の `height` に Tailwind class ではなくピクセル値を渡すよう修正
- ネイティブ再生はユーザージェスチャー内で `play()` / `pause()` を同期呼び出し
- Player 表示中はフォーカス位置に関わらずキーボード操作を有効化（Esc で閉じるを追加）

## Test plan

- [x] `yarn test:run src/util/playerMediaMode.test.ts`
- [x] `yarn check`
- [ ] 手動: 添付 MP4 で再生/シーク/音量が動くこと
- [ ] 手動: YouTube URL でカスタム再生/シーク/音量が disabled、iframe 内操作は可能
- [ ] 手動: 埋め込み失敗時にシークが無効のままであること
- [ ] 手動: Player 表示中にタイムライン側フォーカスでも Space/矢印/Esc が効くこと

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6003-3ddc-7955-8c2f-3d14339e0a24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6003-3ddc-7955-8c2f-3d14339e0a24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

