### PR TITLE
chore: add Foglamp package (no AI SDK call sites yet)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "domelementtype": "^3.0.0",
     "embla-carousel-react": "^8.6.0",
     "emoji-picker-react": "^4.19.1",
+    "foglamp": "^0.7.1",
     "html-react-parser": "^6.1.4",
     "jquery": "^4.0.0",
     "lucide-react": "^1.24.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4526,6 +4526,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"foglamp@npm:^0.7.1":
+  version: 0.7.1
+  resolution: "foglamp@npm:0.7.1"
+  dependencies:
+    uuidv7: "npm:^1.2.1"
+  peerDependencies:
+    ai: ^4 || ^5 || ^6 || ^7.0.0-beta.1
+    react: ^18 || ^19
+    react-dom: ^18 || ^19
+  peerDependenciesMeta:
+    react:
+      optional: true
+    react-dom:
+      optional: true
+  bin:
+    foglamp: dist/cli.mjs
+  checksum: 10c0/02e4bb65bbb5bfbb11ff1e69026a0aa3619996ba066cfeca9f92a767293f6c73f1aedd5218d600f5da2b4857d3a33feb139cd9f8fec3ba1d6defecfc7502cb5e
+  languageName: node
+  linkType: hard
+
 "follow-redirects@npm:^1.15.11":
   version: 1.16.0
   resolution: "follow-redirects@npm:1.16.0"
@@ -5795,6 +5815,7 @@ __metadata:
     domelementtype: "npm:^3.0.0"
     embla-carousel-react: "npm:^8.6.0"
     emoji-picker-react: "npm:^4.19.1"
+    foglamp: "npm:^0.7.1"
     globals: "npm:^17.7.0"
     html-react-parser: "npm:^6.1.4"
     husky: "npm:9.1.7"
@@ -7808,6 +7829,15 @@ __metadata:
   bin:
     uuid: dist/esm/bin/uuid
   checksum: 10c0/9e3af58eba872ece5a5e76f4773a94fc78a0ef2c2444c38dbe6b42f41dadf76c01850fd783604f27986f6195e6286aef064d45987d401b2a33127b98ddf7c0c5
+  languageName: node
+  linkType: hard
+
+"uuidv7@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "uuidv7@npm:1.2.1"
+  bin:
+    uuidv7: cli.js
+  checksum: 10c0/adaf3387f10435efccf5ab6bb23344228c5737f98137619dc53521d2325522536218449175a0f2b1b13c4ffb846448cbcc4fb667bebf0457392a0b7bb35004a8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Installed `foglamp@^0.7.1` via Yarn.
- Wrote `FOGLAMP_API_KEY` into local `.env` (gitignored; not in this PR).

## Why no wrap / HUD wiring

This repo is a Fediverse client and does **not** depend on the Vercel AI SDK (`ai`). A full-tree search found no `generateText` / `streamText` / `generateObject` / `streamObject` / `ToolLoopAgent` usage, so there is nothing for `foglamp/wrap` or `fog.integration(...)` to attach to.

Per Foglamp guidance, no demo endpoints or synthetic traces were added. Live HUD was skipped for the same reason (no Node-side `foglamp({ hud: true })` call site with model calls).

When AI SDK usage is added later:

1. Check the installed `ai` major (v4–v6 → `wrap()` from `foglamp/wrap`; v7 → `fog.integration(...)`).
2. Map real agents / workflows / sessions with static name literals.
3. Pass `hud: true` and render `<FoglampHUD />` from `foglamp/hud` in the root layout.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c6b49218-ba63-4d19-ba4a-4e9de116960c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c6b49218-ba63-4d19-ba4a-4e9de116960c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

