### PR TITLE
fix(sonar): 3934fc48-d632-45e2-bfb4-c33a16ea30ab

### DIFF
--- a/src/util/db/query-ir/executor/graphExecutor.ts
+++ b/src/util/db/query-ir/executor/graphExecutor.ts
@@ -262,18 +262,23 @@ function runMergeNode(
   recordNodeStat(nodeStats, nodeId, nodeStart, false, output.rows.length)
 }
 
+type OutputNodeExecutionContext = {
+  db: DbExec
+  outputs: Map<string, NodeOutput>
+  nodeStats: Record<string, NodeStat>
+  options: GraphExecuteOptions
+  start: number
+  captureVersionsFn: () => Record<string, number>
+}
+
 function runOutputNode(
-  db: DbExec,
-  outputs: Map<string, NodeOutput>,
-  nodeStats: Record<string, NodeStat>,
+  context: OutputNodeExecutionContext,
   nodeId: string,
   node: OutputNodeV2,
   incoming: string[],
-  options: GraphExecuteOptions,
   nodeStart: number,
-  start: number,
-  captureVersionsFn: () => Record<string, number>,
 ): GraphExecuteResult {
+  const { db, outputs, nodeStats, options, start, captureVersionsFn } = context
   const firstInput = getFirstUpstreamOutput(incoming, outputs)
   if (!firstInput) {
     return buildEmptyGraphResult(nodeStats, outputs, start, captureVersionsFn)
@@ -373,16 +378,11 @@ export function executeGraphPlan(
         break
       case 'output-v2':
         return runOutputNode(
-          db,
-          outputs,
-          nodeStats,
+          { captureVersionsFn, db, nodeStats, options, outputs, start },
           nodeId,
           entry.node as OutputNodeV2,
           incoming,
-          options,
           nodeStart,
-          start,
-          captureVersionsFn,
         )
     }
   }


### PR DESCRIPTION
## SonarQube Fix Loop

- Issue: 3934fc48-d632-45e2-bfb4-c33a16ea30ab
- Rule: typescript:S107
- Component: WakuwakuP_miyulab-fe_2b9f1381-5c7d-4b89-8aca-9a9a897900dc:src/util/db/query-ir/executor/graphExecutor.ts
- Severity: Medium

Automated fix by Fix Loop Orchestrator.