### PR TITLE
fix(sonar): c931f98e-c8aa-4762-a5e8-fd0fb587091d

### DIFF
--- a/src/app/_components/FlowEditor/__tests__/queryPlanToFlow.test.ts
+++ b/src/app/_components/FlowEditor/__tests__/queryPlanToFlow.test.ts
@@ -64,6 +64,11 @@ const pe = (source: string, target: string): QueryPlanV2Edge => ({
   target,
 })
 
+const sortPlanEdges = (edges: QueryPlanV2Edge[]) =>
+  [...edges].sort((a, b) =>
+    `${a.source}-${a.target}`.localeCompare(`${b.source}-${b.target}`),
+  )
+
 const v2 = (
   nodes: QueryPlanV2Node[],
   edges: QueryPlanV2Edge[],
@@ -588,11 +593,7 @@ describe('ラウンドトリップ（queryPlanToFlow ↔ flowToQueryPlanV2）', 
     const result = flowToQueryPlanV2(flow)
 
     // Assert
-    const sortEdges = (edges: { source: string; target: string }[]) =>
-      [...edges].sort((a, b) =>
-        `${a.source}-${a.target}`.localeCompare(`${b.source}-${b.target}`),
-      )
-    expect(sortEdges(result.edges)).toEqual(sortEdges(original.edges))
+    expect(sortPlanEdges(result.edges)).toEqual(sortPlanEdges(original.edges))
   })
 
   it('V2プラン → Flow → V2プランの変換で、各ノードのconfigが同一であること', () => {
@@ -634,11 +635,7 @@ describe('ラウンドトリップ（queryPlanToFlow ↔ flowToQueryPlanV2）', 
     expect(resultIds).toEqual(originalIds)
 
     // Assert — エッジ
-    const sortEdges = (edges: { source: string; target: string }[]) =>
-      [...edges].sort((a, b) =>
-        `${a.source}-${a.target}`.localeCompare(`${b.source}-${b.target}`),
-      )
-    expect(sortEdges(result.edges)).toEqual(sortEdges(original.edges))
+    expect(sortPlanEdges(result.edges)).toEqual(sortPlanEdges(original.edges))
 
     // Assert — ノード config
     for (const origNode of original.nodes) {


### PR DESCRIPTION
## SonarQube Fix Loop

- Issue: c931f98e-c8aa-4762-a5e8-fd0fb587091d
- Rule: typescript:S4144
- Component: WakuwakuP_miyulab-fe_2b9f1381-5c7d-4b89-8aca-9a9a897900dc:src/app/_components/FlowEditor/__tests__/queryPlanToFlow.test.ts
- Severity: Medium

Automated fix by Fix Loop Orchestrator.