### PR TITLE
fix: restore sqlite schema type compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ yarn-error.log*
 # local env files
 .env*.local
 
+# local scan metadata
+.foglamp/
+
 # vercel
 .vercel
 

--- a/src/util/db/sqlite/initSqlite.ts
+++ b/src/util/db/sqlite/initSqlite.ts
@@ -167,7 +167,23 @@ async function initMainThreadFallback(
 
   // スキーマ初期化
   const { ensureSchema } = await import('./schema')
-  ensureSchema({ db: rawDb })
+  // sqlite-wasm の exec は戻り値ごとの overload なので、
+  // スキーマ層が使う狭いインターフェースへ明示的に変換する。
+  const schemaDb: import('./worker/workerSchema').SchemaDbHandle['db'] = {
+    exec: (sql, opts) => {
+      if (opts?.returnValue === 'resultRows') {
+        return rawDb.exec(sql, {
+          bind: opts.bind,
+          returnValue: 'resultRows',
+        })
+      }
+      if (opts?.bind !== undefined) {
+        return rawDb.exec(sql, { bind: opts.bind })
+      }
+      return rawDb.exec(sql)
+    },
+  }
+  ensureSchema({ db: schemaDb })
 
   console.warn(
     'SQLite: using in-memory fallback (no Worker). Data will not persist.',


### PR DESCRIPTION
## Summary

- adapt sqlite-wasm's overloaded `exec` API to the narrow schema database contract
- ignore local `.foglamp/` scan metadata following the pre-PR Bugbot review

## Root cause

Vercel production deployments started failing after `c29393c27b` (PR #809), which removed the compatibility assertion around `ensureSchema({ db: rawDb })`.

The sqlite-wasm `Database.exec` method has return-value-specific overloads, so TypeScript cannot assign it directly to the schema layer's intentionally narrow `exec` interface. The first failed deployment and the latest failed deployment both report this same type error.

This change uses a small typed adapter that forwards the schema layer's supported options to the matching sqlite-wasm overload.

## Verification

- `yarn install --immutable`
- `yarn check`
- `yarn test:run` (88 files, 1,726 tests)
- `yarn build`
- Cursor Agent `/review-bugbot`: no bugs after fixing its one finding
- Cursor Agent `/review-security`: no issues
