### PR TITLE
Ignore .foglamp scan artifacts containing edit tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ yarn-error.log*
 
 # local env files
 .env*.local
+.env
 
 # vercel
 .vercel
@@ -35,11 +36,10 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 
-.vercel
-
 certificates
 
 plans/*
 !plans/.gitkeep
 
-.env
+# foglamp scan artifacts (editToken is a secret)
+.foglamp/


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add `.foglamp/` to `.gitignore` so foglamp codebase scan outputs (including the secret `editToken` in `scan.lock.json`) are never committed.
- Local scan data is prepared at `.foglamp/scan.json` for optional publish to foglamp.dev; that file stays gitignored.

## Test plan
- [ ] Confirm `git check-ignore -v .foglamp/scan.json` matches `.gitignore`
- [ ] Confirm `.gitignore` still ignores `.env` and `.vercel`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cd753d2b-f186-48c4-8824-761c8a20e0ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cd753d2b-f186-48c4-8824-761c8a20e0ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

