### PR TITLE
fix(sonar): resolve all open findings

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,1 +1,2 @@
 sonar.projectKey=WakuwakuP_miyulab-fe_2b9f1381-5c7d-4b89-8aca-9a9a897900dc
+sonar.exclusions=src/zenstack/**

--- a/src/app/_components/DetailPanel.tsx
+++ b/src/app/_components/DetailPanel.tsx
@@ -36,7 +36,7 @@ const normalizeSearchQuery = (rawQuery: string): string => {
 
   try {
     const url = new URL(rawQuery)
-    const pathMatch = url.pathname.match(/^\/(?:@|users\/)([^/@]+)\/?$/)
+    const pathMatch = /^\/(?:@|users\/)([^/@]+)\/?$/.exec(url.pathname)
     if (pathMatch?.[1]) {
       return `${pathMatch[1]}@${url.host}`
     }

--- a/src/app/_components/FlowEditor/DebugResultPanel.tsx
+++ b/src/app/_components/FlowEditor/DebugResultPanel.tsx
@@ -2,9 +2,9 @@
 
 import type { DebugNodeResult, DebugResultItem } from './types'
 
-type Props = {
+type Props = Readonly<{
   nodeResults: DebugNodeResult[]
-}
+}>
 
 export function DebugResultPanel({ nodeResults }: Props) {
   if (nodeResults.length === 0) {
@@ -20,7 +20,9 @@ export function DebugResultPanel({ nodeResults }: Props) {
   )
 }
 
-function NodeSection({ nodeResult }: { nodeResult: DebugNodeResult }) {
+function NodeSection({
+  nodeResult,
+}: Readonly<{ nodeResult: DebugNodeResult }>) {
   const { items, nodeLabel } = nodeResult
   const postCount = items.filter((r) => r.table === 'posts').length
   const notifCount = items.filter((r) => r.table === 'notifications').length
@@ -53,9 +55,9 @@ function NodeSection({ nodeResult }: { nodeResult: DebugNodeResult }) {
 
 function PostRow({
   item,
-}: {
+}: Readonly<{
   item: Extract<DebugResultItem, { table: 'posts' }>
-}) {
+}>) {
   return (
     <div className="text-[10px] font-mono text-gray-300 flex items-start gap-1 leading-tight">
       <span className="shrink-0">{item.isReblog ? '🔁' : '📝'}</span>
@@ -72,9 +74,9 @@ function PostRow({
 
 function NotificationRow({
   item,
-}: {
+}: Readonly<{
   item: Extract<DebugResultItem, { table: 'notifications' }>
-}) {
+}>) {
   return (
     <div className="text-[10px] font-mono text-gray-300 flex items-start gap-1 leading-tight">
       <span className="shrink-0">🔔</span>

--- a/src/app/_components/FlowEditor/ExistsConditionRow.tsx
+++ b/src/app/_components/FlowEditor/ExistsConditionRow.tsx
@@ -12,12 +12,12 @@ import type { TableOption } from 'util/db/query-ir/completion'
 import type { ExistsCondition } from 'util/db/query-ir/nodes'
 import { EXISTS_MODES } from './flowNodePanelTypes'
 
-type ExistsConditionRowProps = {
+type ExistsConditionRowProps = Readonly<{
   filter: ExistsCondition
   existsTables: TableOption[]
   onUpdate: (f: ExistsCondition) => void
   onDelete: () => void
-}
+}>
 
 export function ExistsConditionRow({
   filter,

--- a/src/app/_components/FlowEditor/FilterConditionRow.tsx
+++ b/src/app/_components/FlowEditor/FilterConditionRow.tsx
@@ -27,13 +27,13 @@ import {
 import type { FlowNode } from './types'
 import { getNodeLabelV2 } from './types'
 
-type FilterConditionRowProps = {
+type FilterConditionRowProps = Readonly<{
   filter: FilterCondition
   flatColumns: FlatColumnOption[]
   upstreamNodes: FlowNode[]
   onUpdate: (f: FilterCondition) => void
   onDelete: () => void
-}
+}>
 
 export function FilterConditionRow({
   filter,

--- a/src/app/_components/FlowEditor/FlowCanvas.tsx
+++ b/src/app/_components/FlowEditor/FlowCanvas.tsx
@@ -205,7 +205,7 @@ export function FlowCanvas({
   onUpdateNodeData,
   viewportCenterRef,
   execStatus,
-}: FlowCanvasProps) {
+}: Readonly<FlowCanvasProps>) {
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null)
   const [didInitialFit, setDidInitialFit] = useState(false)
 

--- a/src/app/_components/FlowEditor/FlowNodePanel.tsx
+++ b/src/app/_components/FlowEditor/FlowNodePanel.tsx
@@ -18,7 +18,7 @@ export function FlowNodePanel({
   onUpdate,
   onDelete,
   onClose,
-}: FlowNodePanelProps) {
+}: Readonly<FlowNodePanelProps>) {
   const data = node.data as { nodeType: string }
 
   return (

--- a/src/app/_components/FlowEditor/FlowQueryEditorModal.tsx
+++ b/src/app/_components/FlowEditor/FlowQueryEditorModal.tsx
@@ -40,7 +40,6 @@ import {
 } from 'react'
 import type { TimelineConfigV2 } from 'types/types'
 import { topoSort } from 'util/db/query-ir/executor/topoSort'
-import type { SerializedGraphPlan } from 'util/db/query-ir/executor/types'
 import type { QueryPlanV2 } from 'util/db/query-ir/nodes'
 import { validateQueryPlanV2 } from 'util/db/query-ir/v2/validateV2'
 import { getSqliteDb } from 'util/db/sqlite'
@@ -68,17 +67,18 @@ import type {
   FlowExecStatus,
   FlowGraphState,
   FlowNode,
+  NodeExecState,
 } from './types'
 
 // --------------- Props ---------------
 
-type FlowQueryEditorModalProps = {
+type FlowQueryEditorModalProps = Readonly<{
   open: boolean
   onOpenChange: (open: boolean) => void
   /** 編集対象のタイムライン設定 */
   config: TimelineConfigV2
   onSave: (updates: Partial<TimelineConfigV2>) => void
-}
+}>
 
 // --------------- Component ---------------
 
@@ -255,7 +255,7 @@ export function FlowQueryEditorModal({
     }
 
     // 初期状態: 全ノード idle
-    const initStates: Record<string, 'idle' | 'running' | 'done' | 'error'> = {}
+    const initStates: Record<string, NodeExecState> = {}
     for (const nId of order) initStates[nId] = 'idle'
 
     setExecStatus({
@@ -280,14 +280,10 @@ export function FlowQueryEditorModal({
       const backendUrls = resolveBackendUrls(normalized, apps)
 
       const handle = await getSqliteDb()
-      const result = await handle.executeGraphPlan(
-        plan as unknown as SerializedGraphPlan,
-        { backendUrls },
-      )
+      const result = await handle.executeGraphPlan(plan, { backendUrls })
 
       // 結果から各ノードの状態を構築
-      const doneStates: Record<string, 'idle' | 'running' | 'done' | 'error'> =
-        {}
+      const doneStates: Record<string, NodeExecState> = {}
       for (const nId of order) {
         doneStates[nId] = result.meta.nodeStats[nId] ? 'done' : 'idle'
       }

--- a/src/app/_components/FlowEditor/GetIdsPanel.tsx
+++ b/src/app/_components/FlowEditor/GetIdsPanel.tsx
@@ -8,7 +8,7 @@ import {
   SelectValue,
 } from 'components/ui/select'
 import { Plus } from 'lucide-react'
-import { useEffect, useMemo, useRef } from 'react'
+import { useMemo } from 'react'
 import {
   getAllFilterableTables,
   getDefaultTimeColumn,
@@ -18,7 +18,6 @@ import {
   getOutputIdColumns,
   getTimeColumns,
 } from 'util/db/query-ir/completion'
-import { migrateInputBindings } from 'util/db/query-ir/migrateInputBindings'
 import type {
   ExistsCondition,
   FilterCondition,
@@ -30,12 +29,12 @@ import type { FlowNodePanelProps } from './flowNodePanelTypes'
 import { buildFlatColumns, isFilterCondition } from './flowNodePanelTypes'
 import type { FlowEdge, FlowNode, GetIdsFlowNodeData } from './types'
 
-type GetIdsPanelProps = {
+type GetIdsPanelProps = Readonly<{
   edges: FlowEdge[]
   node: FlowNode
   nodes: FlowNode[]
   onUpdate: FlowNodePanelProps['onUpdate']
-}
+}>
 
 export function GetIdsPanel({
   edges,
@@ -87,18 +86,6 @@ export function GetIdsPanel({
         .filter((n): n is FlowNode => n != null),
     [edges, nodes, node.id],
   )
-
-  // 旧 inputBindings → FilterCondition.upstreamSourceNodeId マイグレーション
-  const migratedRef = useRef(false)
-  useEffect(() => {
-    if (migratedRef.current) return
-    const bindings = data.config.inputBindings
-    if (!bindings || bindings.length === 0) return
-    migratedRef.current = true
-
-    const migrated = migrateInputBindings(data.config)
-    onUpdate(node.id, { ...data, config: migrated })
-  }, [data, node.id, onUpdate])
 
   function updateConfig(patch: Partial<typeof data.config>) {
     onUpdate(node.id, { ...data, config: { ...data.config, ...patch } })
@@ -160,8 +147,6 @@ export function GetIdsPanel({
         <Select
           onValueChange={(v) =>
             updateConfig({
-              inputBinding: undefined,
-              inputBindings: undefined,
               outputIdColumn: undefined,
               outputTimeColumn: undefined,
               table: v,

--- a/src/app/_components/FlowEditor/LookupRelatedPanel.tsx
+++ b/src/app/_components/FlowEditor/LookupRelatedPanel.tsx
@@ -31,12 +31,12 @@ function defaultTimeCondition(
   }
 }
 
-type LookupRelatedPanelProps = {
+type LookupRelatedPanelProps = Readonly<{
   edges: FlowEdge[]
   node: FlowNode
   nodes: FlowNode[]
   onUpdate: FlowNodePanelProps['onUpdate']
-}
+}>
 
 export function LookupRelatedPanel({
   edges,
@@ -331,9 +331,9 @@ export function LookupRelatedPanel({
                 </button>
                 <button
                   className={`rounded px-1.5 py-0.5 text-[10px] border transition-colors ${
-                    !data.config.timeCondition.afterInput
-                      ? 'bg-sky-900/50 border-sky-700 text-sky-300'
-                      : 'bg-gray-700 border-gray-600 text-gray-400'
+                    data.config.timeCondition.afterInput
+                      ? 'bg-gray-700 border-gray-600 text-gray-400'
+                      : 'bg-sky-900/50 border-sky-700 text-sky-300'
                   }`}
                   onClick={() => updateTimeCondition({ afterInput: false })}
                   type="button"
@@ -395,9 +395,9 @@ export function LookupRelatedPanel({
             <div className="flex gap-1">
               <button
                 className={`rounded px-1.5 py-0.5 text-[10px] border transition-colors ${
-                  data.config.perLimitOrder !== 'nearest'
-                    ? 'bg-sky-900/50 border-sky-700 text-sky-300'
-                    : 'bg-gray-700 border-gray-600 text-gray-400'
+                  data.config.perLimitOrder === 'nearest'
+                    ? 'bg-gray-700 border-gray-600 text-gray-400'
+                    : 'bg-sky-900/50 border-sky-700 text-sky-300'
                 }`}
                 onClick={() => updateConfig({ perLimitOrder: 'furthest' })}
                 type="button"

--- a/src/app/_components/FlowEditor/MergePanelV2.tsx
+++ b/src/app/_components/FlowEditor/MergePanelV2.tsx
@@ -10,10 +10,10 @@ import {
 import type { FlowNodePanelProps } from './flowNodePanelTypes'
 import type { FlowNode, MergeFlowNodeDataV2 } from './types'
 
-type MergePanelV2Props = {
+type MergePanelV2Props = Readonly<{
   node: FlowNode
   onUpdate: FlowNodePanelProps['onUpdate']
-}
+}>
 
 export function MergePanelV2({ node, onUpdate }: MergePanelV2Props) {
   const data = node.data as MergeFlowNodeDataV2

--- a/src/app/_components/FlowEditor/OutputPanelV2.tsx
+++ b/src/app/_components/FlowEditor/OutputPanelV2.tsx
@@ -10,10 +10,10 @@ import {
 import type { FlowNodePanelProps } from './flowNodePanelTypes'
 import type { FlowNode, OutputFlowNodeDataV2 } from './types'
 
-type OutputPanelV2Props = {
+type OutputPanelV2Props = Readonly<{
   node: FlowNode
   onUpdate: FlowNodePanelProps['onUpdate']
-}
+}>
 
 export function OutputPanelV2({ node, onUpdate }: OutputPanelV2Props) {
   const data = node.data as OutputFlowNodeDataV2

--- a/src/app/_components/FlowEditor/nodes/GetIdsFlowNode.tsx
+++ b/src/app/_components/FlowEditor/nodes/GetIdsFlowNode.tsx
@@ -24,7 +24,13 @@ export const GetIdsFlowNode = memo(function GetIdsFlowNode({
     [deleteNode, id],
   )
 
-  const bindings = data.config.inputBindings ?? []
+  const upstreamColumns = data.config.filters.flatMap((filter) =>
+    'column' in filter &&
+    'upstreamSourceNodeId' in filter &&
+    filter.upstreamSourceNodeId
+      ? [filter.column]
+      : [],
+  )
   const outputIdColumn = data.config.outputIdColumn
   const outputTimeColumn = data.config.outputTimeColumn
 
@@ -80,9 +86,9 @@ export const GetIdsFlowNode = memo(function GetIdsFlowNode({
             .join(', ')}
         </div>
       )}
-      {bindings.length > 0 && (
+      {upstreamColumns.length > 0 && (
         <div className="text-[10px] text-sky-400 mt-0.5">
-          ← {bindings.map((b) => b.column).join(', ')}
+          ← {upstreamColumns.join(', ')}
         </div>
       )}
       <NodeExecBadge execStatus={execStatus} nodeId={id} />

--- a/src/app/_components/FlowEditor/planHelpers.ts
+++ b/src/app/_components/FlowEditor/planHelpers.ts
@@ -2,6 +2,7 @@ import type { BackendFilter, TimelineConfigV2 } from 'types/types'
 import { resolveBackendUrlFromAccountId } from 'util/accountResolver'
 import type { ConfigToNodesContext } from 'util/db/query-ir/compat/configToNodes'
 import { configToQueryPlan } from 'util/db/query-ir/compat/configToNodes'
+import { migrateQueryPlanInputBindings } from 'util/db/query-ir/migrateInputBindings'
 import type { GetIdsFilter, QueryPlanV2 } from 'util/db/query-ir/nodes'
 import { isQueryPlanV2 } from 'util/db/query-ir/nodes'
 import { migrateQueryPlanV1ToV2 } from 'util/db/query-ir/v2/migrateV1ToV2'
@@ -40,16 +41,20 @@ export function createDefaultQueryPlanV2(): QueryPlanV2 {
 export function planFromConfig(config: TimelineConfigV2): QueryPlanV2 {
   if (config.queryPlan) {
     if (isQueryPlanV2(config.queryPlan)) {
-      return config.queryPlan
+      return migrateQueryPlanInputBindings(config.queryPlan)
     }
-    return migrateQueryPlanV1ToV2(config.queryPlan)
+    return migrateQueryPlanInputBindings(
+      migrateQueryPlanV1ToV2(config.queryPlan),
+    )
   }
   const ctx: ConfigToNodesContext = {
     localAccountIds: [],
     queryLimit: 50,
     serverIds: [],
   }
-  return migrateQueryPlanV1ToV2(configToQueryPlan(config, ctx))
+  return migrateQueryPlanInputBindings(
+    migrateQueryPlanV1ToV2(configToQueryPlan(config, ctx)),
+  )
 }
 
 // --------------- V2 plan analysis helpers ---------------

--- a/src/app/_components/GettingStarted.tsx
+++ b/src/app/_components/GettingStarted.tsx
@@ -76,7 +76,7 @@ function hashForReactKey(value: string): string {
   let hash = 0
 
   for (let i = 0; i < value.length; i++) {
-    hash = (hash << 5) - hash + value.charCodeAt(i)
+    hash = (hash << 5) - hash + (value.codePointAt(i) ?? 0)
     hash = Math.trunc(hash)
   }
 

--- a/src/app/_components/MainPanel.tsx
+++ b/src/app/_components/MainPanel.tsx
@@ -5,11 +5,13 @@ import { Dropzone } from 'app/_parts/Dropzone'
 import { Panel } from 'app/_parts/Panel'
 import { StatusRichTextarea } from 'app/_parts/StatusRichTextarea'
 import { UserInfo } from 'app/_parts/UserInfo'
+import parse from 'html-react-parser'
 import type { Entity } from 'megalodon'
 import { useCallback, useContext, useEffect, useState } from 'react'
 import { RiCloseCircleLine, RiPlayFill } from 'react-icons/ri'
 import { containsHashtag } from 'util/containsHashtag'
 import { replaceEmojis } from 'util/emojiReplacer'
+import { escapeHtml } from 'util/escapeHtml'
 import { GetClient } from 'util/GetClient'
 import { canPlay } from 'util/PlayerUtils'
 import { AppsContext } from 'util/provider/AppsProvider'
@@ -76,7 +78,7 @@ export const MainPanel = () => {
 
   const getDisplayNameFormatted = (account: Entity.Account) =>
     replaceEmojis(
-      account.display_name,
+      escapeHtml(account.display_name),
       account.emojis,
       'min-w-4 h-4 inline-block',
     )
@@ -269,12 +271,9 @@ export const MainPanel = () => {
                     />
                     <div>
                       <div>
-                        <span
-                          // biome-ignore lint/security/noDangerouslySetInnerHtml: emoji replacement
-                          dangerouslySetInnerHTML={{
-                            __html: getDisplayNameFormatted(replyTo.account),
-                          }}
-                        />
+                        <span>
+                          {parse(getDisplayNameFormatted(replyTo.account))}
+                        </span>
                       </div>
                     </div>
                   </div>
@@ -289,13 +288,7 @@ export const MainPanel = () => {
                     </button>
                   </div>
                 </div>
-                <div
-                  className="content p-2"
-                  // biome-ignore lint/security/noDangerouslySetInnerHtml: TODO:
-                  dangerouslySetInnerHTML={{
-                    __html: contentFormatted(),
-                  }}
-                />
+                <div className="content p-2">{parse(contentFormatted())}</div>
               </div>
             )}
           </div>

--- a/src/app/_components/NodeEditor/AddFilterMenu.tsx
+++ b/src/app/_components/NodeEditor/AddFilterMenu.tsx
@@ -370,10 +370,10 @@ export const PRESETS: Preset[] = [
 // Component
 // ---------------------------------------------------------------------------
 
-type AddFilterMenuProps = {
+type AddFilterMenuProps = Readonly<{
   onAddNode: (node: FilterNode) => void
   onApplyPreset: (nodes: FilterNode[]) => void
-}
+}>
 
 export function AddFilterMenu({
   onAddNode,

--- a/src/app/_components/NodeEditor/AerialReplyBody.tsx
+++ b/src/app/_components/NodeEditor/AerialReplyBody.tsx
@@ -28,10 +28,10 @@ const TIME_WINDOW_OPTIONS = [
 export function AerialReplyBody({
   node,
   onUpdate,
-}: {
+}: Readonly<{
   node: AerialReplyFilter
   onUpdate: (n: AerialReplyFilter) => void
-}) {
+}>) {
   const idPrefix = useId()
   const toggleType = useCallback(
     (key: string) => {

--- a/src/app/_components/NodeEditor/BackendFilterBody.tsx
+++ b/src/app/_components/NodeEditor/BackendFilterBody.tsx
@@ -9,11 +9,11 @@ export function BackendFilterBody({
   accounts,
   node,
   onUpdate,
-}: {
+}: Readonly<{
   accounts?: ReadonlyMap<string, ResolvedAccount>
   node: IRBackendFilter
   onUpdate: (n: IRBackendFilter) => void
-}) {
+}>) {
   const idPrefix = useId()
   const accountEntries = accounts ? [...accounts.entries()] : []
 

--- a/src/app/_components/NodeEditor/ExistsFilterBody.tsx
+++ b/src/app/_components/NodeEditor/ExistsFilterBody.tsx
@@ -23,10 +23,10 @@ const EXISTS_MODES = [
 export function ExistsFilterBody({
   node,
   onUpdate,
-}: {
+}: Readonly<{
   node: ExistsFilter
   onUpdate: (n: ExistsFilter) => void
-}) {
+}>) {
   const isCountMode = node.mode.startsWith('count-')
   const existsTableOptions = useMemo(() => getExistsFilterTables(), [])
 

--- a/src/app/_components/NodeEditor/NodeCard.tsx
+++ b/src/app/_components/NodeEditor/NodeCard.tsx
@@ -25,7 +25,7 @@ export function NodeCard({
   node,
   onRemove,
   onUpdate,
-}: NodeCardProps) {
+}: Readonly<NodeCardProps>) {
   const meta = getNodeMeta(node)
 
   const handleUpdate = useCallback(

--- a/src/app/_components/NodeEditor/NodeEditorPanel.tsx
+++ b/src/app/_components/NodeEditor/NodeEditorPanel.tsx
@@ -18,12 +18,12 @@ import { NodeCard } from './NodeCard'
 // Types
 // ---------------------------------------------------------------------------
 
-type NodeEditorPanelProps = {
+type NodeEditorPanelProps = Readonly<{
   /** 登録済みアカウント一覧 (BackendFilter 用) */
   accounts?: ReadonlyMap<string, ResolvedAccount>
   nodes: FilterNode[]
   onChange: (nodes: FilterNode[]) => void
-}
+}>
 
 type NodeKeyEntry = {
   key: string

--- a/src/app/_components/NodeEditor/RawSQLBody.tsx
+++ b/src/app/_components/NodeEditor/RawSQLBody.tsx
@@ -5,10 +5,10 @@ import type { RawSQLFilter } from 'util/db/query-ir/nodes'
 export function RawSQLBody({
   node,
   onUpdate,
-}: {
+}: Readonly<{
   node: RawSQLFilter
   onUpdate: (n: RawSQLFilter) => void
-}) {
+}>) {
   return (
     <textarea
       className="w-full rounded bg-gray-800 border border-gray-600 px-2 py-1 text-xs text-gray-200 font-mono resize-y min-h-[2.5rem]"

--- a/src/app/_components/NodeEditor/TableFilterBody.tsx
+++ b/src/app/_components/NodeEditor/TableFilterBody.tsx
@@ -36,10 +36,10 @@ const FILTER_OPS: { label: string; value: FilterOp }[] = [
 export function TableFilterBody({
   node,
   onUpdate,
-}: {
+}: Readonly<{
   node: TableFilter
   onUpdate: (n: TableFilter) => void
-}) {
+}>) {
   const isNullOp = node.op === 'IS NULL' || node.op === 'IS NOT NULL'
 
   // テーブル一覧

--- a/src/app/_components/NodeEditor/TimelineScopeBody.tsx
+++ b/src/app/_components/NodeEditor/TimelineScopeBody.tsx
@@ -14,10 +14,10 @@ const TIMELINE_KEYS = [
 export function TimelineScopeBody({
   node,
   onUpdate,
-}: {
+}: Readonly<{
   node: TimelineScope
   onUpdate: (n: TimelineScope) => void
-}) {
+}>) {
   const idPrefix = useId()
   const toggle = useCallback(
     (key: string) => {

--- a/src/app/_components/NodeEditor/ValueInput.tsx
+++ b/src/app/_components/NodeEditor/ValueInput.tsx
@@ -36,7 +36,7 @@ import type { FilterOp, FilterValue } from 'util/db/query-ir/nodes'
 // Types
 // ---------------------------------------------------------------------------
 
-type ValueInputProps = {
+type ValueInputProps = Readonly<{
   /** カラム名 */
   column: string
   /** カラム型 */
@@ -55,7 +55,7 @@ type ValueInputProps = {
   /** テーブル名 */
   table: string
   value: FilterValue
-}
+}>
 
 // ---------------------------------------------------------------------------
 // Async multi-select combobox (DB search backed)
@@ -68,7 +68,7 @@ function AsyncMultiCombobox({
   searchValues,
   table,
   value,
-}: {
+}: Readonly<{
   column: string
   onChange: (values: string[]) => void
   placeholder?: string
@@ -79,7 +79,7 @@ function AsyncMultiCombobox({
   ) => Promise<string[]>
   table: string
   value: string[]
-}) {
+}>) {
   const [searchResults, setSearchResults] = useState<string[]>([])
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -153,7 +153,7 @@ function AutocompleteInput({
   searchValues,
   table,
   value,
-}: {
+}: Readonly<{
   column: string
   onChange: (value: string) => void
   searchValues: (
@@ -163,7 +163,7 @@ function AutocompleteInput({
   ) => Promise<string[]>
   table: string
   value: string
-}) {
+}>) {
   const [searchResults, setSearchResults] = useState<string[]>([])
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -230,11 +230,11 @@ function StaticMultiCombobox({
   items,
   onChange,
   value,
-}: {
+}: Readonly<{
   items: string[]
   onChange: (values: string[]) => void
   value: string[]
-}) {
+}>) {
   return (
     <Combobox items={items} multiple onValueChange={onChange} value={value}>
       <ComboboxChips className="min-h-7 text-xs bg-gray-800 border-gray-600">
@@ -286,12 +286,12 @@ function KnownValuesInput({
   knownValues,
   onChange,
   value,
-}: {
+}: Readonly<{
   isArrayOp: boolean
   knownValues: string[]
   onChange: (value: FilterValue) => void
   value: FilterValue
-}) {
+}>) {
   if (isArrayOp) {
     const arrayVal = Array.isArray(value) ? (value as string[]) : []
     return (
@@ -326,14 +326,14 @@ function NumericValueInput({
   searchValues,
   table,
   value,
-}: {
+}: Readonly<{
   column: string
   isArrayOp: boolean
   onChange: (value: FilterValue) => void
   searchValues?: ValueInputProps['searchValues']
   table: string
   value: FilterValue
-}) {
+}>) {
   if (!isArrayOp) {
     return (
       <Input
@@ -385,14 +385,14 @@ function SearchValueInput({
   searchValues,
   table,
   value,
-}: {
+}: Readonly<{
   column: string
   isArrayOp: boolean
   onChange: (value: FilterValue) => void
   searchValues: NonNullable<ValueInputProps['searchValues']>
   table: string
   value: FilterValue
-}) {
+}>) {
   if (isArrayOp) {
     return (
       <AsyncMultiCombobox
@@ -420,11 +420,11 @@ function FallbackValueInput({
   isArrayOp,
   onChange,
   value,
-}: {
+}: Readonly<{
   isArrayOp: boolean
   onChange: (value: FilterValue) => void
   value: FilterValue
-}) {
+}>) {
   if (isArrayOp) {
     const arrayVal = toStringArray(value)
     return (

--- a/src/app/_components/UnifiedTimeline.tsx
+++ b/src/app/_components/UnifiedTimeline.tsx
@@ -28,13 +28,7 @@ export const UnifiedTimeline = ({
   headerOffset?: string
 }) => {
   const { data, hasMoreOlder, isLoadingOlder, loadOlder, queryDuration } =
-    useTimelineData(config) as {
-      data: StatusAddAppIndex[]
-      hasMoreOlder: boolean
-      isLoadingOlder: boolean
-      loadOlder: () => Promise<void>
-      queryDuration: number | null
-    }
+    useTimelineData(config)
   const { initializing } = useOtherQueueProgress()
 
   const displayName = useMemo(() => {

--- a/src/app/_parts/AccountFilterEditor.tsx
+++ b/src/app/_parts/AccountFilterEditor.tsx
@@ -6,10 +6,10 @@ import type { AccountFilter, AccountFilterMode } from 'types/types'
 export function AccountFilterEditor({
   onChange,
   value,
-}: {
+}: Readonly<{
   onChange: (filter: AccountFilter | undefined) => void
   value: AccountFilter | undefined
-}) {
+}>) {
   const [input, setInput] = useState('')
   const mode: AccountFilterMode = value?.mode ?? 'exclude'
   const accts = value?.accts ?? []

--- a/src/app/_parts/CollapsibleSection.tsx
+++ b/src/app/_parts/CollapsibleSection.tsx
@@ -6,11 +6,11 @@ export function CollapsibleSection({
   children,
   defaultOpen = false,
   title,
-}: {
+}: Readonly<{
   children: React.ReactNode
   defaultOpen?: boolean
   title: string
-}) {
+}>) {
   const [isOpen, setIsOpen] = useState(defaultOpen)
 
   return (

--- a/src/app/_parts/EmojiReactions.tsx
+++ b/src/app/_parts/EmojiReactions.tsx
@@ -31,7 +31,7 @@ export const EmojiReactions = ({
   const emojiUrlMap = useMemo(() => {
     const map = new Map<string, { url: string; static_url?: string }>()
     const statusApp =
-      status.appIndex != null ? apps[status.appIndex] : undefined
+      typeof status.appIndex === 'number' ? apps[status.appIndex] : undefined
     if (statusApp?.backendUrl) {
       const catalog = emojiCatalog.get(statusApp.backendUrl)
       const list = catalog && catalog.length > 0 ? catalog : emojiFallback

--- a/src/app/_parts/LanguageFilter.tsx
+++ b/src/app/_parts/LanguageFilter.tsx
@@ -15,10 +15,10 @@ const LANGUAGE_PRESETS = [
 export function LanguageFilter({
   onChange,
   value,
-}: {
+}: Readonly<{
   onChange: (filter: string[] | undefined) => void
   value: string[] | undefined
-}) {
+}>) {
   const [input, setInput] = useState('')
   const languages = value ?? []
 

--- a/src/app/_parts/Media.tsx
+++ b/src/app/_parts/Media.tsx
@@ -3,6 +3,32 @@ import type { HTMLProps } from 'react'
 import { RiPlayCircleLine } from 'react-icons/ri'
 import { toSecureResourceUrl } from 'util/secureResourceUrl'
 
+const toWellFormedText = (value: string): string => {
+  let result = ''
+  for (const character of value) {
+    const codePoint = character.codePointAt(0) ?? 0
+    if (codePoint >= 0xd800 && codePoint <= 0xdfff) {
+      result += '\uFFFD'
+    } else {
+      result += character
+    }
+  }
+  return result
+}
+
+const descriptionTrackUrl = (description: string): string => {
+  const cueText = toWellFormedText(description)
+    .replaceAll(/[\r\n]+/g, ' ')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+  const captions = `WEBVTT
+
+00:00:00.000 --> 99:59:59.999
+${cueText}`
+  return `data:text/vtt;charset=utf-8,${encodeURIComponent(captions)}`
+}
+
 export const Media = ({
   media,
   onClick,
@@ -107,7 +133,17 @@ export const Media = ({
     case 'audio':
       return (
         <div className={['relative h-16 p-0.5', className].join(' ')}>
-          <audio className="w-full" controls key={media.id} src={mediaUrl} />
+          <audio className="w-full" controls key={media.id} src={mediaUrl}>
+            {media.description && (
+              <track
+                default
+                kind="descriptions"
+                label="Attachment description"
+                src={descriptionTrackUrl(media.description)}
+                srcLang="und"
+              />
+            )}
+          </audio>
           <button
             aria-label={media.description || 'Open audio media'}
             className="absolute left-0 top-0 z-1 h-full w-full border-0 bg-transparent p-0"

--- a/src/app/_parts/MediaFilterControls.tsx
+++ b/src/app/_parts/MediaFilterControls.tsx
@@ -5,10 +5,10 @@ import type { TimelineConfigV2 } from 'types/types'
 export function MediaFilterControls({
   config,
   onChange,
-}: {
+}: Readonly<{
   config: TimelineConfigV2
   onChange: (updates: Partial<TimelineConfigV2>) => void
-}) {
+}>) {
   return (
     <div className="space-y-1">
       <label className="flex items-center space-x-2 cursor-pointer text-xs">

--- a/src/app/_parts/MuteBlockControls.tsx
+++ b/src/app/_parts/MuteBlockControls.tsx
@@ -7,12 +7,12 @@ export function MuteBlockControls({
   onChange,
   onOpenBlockManager,
   onOpenMuteManager,
-}: {
+}: Readonly<{
   config: TimelineConfigV2
   onChange: (updates: Partial<TimelineConfigV2>) => void
   onOpenBlockManager: () => void
   onOpenMuteManager: () => void
-}) {
+}>) {
   return (
     <div className="space-y-1">
       <label className="flex items-center gap-2 text-xs cursor-pointer">

--- a/src/app/_parts/Notification.tsx
+++ b/src/app/_parts/Notification.tsx
@@ -3,12 +3,14 @@
 import { ProxyImage } from 'app/_parts/ProxyImage'
 import { Status } from 'app/_parts/Status'
 
+import parse from 'html-react-parser'
 import * as emoji from 'node-emoji'
 import type { KeyboardEvent } from 'react'
 import { useContext, useMemo } from 'react'
 import { RiStarFill } from 'react-icons/ri'
 import type { NotificationAddAppIndex, StatusAddAppIndex } from 'types/types'
 import { replaceEmojis } from 'util/emojiReplacer'
+import { escapeHtml } from 'util/escapeHtml'
 import { AppsContext } from 'util/provider/AppsProvider'
 import { SetDetailContext } from 'util/provider/DetailProvider'
 import {
@@ -113,7 +115,7 @@ export const Notification = ({
   const displayName = useMemo(() => {
     if (notification.account == null) return ''
     return replaceEmojis(
-      notification.account.display_name,
+      escapeHtml(notification.account.display_name),
       notification.account.emojis,
     )
   }, [notification.account])
@@ -193,12 +195,7 @@ export const Notification = ({
               )}
               <span className="w-[calc(100%-56px)] pl-2">
                 <span className="block w-full truncate">
-                  <span
-                    // biome-ignore lint/security/noDangerouslySetInnerHtml: TODO
-                    dangerouslySetInnerHTML={{
-                      __html: displayName,
-                    }}
-                  />
+                  <span>{parse(displayName)}</span>
                 </span>
                 <span
                   className="block w-full truncate text-gray-300"
@@ -247,12 +244,7 @@ export const Notification = ({
               )}
               <span className="w-[calc(100%-56px)] pl-2">
                 <span className="block w-full truncate">
-                  <span
-                    // biome-ignore lint/security/noDangerouslySetInnerHtml: TODO
-                    dangerouslySetInnerHTML={{
-                      __html: displayName,
-                    }}
-                  />
+                  <span>{parse(displayName)}</span>
                 </span>
                 <span
                   className="block w-full truncate text-gray-300"
@@ -304,12 +296,7 @@ export const Notification = ({
               )}
               <span className="w-[calc(100%-56px)] pl-2">
                 <span className="block w-full truncate">
-                  <span
-                    // biome-ignore lint/security/noDangerouslySetInnerHtml: TODO
-                    dangerouslySetInnerHTML={{
-                      __html: displayName,
-                    }}
-                  />
+                  <span>{parse(displayName)}</span>
                 </span>
                 <span
                   className="block w-full truncate text-gray-300"
@@ -366,12 +353,7 @@ export const Notification = ({
               )}
               <span className="w-[calc(100%-56px)] pl-2">
                 <span className="block w-full truncate">
-                  <span
-                    // biome-ignore lint/security/noDangerouslySetInnerHtml: TODO
-                    dangerouslySetInnerHTML={{
-                      __html: displayName,
-                    }}
-                  />
+                  <span>{parse(displayName)}</span>
                 </span>
                 <span
                   className="block w-full truncate text-gray-300"
@@ -409,12 +391,7 @@ export const Notification = ({
               )}
               <span className="w-[calc(100%-56px)] pl-2">
                 <span className="block w-full truncate">
-                  <span
-                    // biome-ignore lint/security/noDangerouslySetInnerHtml: TODO
-                    dangerouslySetInnerHTML={{
-                      __html: displayName,
-                    }}
-                  />
+                  <span>{parse(displayName)}</span>
                 </span>
                 <span
                   className="block w-full truncate text-gray-300"

--- a/src/app/_parts/NotificationTypeFilter.tsx
+++ b/src/app/_parts/NotificationTypeFilter.tsx
@@ -19,10 +19,10 @@ const NOTIFICATION_TYPE_OPTIONS: {
 export function NotificationTypeFilter({
   onChange,
   value,
-}: {
+}: Readonly<{
   onChange: (filter: NotificationType[] | undefined) => void
   value: NotificationType[] | undefined
-}) {
+}>) {
   // 未設定 = 全てオフ状態（通知を取得しない）
   const selected: NotificationType[] = value ?? []
 

--- a/src/app/_parts/Panel.tsx
+++ b/src/app/_parts/Panel.tsx
@@ -20,9 +20,9 @@ export const Panel = ({
   const ref = useRef<HTMLDivElement>(null)
   const offset = headerOffset ?? '0px'
   const mainAreaHeight =
-    name === undefined
-      ? `calc(100vh - 0.75rem - ${offset})`
-      : `calc(100vh - 0.75rem - 2rem - ${offset})`
+    name !== undefined
+      ? `calc(100vh - 0.75rem - 2rem - ${offset})`
+      : `calc(100vh - 0.75rem - ${offset})`
 
   const durationTitle =
     queryDuration != null ? `Query: ${queryDuration.toFixed(2)} ms` : undefined

--- a/src/app/_parts/Poll.tsx
+++ b/src/app/_parts/Poll.tsx
@@ -71,9 +71,7 @@ export const Poll = ({
     <div className="p-2">
       <div>
         {poll.options.map((option, index) => {
-          const barRedChannel = selected?.some((s) => s === index)
-            ? '255'
-            : '59'
+          const barRedChannel = selected.includes(index) ? '255' : '59'
           const fallbackBackground =
             'linear-gradient(rgba(255,255,255,0.1) 0%, rgba(255,255,255,0.1) 100%)'
           let backgroundImage = fallbackBackground

--- a/src/app/_parts/Status.tsx
+++ b/src/app/_parts/Status.tsx
@@ -19,6 +19,7 @@ import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import { RiRepeatFill, RiVideoLine } from 'react-icons/ri'
 import type { PollAddAppIndex, StatusAddAppIndex } from 'types/types'
 import { replaceEmojis } from 'util/emojiReplacer'
+import { escapeHtml } from 'util/escapeHtml'
 import { canPlay } from 'util/PlayerUtils'
 import { AppsContext } from 'util/provider/AppsProvider'
 import { SetDetailContext } from 'util/provider/DetailProvider'
@@ -118,7 +119,7 @@ export const Status = ({
 
   const getDisplayName = useCallback(
     (account: Entity.Account) =>
-      replaceEmojis(account.display_name, account.emojis),
+      replaceEmojis(escapeHtml(account.display_name), account.emojis),
     [],
   )
 
@@ -355,13 +356,7 @@ export const Status = ({
               loading="lazy"
               src={toSecureResourceUrl(status.account.avatar)}
             />
-            <span
-              className="pl-2 whitespace-nowrap"
-              // biome-ignore lint/security/noDangerouslySetInnerHtml: TODO
-              dangerouslySetInnerHTML={{
-                __html: displayName,
-              }}
-            />
+            <span className="pl-2 whitespace-nowrap">{parse(displayName)}</span>
           </button>
           <UserInfo
             account={{

--- a/src/app/_parts/StatusRichTextarea.tsx
+++ b/src/app/_parts/StatusRichTextarea.tsx
@@ -233,7 +233,7 @@ export const StatusRichTextarea = ({
   const emojiMatch = pos ? EMOJI_REG.exec(targetText) : null
   const tagMatch = pos !== null ? TAG_REG.exec(targetText) : null
 
-  const mentionName = mentionMatch == null ? '' : mentionMatch[1]
+  const mentionName = mentionMatch?.[1] ?? ''
   const emojiName = emojiMatch?.[1] ?? ''
 
   const tagName = tagMatch?.[1] ?? ''

--- a/src/app/_parts/TimelineTypeSelector.tsx
+++ b/src/app/_parts/TimelineTypeSelector.tsx
@@ -15,11 +15,11 @@ export function TimelineTypeSelector({
   configType,
   onChange,
   value,
-}: {
+}: Readonly<{
   configType: TimelineConfigV2['type']
   onChange: (types: StatusTimelineType[] | undefined) => void
   value: StatusTimelineType[] | undefined
-}) {
+}>) {
   // 未設定時は config.type から推定
   const defaultTypes: StatusTimelineType[] =
     configType === 'home' || configType === 'local' || configType === 'public'

--- a/src/app/_parts/ToggleFilters.tsx
+++ b/src/app/_parts/ToggleFilters.tsx
@@ -35,10 +35,10 @@ const TOGGLE_FILTERS: {
 export function ToggleFilters({
   config,
   onChange,
-}: {
+}: Readonly<{
   config: TimelineConfigV2
   onChange: (updates: Partial<TimelineConfigV2>) => void
-}) {
+}>) {
   return (
     <div className="space-y-1">
       {TOGGLE_FILTERS.map((filter) => {

--- a/src/app/_parts/UserInfo.tsx
+++ b/src/app/_parts/UserInfo.tsx
@@ -4,11 +4,13 @@
 import { ProxyImage } from 'app/_parts/ProxyImage'
 import { Visibility } from 'app/_parts/Visibility'
 
+import parse from 'html-react-parser'
 import type { Entity } from 'megalodon'
 import { useContext, useMemo } from 'react'
 import { RiRobotFill } from 'react-icons/ri'
 import type { AccountAddAppIndex } from 'types/types'
 import { replaceEmojis } from 'util/emojiReplacer'
+import { escapeHtml } from 'util/escapeHtml'
 import { SetDetailContext } from 'util/provider/DetailProvider'
 
 export const UserInfo = ({
@@ -26,7 +28,7 @@ export const UserInfo = ({
   const getDisplayName = useMemo(
     () =>
       replaceEmojis(
-        account.display_name,
+        escapeHtml(account.display_name),
         account.emojis,
         'min-w-5 h-5 inline-block',
       ),
@@ -82,12 +84,7 @@ export const UserInfo = ({
           <span className="block w-[calc(100%-24px)] pl-2">
             <span className="flex w-full justify-between truncate">
               <span>
-                <span
-                  // biome-ignore lint/security/noDangerouslySetInnerHtml: TODO
-                  dangerouslySetInnerHTML={{
-                    __html: getDisplayName,
-                  }}
-                />
+                <span>{parse(getDisplayName)}</span>
                 <span className="pl-1 text-gray-300">@{account.acct}</span>
               </span>
               <Visibility visibility={visibility} />
@@ -96,13 +93,7 @@ export const UserInfo = ({
         ) : (
           <span className="block w-[calc(100%-46px)] pl-2">
             <span className="flex w-full justify-between [&>span]:inline-block">
-              <span
-                className="truncate"
-                // biome-ignore lint/security/noDangerouslySetInnerHtml: TODO
-                dangerouslySetInnerHTML={{
-                  __html: getDisplayName,
-                }}
-              />
+              <span className="truncate">{parse(getDisplayName)}</span>
               <Visibility visibility={visibility} />
             </span>
             <span

--- a/src/app/_parts/VisibilityFilter.tsx
+++ b/src/app/_parts/VisibilityFilter.tsx
@@ -12,10 +12,10 @@ const VISIBILITY_OPTIONS: { label: string; value: VisibilityType }[] = [
 export function VisibilityFilter({
   onChange,
   value,
-}: {
+}: Readonly<{
   onChange: (filter: VisibilityType[] | undefined) => void
   value: VisibilityType[] | undefined
-}) {
+}>) {
   // 未設定 = 全て選択状態
   const selected: VisibilityType[] = value ?? [
     'public',

--- a/src/util/__tests__/attachmentProxy.test.ts
+++ b/src/util/__tests__/attachmentProxy.test.ts
@@ -1,4 +1,4 @@
-import { lookup } from 'node:dns/promises'
+import type { LookupAddress } from 'node:dns'
 import {
   createProxyAccessToken,
   getAttachmentProxyAllowedDomains,
@@ -11,19 +11,24 @@ import {
 } from 'util/attachmentProxy'
 import { describe, expect, it, vi } from 'vitest'
 
-vi.mock('node:dns/promises', () => ({
-  lookup: vi.fn(),
-}))
+type LookupAll = (
+  hostname: string,
+  options: { all: true; verbatim?: boolean },
+) => Promise<LookupAddress[]>
 
-const mockedLookup = vi.mocked(lookup)
+const mockedLookup = vi.hoisted(() => vi.fn<LookupAll>())
+
+vi.mock('node:dns/promises', () => ({
+  lookup: mockedLookup,
+}))
 
 describe('attachmentProxy', () => {
   describe('isPrivateHost', () => {
     it('IPv4 loopbackとプライベートアドレスを拒否する', () => {
       expect(isPrivateHost('localhost')).toBe(true)
       expect(isPrivateHost('127.0.0.1')).toBe(true)
-      expect(isPrivateHost('10.0.0.1')).toBe(true)
-      expect(isPrivateHost('192.168.1.1')).toBe(true)
+      expect(isPrivateHost('10.0.0.1')).toBe(true) // NOSONAR -- SSRF boundary fixture.
+      expect(isPrivateHost('192.168.1.1')).toBe(true) // NOSONAR -- SSRF boundary fixture.
     })
 
     it('IPv6 loopbackを拒否する', () => {
@@ -32,14 +37,14 @@ describe('attachmentProxy', () => {
     })
 
     it('IPv4-mapped IPv6 loopbackを拒否する', () => {
-      expect(isPrivateHost('::ffff:127.0.0.1')).toBe(true)
+      expect(isPrivateHost('::ffff:127.0.0.1')).toBe(true) // NOSONAR -- SSRF boundary fixture.
       expect(isPrivateHost('[::ffff:127.0.0.1]')).toBe(true)
     })
 
     it('IPv6 link-localとULAを拒否する', () => {
-      expect(isPrivateHost('fe80::1')).toBe(true)
-      expect(isPrivateHost('fd12:3456:789a:1::1')).toBe(true)
-      expect(isPrivateHost('fc00::1')).toBe(true)
+      expect(isPrivateHost('fe80::1')).toBe(true) // NOSONAR -- SSRF boundary fixture.
+      expect(isPrivateHost('fd12:3456:789a:1::1')).toBe(true) // NOSONAR -- SSRF boundary fixture.
+      expect(isPrivateHost('fc00::1')).toBe(true) // NOSONAR -- SSRF boundary fixture.
     })
 
     it('公開ホストを許可する', () => {
@@ -55,21 +60,25 @@ describe('attachmentProxy', () => {
 
   describe('isPrivateHostWithDns', () => {
     it('DNS解決後にプライベートIPへ解決するドメインを拒否する', async () => {
-      mockedLookup.mockResolvedValue([{ address: '10.0.0.1', family: 4 }])
+      mockedLookup.mockResolvedValue([
+        { address: '10.0.0.1', family: 4 }, // NOSONAR -- SSRF fixture.
+      ])
 
       await expect(isPrivateHostWithDns('cdn.example.com')).resolves.toBe(true)
     })
 
     it('DNS解決後に公開IPへ解決するドメインを許可する', async () => {
-      mockedLookup.mockResolvedValue([{ address: '93.184.216.34', family: 4 }])
+      mockedLookup.mockResolvedValue([
+        { address: '93.184.216.34', family: 4 }, // NOSONAR -- DNS fixture.
+      ])
 
       await expect(isPrivateHostWithDns('cdn.example.com')).resolves.toBe(false)
     })
 
     it('DNS解決結果にプライベートIPが含まれる場合は拒否する', async () => {
       mockedLookup.mockResolvedValue([
-        { address: '93.184.216.34', family: 4 },
-        { address: '192.168.1.1', family: 4 },
+        { address: '93.184.216.34', family: 4 }, // NOSONAR -- DNS fixture.
+        { address: '192.168.1.1', family: 4 }, // NOSONAR -- SSRF fixture.
       ])
 
       await expect(isPrivateHostWithDns('cdn.example.com')).resolves.toBe(true)
@@ -84,7 +93,9 @@ describe('attachmentProxy', () => {
     it('リテラルIPにはDNS解決を行わない', async () => {
       mockedLookup.mockClear()
 
-      await expect(isPrivateHostWithDns('93.184.216.34')).resolves.toBe(false)
+      await expect(
+        isPrivateHostWithDns('93.184.216.34'), // NOSONAR -- DNS bypass fixture.
+      ).resolves.toBe(false)
       expect(mockedLookup).not.toHaveBeenCalled()
     })
   })

--- a/src/util/attachmentProxy.ts
+++ b/src/util/attachmentProxy.ts
@@ -31,12 +31,12 @@ function isPrivateIpv6(hostname: string): boolean {
 
   if (host === '::1') return true
 
-  const ipv4Mapped = host.match(/^::ffff:(.+)$/i)
+  const ipv4Mapped = /^::ffff:(.+)$/i.exec(host)
   if (ipv4Mapped) {
     const mapped = ipv4Mapped[1]
     if (mapped.includes('.')) {
       if (isPrivateIpv4(mapped)) return true
-    } else if (mapped.replace(/:/g, '').toLowerCase() === '7f001') {
+    } else if (mapped.replaceAll(':', '').toLowerCase() === '7f001') {
       return true
     }
   }
@@ -149,7 +149,7 @@ function timingSafeEqualString(a: string, b: string): boolean {
   if (a.length !== b.length) return false
   let mismatch = 0
   for (let i = 0; i < a.length; i++) {
-    mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i)
+    mismatch |= (a.codePointAt(i) ?? 0) ^ (b.codePointAt(i) ?? 0)
   }
   return mismatch === 0
 }
@@ -172,8 +172,11 @@ async function hmacSha256Base64Url(
   )
   const bytes = new Uint8Array(signature)
   let binary = ''
-  for (const byte of bytes) binary += String.fromCharCode(byte)
-  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+  for (const byte of bytes) binary += String.fromCodePoint(byte)
+  return btoa(binary)
+    .replaceAll('+', '-')
+    .replaceAll('/', '_')
+    .replace(/=+$/, '')
 }
 
 export async function createProxyAccessToken(): Promise<string | null> {

--- a/src/util/db/query-ir/__tests__/flatFetchAssembler.test.ts
+++ b/src/util/db/query-ir/__tests__/flatFetchAssembler.test.ts
@@ -5,6 +5,8 @@ import {
   assemblePostFromFlat,
 } from '../executor/flatFetchAssembler'
 
+type SqlValue = string | number | null
+
 // ================================================================
 // ヘルパー
 // ================================================================
@@ -55,8 +57,8 @@ function makePostRow(
     spoilerText: string
     visibility: string
   }> = {},
-): (string | number | null)[] {
-  const row: (string | number | null)[] = new Array(30).fill(null)
+): SqlValue[] {
+  const row: SqlValue[] = new Array(30).fill(null)
   row[0] = postId
   row[1] = overrides.objectUri ?? `https://example.com/objects/${postId}`
   row[2] = null // canonical_url
@@ -113,8 +115,8 @@ function makeNotifRow(
     reactionUrl: string | null
     relatedPostId: number | null
   }> = {},
-): (string | number | null)[] {
-  const row: (string | number | null)[] = new Array(19).fill(null)
+): SqlValue[] {
+  const row: SqlValue[] = new Array(19).fill(null)
   row[0] = id
   row[1] = overrides.localAccountId ?? 1
   row[2] = overrides.localId ?? `notif_${id}`
@@ -383,11 +385,13 @@ describe('assembleNotificationFromFlat', () => {
       })
       const result = assembleNotificationFromFlat(row, new Map(), new Map())
 
-      expect(result.account.acct).toBe('bob@mastodon.social')
-      expect(result.account.username).toBe('bob')
-      expect(result.account.display_name).toBe('Bob')
-      expect(result.account.avatar).toBe('https://example.com/bob.png')
-      expect(result.account.bot).toBe(false)
+      expect(result.account).toMatchObject({
+        acct: 'bob@mastodon.social',
+        avatar: 'https://example.com/bob.png',
+        bot: false,
+        display_name: 'Bob',
+        username: 'bob',
+      })
     })
 
     it('アクター絵文字Map にデータがあれば emojis がパースされる', () => {
@@ -411,8 +415,8 @@ describe('assembleNotificationFromFlat', () => {
         actorEmojisMap,
       )
 
-      expect(result.account.emojis).toHaveLength(1)
-      expect(result.account.emojis[0].shortcode).toBe('partyblob')
+      expect(result.account?.emojis).toHaveLength(1)
+      expect(result.account?.emojis[0].shortcode).toBe('partyblob')
     })
   })
 
@@ -428,7 +432,7 @@ describe('assembleNotificationFromFlat', () => {
       const result = assembleNotificationFromFlat(row, postMap, new Map())
 
       expect(result.status).toBeDefined()
-      expect((result.status as { post_id: number }).post_id).toBe(50)
+      expect(Reflect.get(result.status ?? {}, 'post_id')).toBe(50)
     })
 
     it('related_post_id が null の場合、status は undefined', () => {

--- a/src/util/db/query-ir/__tests__/flatFetchExecutor.test.ts
+++ b/src/util/db/query-ir/__tests__/flatFetchExecutor.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it, vi } from 'vitest'
 import { executeFlatFetch } from '../executor/flatFetchExecutor'
 import type { FlatFetchRequest } from '../executor/flatFetchTypes'
 
+type SqlValue = string | number | null
+
 // ================================================================
 // ヘルパー
 // ================================================================
@@ -12,8 +14,8 @@ import type { FlatFetchRequest } from '../executor/flatFetchTypes'
 function makePostRow(
   postId: number,
   overrides: Partial<{ reblogOfPostId: number | null }> = {},
-): (string | number | null)[] {
-  const row: (string | number | null)[] = new Array(30).fill(null)
+): SqlValue[] {
+  const row: SqlValue[] = new Array(30).fill(null)
   row[0] = postId
   row[1] = `https://example.com/objects/${postId}`
   row[3] = '<p>test</p>'
@@ -21,7 +23,7 @@ function makePostRow(
   row[7] = 0
   row[8] = ''
   row[10] = overrides.reblogOfPostId ?? null
-  row[11] = overrides.reblogOfPostId != null ? 1 : 0
+  row[11] = overrides.reblogOfPostId == null ? 0 : 1
   row[13] = 'public'
   row[14] = 100 + postId
   row[15] = `user${postId}@example.com`
@@ -50,8 +52,8 @@ function makeNotifRow(
     actorProfileId: number | null
     relatedPostId: number | null
   }> = {},
-): (string | number | null)[] {
-  const row: (string | number | null)[] = new Array(19).fill(null)
+): SqlValue[] {
+  const row: SqlValue[] = new Array(19).fill(null)
   row[0] = id
   row[1] = 1
   row[2] = `notif_${id}`
@@ -75,7 +77,7 @@ function makeNotifRow(
 /**
  * db.exec モック — 呼び出し順にレスポンスを返す
  */
-function mockDb(responses: Record<number, (string | number | null)[][]> = {}) {
+function mockDb(responses: Record<number, SqlValue[][]> = {}) {
   const calls: { bind: unknown[]; sql: string }[] = []
   let callIndex = 0
   return {
@@ -83,8 +85,8 @@ function mockDb(responses: Record<number, (string | number | null)[][]> = {}) {
     exec: vi.fn(
       (sql: string, opts: { bind?: unknown[]; returnValue?: string }) => {
         const idx = callIndex++
-        calls.push({ bind: (opts.bind ?? []) as unknown[], sql })
-        return responses[idx] ?? ([] as (string | number | null)[][])
+        calls.push({ bind: opts.bind ?? [], sql })
+        return responses[idx] ?? []
       },
     ),
   }
@@ -232,7 +234,7 @@ describe('executeFlatFetch', () => {
       expect(result.posts.has(99)).toBe(true)
       const reblogStatus = result.posts.get(1)
       expect(reblogStatus?.reblog).not.toBeNull()
-      expect((reblogStatus?.reblog as { post_id: number })?.post_id).toBe(99)
+      expect(Reflect.get(reblogStatus?.reblog ?? {}, 'post_id')).toBe(99)
     })
 
     it('reblog_of_post_id が入力 postIds に含まれる場合、追加クエリは不要', () => {
@@ -260,7 +262,7 @@ describe('executeFlatFetch', () => {
 
       const notif = result.notifications.get(10)
       expect(notif?.status).toBeDefined()
-      expect((notif.status as { post_id: number }).post_id).toBe(50)
+      expect(Reflect.get(notif?.status ?? {}, 'post_id')).toBe(50)
     })
   })
 

--- a/src/util/db/query-ir/__tests__/migrateInputBindings.test.ts
+++ b/src/util/db/query-ir/__tests__/migrateInputBindings.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { migrateInputBindings } from '../migrateInputBindings'
-import type { FilterCondition, GetIdsNode } from '../nodes'
+import {
+  migrateInputBindings,
+  migrateQueryPlanInputBindings,
+} from '../migrateInputBindings'
+import type { FilterCondition, GetIdsNode, QueryPlanV2 } from '../nodes'
 
 type GetIdsConfig = Pick<
   GetIdsNode,
@@ -279,7 +282,7 @@ describe('migrateInputBindings', () => {
       const result = migrateInputBindings(config)
 
       // Assert
-      expect(result.inputBindings).toBeUndefined()
+      expect(Reflect.get(result, 'inputBindings')).toBeUndefined()
     })
 
     it('変換後に inputBinding が undefined になること', () => {
@@ -295,7 +298,7 @@ describe('migrateInputBindings', () => {
       const result = migrateInputBindings(config)
 
       // Assert
-      expect(result.inputBinding).toBeUndefined()
+      expect(Reflect.get(result, 'inputBinding')).toBeUndefined()
     })
 
     it('旧 inputBinding (column のみ) がある場合もクリアされること', () => {
@@ -311,8 +314,8 @@ describe('migrateInputBindings', () => {
       const result = migrateInputBindings(config)
 
       // Assert
-      expect(result.inputBinding).toBeUndefined()
-      expect(result.inputBindings).toBeUndefined()
+      expect(Reflect.get(result, 'inputBinding')).toBeUndefined()
+      expect(Reflect.get(result, 'inputBindings')).toBeUndefined()
     })
 
     it('inputBindings が空配列の場合でも inputBindings と inputBinding がクリアされること', () => {
@@ -328,8 +331,8 @@ describe('migrateInputBindings', () => {
       const result = migrateInputBindings(config)
 
       // Assert
-      expect(result.inputBindings).toBeUndefined()
-      expect(result.inputBinding).toBeUndefined()
+      expect(Reflect.get(result, 'inputBindings')).toBeUndefined()
+      expect(Reflect.get(result, 'inputBinding')).toBeUndefined()
     })
   })
 
@@ -382,6 +385,69 @@ describe('migrateInputBindings', () => {
     expect(originalFilter.op).toBe('=')
     expect(originalFilter.value).toBe('123')
     expect(originalFilter.upstreamSourceNodeId).toBeUndefined()
-    expect(config.inputBindings).toHaveLength(1)
+    expect(Reflect.get(config, 'inputBindings')).toHaveLength(1)
+  })
+})
+
+describe('migrateQueryPlanInputBindings', () => {
+  it('プラン内のすべての GetIds ノードを移行し、他のノードを維持すること', () => {
+    const outputNode: QueryPlanV2['nodes'][number] = {
+      id: 'output',
+      node: {
+        kind: 'output-v2',
+        pagination: { limit: 20 },
+        sort: { direction: 'DESC', field: 'created_at_ms' },
+      },
+    }
+    const plan: QueryPlanV2 = {
+      edges: [
+        { source: 'source-1', target: 'output' },
+        { source: 'source-2', target: 'output' },
+      ],
+      nodes: [
+        {
+          id: 'source-1',
+          node: {
+            filters: [],
+            inputBindings: [{ column: 'user_id', sourceNodeId: 'upstream-1' }],
+            kind: 'get-ids',
+            table: 'posts',
+          },
+        },
+        {
+          id: 'source-2',
+          node: {
+            filters: [],
+            inputBindings: [
+              { column: 'account_id', sourceNodeId: 'upstream-2' },
+            ],
+            kind: 'get-ids',
+            table: 'notifications',
+          },
+        },
+        outputNode,
+      ],
+      version: 2,
+    }
+
+    const result = migrateQueryPlanInputBindings(plan)
+
+    const firstSource = result.nodes[0]?.node
+    const secondSource = result.nodes[1]?.node
+    expect(firstSource?.kind).toBe('get-ids')
+    expect(secondSource?.kind).toBe('get-ids')
+    if (firstSource?.kind !== 'get-ids' || secondSource?.kind !== 'get-ids') {
+      throw new Error('Expected GetIds nodes')
+    }
+    expect(firstSource.filters[0]).toMatchObject({
+      column: 'user_id',
+      upstreamSourceNodeId: 'upstream-1',
+    })
+    expect(secondSource.filters[0]).toMatchObject({
+      column: 'account_id',
+      upstreamSourceNodeId: 'upstream-2',
+    })
+    expect(result.nodes[2]).toBe(outputNode)
+    expect(plan.nodes[0]?.node).toHaveProperty('inputBindings')
   })
 })

--- a/src/util/db/query-ir/__tests__/outputExecutor.test.ts
+++ b/src/util/db/query-ir/__tests__/outputExecutor.test.ts
@@ -34,7 +34,7 @@ function mockDb() {
     calls,
     exec: vi.fn(
       (sql: string, opts: { bind?: unknown[]; returnValue?: string }) => {
-        calls.push({ bind: (opts.bind ?? []) as unknown[], sql })
+        calls.push({ bind: opts.bind ?? [], sql })
         return [] as (string | number | null)[][]
       },
     ),

--- a/src/util/db/query-ir/__tests__/topoSort.test.ts
+++ b/src/util/db/query-ir/__tests__/topoSort.test.ts
@@ -149,7 +149,7 @@ describe('topoSort', () => {
       expect(result.indexOf('getIds1')).toBeLessThan(mergeIdx)
       expect(result.indexOf('getIds2')).toBeLessThan(mergeIdx)
       expect(mergeIdx).toBeLessThan(outputIdx)
-      expect(result[result.length - 1]).toBe('output1')
+      expect(result.at(-1)).toBe('output1')
     })
 
     it('3つのGetIds → Merge → Output の扇型DAGの時、すべてのGetIdsがMergeより前に来ること', () => {
@@ -178,7 +178,7 @@ describe('topoSort', () => {
       expect(result.indexOf('g1')).toBeLessThan(mergeIdx)
       expect(result.indexOf('g2')).toBeLessThan(mergeIdx)
       expect(result.indexOf('g3')).toBeLessThan(mergeIdx)
-      expect(result[result.length - 1]).toBe('output1')
+      expect(result.at(-1)).toBe('output1')
     })
 
     it('GetIds → LookupRelated → Merge → Output のチェーンの時、依存順に並んで返ること', () => {
@@ -236,7 +236,7 @@ describe('topoSort', () => {
           result.indexOf(edge.target),
         )
       }
-      expect(result[result.length - 1]).toBe('output1')
+      expect(result.at(-1)).toBe('output1')
       expect(result).toHaveLength(6)
     })
   })
@@ -253,7 +253,7 @@ describe('topoSort', () => {
       const result = topoSort(plan)
 
       // Assert
-      expect(result[result.length - 1]).toBe('output1')
+      expect(result.at(-1)).toBe('output1')
     })
 
     it('Outputノードに依存するエッジが無い孤立Outputと他ノードがある時、Outputが最後に来ること', () => {
@@ -267,7 +267,7 @@ describe('topoSort', () => {
       const result = topoSort(plan)
 
       // Assert
-      expect(result[result.length - 1]).toBe('output1')
+      expect(result.at(-1)).toBe('output1')
       expect(result).toHaveLength(2)
       expect(result).toContain('getIds1')
     })
@@ -370,7 +370,7 @@ describe('topoSort', () => {
 
       // Assert
       expect(result).toHaveLength(3)
-      expect(result[result.length - 1]).toBe('output1')
+      expect(result.at(-1)).toBe('output1')
       expect(result).toContain('g1')
       expect(result).toContain('merge1')
     })
@@ -561,7 +561,7 @@ describe('topoSort', () => {
       // 最初に見つかった output が最後に来る
       // Kahn のアルゴリズムで入次数0のノードがすべて処理され、
       // findIndex で最初の output-v2 が最後に移動される
-      const lastElement = result[result.length - 1]
+      const lastElement = result.at(-1)
       expect(
         lastElement === 'output-first' || lastElement === 'output-second',
       ).toBe(true)
@@ -605,7 +605,7 @@ describe('topoSort', () => {
       const result = topoSort(plan)
 
       // Assert
-      expect(result[result.length - 1]).toBe('output1')
+      expect(result.at(-1)).toBe('output1')
       expect(result).toHaveLength(4)
     })
 
@@ -626,7 +626,7 @@ describe('topoSort', () => {
 
       // Assert
       expect(result).toHaveLength(4)
-      expect(result[result.length - 1]).toBe('output1')
+      expect(result.at(-1)).toBe('output1')
       expect(result).toContain('g1')
       expect(result).toContain('merge1')
       expect(result).toContain('lookup1')
@@ -699,7 +699,7 @@ describe('topoSort', () => {
       expect(idxA).toBeLessThan(idxC)
       expect(idxB).toBeLessThan(idxD)
       expect(idxC).toBeLessThan(idxD)
-      expect(result[result.length - 1]).toBe('output1')
+      expect(result.at(-1)).toBe('output1')
     })
   })
 
@@ -728,7 +728,7 @@ describe('topoSort', () => {
       const mergeIdx = result.indexOf('merge-union')
       expect(result.indexOf('getIds-posts')).toBeLessThan(mergeIdx)
       expect(result.indexOf('getIds-notifs')).toBeLessThan(mergeIdx)
-      expect(result[result.length - 1]).toBe('output1')
+      expect(result.at(-1)).toBe('output1')
       expect(result).toHaveLength(4)
     })
 
@@ -762,7 +762,7 @@ describe('topoSort', () => {
           result.indexOf(edge.target),
         )
       }
-      expect(result[result.length - 1]).toBe('output1')
+      expect(result.at(-1)).toBe('output1')
       expect(result).toHaveLength(5)
     })
 

--- a/src/util/db/query-ir/bridge.ts
+++ b/src/util/db/query-ir/bridge.ts
@@ -128,9 +128,9 @@ function resolveStep(
         // プレースホルダを実 SQL に置換 (interactions は scoped 版を使用)
         if (key === 'interactions') {
           resolved[key] =
-            BATCH_PLACEHOLDER_MAP[template] != null
-              ? scopedBatch.interactions
-              : template
+            BATCH_PLACEHOLDER_MAP[template] == null
+              ? template
+              : scopedBatch.interactions
         } else {
           resolved[key] = BATCH_PLACEHOLDER_MAP[template] ?? template
         }

--- a/src/util/db/query-ir/compat/configToNodes.ts
+++ b/src/util/db/query-ir/compat/configToNodes.ts
@@ -155,7 +155,7 @@ function buildLanguageFilter(
     return undefined
   }
   const inList = config.languageFilter
-    .map((l) => `'${l.replace(/'/g, "''")}'`)
+    .map((l) => `'${l.replaceAll("'", "''")}'`)
     .join(',')
   return {
     kind: 'raw-sql-filter',

--- a/src/util/db/query-ir/compat/nodesToWhere.ts
+++ b/src/util/db/query-ir/compat/nodesToWhere.ts
@@ -39,7 +39,7 @@ const TABLE_TO_ALIAS: Record<string, string> = {
 
 /** SQL 文字列リテラル用エスケープ: ' → '' */
 function escapeSql(value: string): string {
-  return value.replace(/'/g, "''")
+  return value.replaceAll("'", "''")
 }
 
 function timelineScopeToSql(node: TimelineScope): string {

--- a/src/util/db/query-ir/compat/recognizers.ts
+++ b/src/util/db/query-ir/compat/recognizers.ts
@@ -96,7 +96,7 @@ function tryAccountFilter(cond: string): FilterNode | null {
   if (prInMatch) {
     const accts = prInMatch[1]
       .split(',')
-      .map((s) => s.trim().replace(/'/g, ''))
+      .map((s) => s.trim().replaceAll("'", ''))
       .filter(Boolean)
     return {
       column: 'acct',
@@ -107,11 +107,11 @@ function tryAccountFilter(cond: string): FilterNode | null {
     }
   }
   // W-1: NOT IN: pr.acct NOT IN ('a', 'b')
-  const prNotInMatch = cond.match(/^pr\.acct\s+NOT\s+IN\s*\(([^)]+)\)$/i)
+  const prNotInMatch = /^pr\.acct\s+NOT\s+IN\s*\(([^)]+)\)$/i.exec(cond)
   if (prNotInMatch) {
     const accts = prNotInMatch[1]
       .split(',')
-      .map((s) => s.trim().replace(/'/g, ''))
+      .map((s) => s.trim().replaceAll("'", ''))
       .filter(Boolean)
     return {
       column: 'acct',
@@ -127,10 +127,10 @@ function tryAccountFilter(cond: string): FilterNode | null {
 /** p.is_reblog = 0/1, p.is_sensitive = 0/1, p.spoiler_text = '', p.in_reply_to_uri IS NULL */
 function tryPropertyFilter(cond: string): FilterNode | null {
   // p.column = value
-  const eqMatch = cond.match(/^p\.(\w+)\s*=\s*('([^']*)'|(\d+))$/i)
+  const eqMatch = /^p\.(\w+)\s*=\s*('([^']*)'|(\d+))$/i.exec(cond)
   if (eqMatch) {
     const field = eqMatch[1]
-    const value = eqMatch[3] !== undefined ? eqMatch[3] : Number(eqMatch[4])
+    const value = eqMatch[3] ?? Number(eqMatch[4])
     return {
       column: field,
       kind: 'table-filter',
@@ -140,10 +140,10 @@ function tryPropertyFilter(cond: string): FilterNode | null {
     }
   }
   // p.column != value
-  const neqMatch = cond.match(/^p\.(\w+)\s*!=\s*('([^']*)'|(\d+))$/i)
+  const neqMatch = /^p\.(\w+)\s*!=\s*('([^']*)'|(\d+))$/i.exec(cond)
   if (neqMatch) {
     const field = neqMatch[1]
-    const value = neqMatch[3] !== undefined ? neqMatch[3] : Number(neqMatch[4])
+    const value = neqMatch[3] ?? Number(neqMatch[4])
     return {
       column: field,
       kind: 'table-filter',
@@ -153,7 +153,7 @@ function tryPropertyFilter(cond: string): FilterNode | null {
     }
   }
   // p.column IS NULL
-  const isNullMatch = cond.match(/^p\.(\w+)\s+IS\s+NULL$/i)
+  const isNullMatch = /^p\.(\w+)\s+IS\s+NULL$/i.exec(cond)
   if (isNullMatch) {
     return {
       column: isNullMatch[1],
@@ -163,7 +163,7 @@ function tryPropertyFilter(cond: string): FilterNode | null {
     }
   }
   // p.column IS NOT NULL
-  const isNotNullMatch = cond.match(/^p\.(\w+)\s+IS\s+NOT\s+NULL$/i)
+  const isNotNullMatch = /^p\.(\w+)\s+IS\s+NOT\s+NULL$/i.exec(cond)
   if (isNotNullMatch) {
     return {
       column: isNotNullMatch[1],
@@ -174,12 +174,12 @@ function tryPropertyFilter(cond: string): FilterNode | null {
   }
   // p.language = 'ja' — already covered by p.column = 'value'
   // p.language IN ('ja', 'en')
-  const langInMatch = cond.match(/^p\.(\w+)\s+IN\s*\(([^)]+)\)$/i)
+  const langInMatch = /^p\.(\w+)\s+IN\s*\(([^)]+)\)$/i.exec(cond)
   if (langInMatch) {
     const field = langInMatch[1]
     const values = langInMatch[2]
       .split(',')
-      .map((s) => s.trim().replace(/'/g, ''))
+      .map((s) => s.trim().replaceAll("'", ''))
       .filter(Boolean)
     return {
       column: field,
@@ -190,12 +190,12 @@ function tryPropertyFilter(cond: string): FilterNode | null {
     }
   }
   // W-1: p.column NOT IN ('a', 'b')
-  const notInMatch = cond.match(/^p\.(\w+)\s+NOT\s+IN\s*\(([^)]+)\)$/i)
+  const notInMatch = /^p\.(\w+)\s+NOT\s+IN\s*\(([^)]+)\)$/i.exec(cond)
   if (notInMatch) {
     const field = notInMatch[1]
     const values = notInMatch[2]
       .split(',')
-      .map((s) => s.trim().replace(/'/g, ''))
+      .map((s) => s.trim().replaceAll("'", ''))
       .filter(Boolean)
     return {
       column: field,
@@ -210,7 +210,7 @@ function tryPropertyFilter(cond: string): FilterNode | null {
 
 /** vt.name = 'public' or vt.name IN (...) */
 function tryVisibilityFilter(cond: string): FilterNode | null {
-  const single = cond.match(/^vt\.name\s*=\s*'([^']+)'$/i)
+  const single = /^vt\.name\s*=\s*'([^']+)'$/i.exec(cond)
   if (single) {
     return {
       column: 'name',
@@ -220,11 +220,11 @@ function tryVisibilityFilter(cond: string): FilterNode | null {
       value: [single[1]],
     }
   }
-  const multi = cond.match(/^vt\.name\s+IN\s*\(([^)]+)\)$/i)
+  const multi = /^vt\.name\s+IN\s*\(([^)]+)\)$/i.exec(cond)
   if (multi) {
     const types = multi[1]
       .split(',')
-      .map((s) => s.trim().replace(/'/g, ''))
+      .map((s) => s.trim().replaceAll("'", ''))
       .filter(Boolean)
     return {
       column: 'name',
@@ -239,7 +239,7 @@ function tryVisibilityFilter(cond: string): FilterNode | null {
 
 /** ps.favourites_count >= 10 etc. */
 function tryStatsFilter(cond: string): FilterNode | null {
-  const match = cond.match(/^ps\.(\w+)\s*(>=|<=|>|<|=|!=)\s*(\d+)$/i)
+  const match = /^ps\.(\w+)\s*(>=|<=|>|<|=|!=)\s*(\d+)$/i.exec(cond)
   if (match) {
     return {
       column: match[1],
@@ -254,7 +254,7 @@ function tryStatsFilter(cond: string): FilterNode | null {
 
 /** ht.name = 'photo' or ht.name IN (...) */
 function tryTagFilter(cond: string): FilterNode | null {
-  const single = cond.match(/^ht\.name\s*=\s*'([^']+)'$/i)
+  const single = /^ht\.name\s*=\s*'([^']+)'$/i.exec(cond)
   if (single) {
     return {
       column: 'name',
@@ -264,11 +264,11 @@ function tryTagFilter(cond: string): FilterNode | null {
       value: [single[1]],
     }
   }
-  const multi = cond.match(/^ht\.name\s+IN\s*\(([^)]+)\)$/i)
+  const multi = /^ht\.name\s+IN\s*\(([^)]+)\)$/i.exec(cond)
   if (multi) {
     const tags = multi[1]
       .split(',')
-      .map((s) => s.trim().replace(/'/g, ''))
+      .map((s) => s.trim().replaceAll("'", ''))
       .filter(Boolean)
     return {
       column: 'name',
@@ -284,9 +284,10 @@ function tryTagFilter(cond: string): FilterNode | null {
 /** W-4: EXISTS(SELECT 1 FROM <table> WHERE post_id = p.id) — ジェネリック */
 function tryExistsFilter(cond: string): FilterNode | null {
   // EXISTS: EXISTS(SELECT 1 FROM <table> WHERE post_id = p.id)
-  const existsMatch = cond.match(
-    /^EXISTS\s*\(\s*SELECT\s+1\s+FROM\s+(\w+)\s+WHERE\s+post_id\s*=\s*p\.id\s*\)$/i,
-  )
+  const existsMatch =
+    /^EXISTS\s*\(\s*SELECT\s+1\s+FROM\s+(\w+)\s+WHERE\s+post_id\s*=\s*p\.id\s*\)$/i.exec(
+      cond,
+    )
   if (existsMatch) {
     return {
       kind: 'exists-filter',
@@ -295,9 +296,10 @@ function tryExistsFilter(cond: string): FilterNode | null {
     } satisfies ExistsFilter
   }
   // NOT EXISTS: NOT EXISTS(SELECT 1 FROM <table> WHERE post_id = p.id)
-  const notExistsMatch = cond.match(
-    /^NOT\s+EXISTS\s*\(\s*SELECT\s+1\s+FROM\s+(\w+)\s+WHERE\s+post_id\s*=\s*p\.id\s*\)$/i,
-  )
+  const notExistsMatch =
+    /^NOT\s+EXISTS\s*\(\s*SELECT\s+1\s+FROM\s+(\w+)\s+WHERE\s+post_id\s*=\s*p\.id\s*\)$/i.exec(
+      cond,
+    )
   if (notExistsMatch) {
     return {
       kind: 'exists-filter',
@@ -310,9 +312,10 @@ function tryExistsFilter(cond: string): FilterNode | null {
 
 /** W-4+W-6: (SELECT COUNT(*) FROM <table> WHERE post_id = p.id) <op> N — ジェネリック */
 function tryCountFilter(cond: string): FilterNode | null {
-  const match = cond.match(
-    /^\(SELECT\s+COUNT\(\*\)\s+FROM\s+(\w+)\s+WHERE\s+post_id\s*=\s*p\.id\)\s*(>=|<=|=)\s*(\d+)$/i,
-  )
+  const match =
+    /^\(SELECT\s+COUNT\(\*\)\s+FROM\s+(\w+)\s+WHERE\s+post_id\s*=\s*p\.id\)\s*(>=|<=|=)\s*(\d+)$/i.exec(
+      cond,
+    )
   if (!match) return null
 
   const table = match[1]
@@ -344,7 +347,7 @@ function tryCountFilter(cond: string): FilterNode | null {
 
 /** pme.acct = 'user@example.com' (mention filter) */
 function tryMentionFilter(cond: string): FilterNode | null {
-  const single = cond.match(/^pme\.acct\s*=\s*'([^']+)'$/i)
+  const single = /^pme\.acct\s*=\s*'([^']+)'$/i.exec(cond)
   if (single) {
     return {
       column: 'acct',
@@ -354,11 +357,11 @@ function tryMentionFilter(cond: string): FilterNode | null {
       value: [single[1]],
     }
   }
-  const multi = cond.match(/^pme\.acct\s+IN\s*\(([^)]+)\)$/i)
+  const multi = /^pme\.acct\s+IN\s*\(([^)]+)\)$/i.exec(cond)
   if (multi) {
     const accts = multi[1]
       .split(',')
-      .map((s) => s.trim().replace(/'/g, ''))
+      .map((s) => s.trim().replaceAll("'", ''))
       .filter(Boolean)
     return {
       column: 'acct',
@@ -373,7 +376,7 @@ function tryMentionFilter(cond: string): FilterNode | null {
 
 /** pe.is_bookmarked = 1, pe.is_favourited = 1 etc. */
 function tryInteractionFilter(cond: string): FilterNode | null {
-  const match = cond.match(/^pe\.(is_\w+)\s*=\s*(\d+)$/i)
+  const match = /^pe\.(is_\w+)\s*=\s*(\d+)$/i.exec(cond)
   if (match) {
     return {
       column: match[1],

--- a/src/util/db/query-ir/compile.ts
+++ b/src/util/db/query-ir/compile.ts
@@ -310,14 +310,14 @@ export function compileMergeNode(mergeNode: MergeNode): ExecutionPlan {
     if (idStep) {
       const key = idCollectStepKey(idStep)
       const existing = stepKeyMap.get(key)
-      if (existing !== undefined) {
-        // 重複 SQL — 既存ステップのインデックスを再利用
-        stepIndices.push(existing)
-      } else {
+      if (existing === undefined) {
         const idx = steps.length
         stepKeyMap.set(key, idx)
         stepIndices.push(idx)
         steps.push(idStep)
+      } else {
+        // 重複 SQL — 既存ステップのインデックスを再利用
+        stepIndices.push(existing)
       }
     }
   }
@@ -348,7 +348,7 @@ export function compileMergeNode(mergeNode: MergeNode): ExecutionPlan {
   for (const target of targets) {
     steps.push({
       sqlTemplate: '{DETAIL_QUERY}',
-      target: target as 'posts' | 'notifications',
+      target,
       type: 'detail-fetch',
     } satisfies DetailFetchStep)
   }

--- a/src/util/db/query-ir/completion.ts
+++ b/src/util/db/query-ir/completion.ts
@@ -37,10 +37,7 @@ export function getFilterableTables(
   const result: TableOption[] = []
   for (const entry of Object.values(TABLE_REGISTRY)) {
     // ソーステーブル自身、または joinPath が存在するテーブル
-    if (
-      entry.table === sourceTable ||
-      entry.joinPaths[sourceTable as keyof typeof entry.joinPaths]
-    ) {
+    if (entry.table === sourceTable || entry.joinPaths[sourceTable]) {
       result.push({ label: entry.label, table: entry.table })
     }
   }
@@ -84,7 +81,7 @@ export function getKnownValues(
 ): string[] | undefined {
   const entry = TABLE_REGISTRY[table]
   if (!entry) return undefined
-  return entry.columns[column]?.knownValues as string[] | undefined
+  return entry.columns[column]?.knownValues
 }
 
 /** テーブルのレジストリエントリを返す */
@@ -408,8 +405,7 @@ export function getExistsFilterTables(
   const result: TableOption[] = []
   for (const entry of Object.values(TABLE_REGISTRY)) {
     if (entry.table === sourceTable) continue
-    const joinPath =
-      entry.joinPaths[sourceTable as keyof typeof entry.joinPaths]
+    const joinPath = entry.joinPaths[sourceTable]
     if (joinPath) {
       result.push({ label: entry.label, table: entry.table })
     }

--- a/src/util/db/query-ir/configToQueryPlanV2.ts
+++ b/src/util/db/query-ir/configToQueryPlanV2.ts
@@ -91,8 +91,7 @@ function buildCompositeGraph(
   const edges: QueryPlanV2Edge[] = []
 
   // 各 timelineKey に対して GetIds ノードを生成
-  for (let i = 0; i < timelineKeys.length; i++) {
-    const key = timelineKeys[i]
+  for (const key of timelineKeys) {
     const singleConfig = {
       ...config,
       timelineTypes: undefined,

--- a/src/util/db/query-ir/executor/flatFetchAssembler.ts
+++ b/src/util/db/query-ir/executor/flatFetchAssembler.ts
@@ -212,24 +212,24 @@ export function assembleNotificationFromFlat(
   actorEmojisMap: Map<number, string>,
 ): SqliteStoredNotification {
   const relatedPostId = row[N.RELATED_POST_ID] as number | null
-  const status = relatedPostId != null ? postMap.get(relatedPostId) : undefined
+  const status = relatedPostId == null ? undefined : postMap.get(relatedPostId)
 
   const actorProfileId = row[N.ACTOR_PROFILE_ID] as number | null
   const actorEmojisJson =
-    actorProfileId != null ? (actorEmojisMap.get(actorProfileId) ?? null) : null
+    actorProfileId == null ? null : (actorEmojisMap.get(actorProfileId) ?? null)
 
   const reactionName = row[N.REACTION_NAME] as string | null
   const reactionUrl = row[N.REACTION_URL] as string | null
   const reaction: Entity.Reaction | undefined =
-    reactionName != null
-      ? {
+    reactionName == null
+      ? undefined
+      : {
           accounts: [],
           count: 1,
           me: false,
           name: reactionName,
           ...(reactionUrl ? { static_url: reactionUrl, url: reactionUrl } : {}),
         }
-      : undefined
 
   return {
     account: {

--- a/src/util/db/query-ir/executor/getIdsExecutor.ts
+++ b/src/util/db/query-ir/executor/getIdsExecutor.ts
@@ -11,8 +11,6 @@ import type {
   BindValue,
   ExistsFilter,
   FilterNode,
-  FilterOp,
-  FilterValue,
   GetIdsFilter,
   GetIdsNode,
   TableFilter,
@@ -29,22 +27,22 @@ function getIdsFilterToFilterNode(f: GetIdsFilter): FilterNode {
     return {
       column: f.column,
       kind: 'table-filter',
-      op: f.op as FilterOp,
+      op: f.op,
       table: f.table,
-      value: f.value as FilterValue,
+      value: f.value,
     } satisfies TableFilter
   }
   return {
-    countValue: (f as ExistsFilter).countValue,
-    innerFilters: (f as ExistsFilter).innerFilters?.map((inner) => ({
+    countValue: f.countValue,
+    innerFilters: f.innerFilters?.map((inner) => ({
       column: inner.column,
       kind: 'table-filter' as const,
-      op: inner.op as FilterOp,
+      op: inner.op,
       table: inner.table,
-      value: inner.value as FilterValue,
+      value: inner.value,
     })),
     kind: 'exists-filter',
-    mode: (f as ExistsFilter).mode,
+    mode: f.mode,
     table: f.table,
   } satisfies ExistsFilter
 }
@@ -244,9 +242,9 @@ export function compileGetIds(
   const alias = getSourceAlias(node.table)
   const idCol = node.outputIdColumn ?? 'id'
   const timeCol =
-    node.outputTimeColumn !== null
-      ? (node.outputTimeColumn ?? getDefaultTimeColumn(node.table))
-      : null
+    node.outputTimeColumn === null
+      ? null
+      : (node.outputTimeColumn ?? getDefaultTimeColumn(node.table))
 
   const tsj = node.timeSourceJoin
   const tsjAlias = tsj ? '_time_src' : null
@@ -296,7 +294,7 @@ export function compileGetIds(
       ? `WHERE ${ctx.whereConditions.join(' AND ')}`
       : ''
   const groupByStr = needsGroupBy ? `GROUP BY ${alias}.${idCol}` : ''
-  const limitStr = limit != null ? `LIMIT ${limit}` : ''
+  const limitStr = limit == null ? '' : `LIMIT ${limit}`
 
   const sql = buildSelectSql({
     alias,

--- a/src/util/db/query-ir/executor/graphExecutor.ts
+++ b/src/util/db/query-ir/executor/graphExecutor.ts
@@ -34,9 +34,7 @@ import { WorkerNodeCache } from './workerNodeCache'
 let globalCache: WorkerNodeCache | null = null
 
 function getCache(): WorkerNodeCache {
-  if (!globalCache) {
-    globalCache = new WorkerNodeCache()
-  }
+  globalCache ??= new WorkerNodeCache()
   return globalCache
 }
 
@@ -361,7 +359,7 @@ export function executeGraphPlan(
         runLookupRelatedNode(
           { cache, db, nodeStats, outputs },
           nodeId,
-          entry.node as LookupRelatedNode,
+          entry.node,
           incoming,
           nodeStart,
         )
@@ -371,7 +369,7 @@ export function executeGraphPlan(
           outputs,
           nodeStats,
           nodeId,
-          entry.node as MergeNodeV2,
+          entry.node,
           incoming,
           nodeStart,
         )
@@ -380,7 +378,7 @@ export function executeGraphPlan(
         return runOutputNode(
           { captureVersionsFn, db, nodeStats, options, outputs, start },
           nodeId,
-          entry.node as OutputNodeV2,
+          entry.node,
           incoming,
           nodeStart,
         )

--- a/src/util/db/query-ir/executor/lookupRelatedExecutor.ts
+++ b/src/util/db/query-ir/executor/lookupRelatedExecutor.ts
@@ -71,8 +71,6 @@ function buildJoinOnsAndExtraJoins(
       const pLt = `_p_lt${riIdx}`
       extraJoinStrs.push(
         `JOIN profiles ${pLt} ON ${lt}.${jc.lookupColumn} = ${pLt}.id`,
-      )
-      extraJoinStrs.push(
         `JOIN profiles ${pSrc} ON ${pLt}.canonical_acct = ${pSrc}.canonical_acct`,
       )
       joinOns.push(`${src}.${inputCol} = ${pSrc}.id`)
@@ -95,14 +93,12 @@ function appendTimeWindowConditions(
   if (tc.afterInput) {
     conditions.push(
       `${lt}.${tc.lookupTimeColumn} >= ${src}.${tc.inputTimeColumn}`,
-    )
-    conditions.push(
       `${lt}.${tc.lookupTimeColumn} <= ${src}.${tc.inputTimeColumn} + ${tc.windowMs}`,
     )
     return
   }
-  conditions.push(`${lt}.${tc.lookupTimeColumn} < ${src}.${tc.inputTimeColumn}`)
   conditions.push(
+    `${lt}.${tc.lookupTimeColumn} < ${src}.${tc.inputTimeColumn}`,
     `${lt}.${tc.lookupTimeColumn} >= ${src}.${tc.inputTimeColumn} - ${tc.windowMs}`,
   )
 }

--- a/src/util/db/query-ir/executor/outputExecutor.ts
+++ b/src/util/db/query-ir/executor/outputExecutor.ts
@@ -19,7 +19,7 @@ import {
   buildScopedBatchTemplates,
   buildSpbFilter,
 } from '../../sqlite/queries/statusSelect'
-import type { OutputNodeV2 } from '../nodes'
+import type { BindValue, OutputNodeV2 } from '../nodes'
 import type { NodeOutputRow } from '../plan'
 import type { DisplayOrderEntry, GraphExecuteResult, NodeOutput } from './types'
 
@@ -28,6 +28,8 @@ const REBLOG_POST_ID_COLUMN_INDEX = 25
 
 /** Output ノードで受入可能なテーブル */
 const SUPPORTED_TABLES = new Set(['posts', 'notifications'])
+
+type DbRow = BindValue[]
 
 function applySortCursorAndPagination(
   rows: NodeOutputRow[],
@@ -113,13 +115,13 @@ export function executeOutput(
     postRows.length > 0
       ? executePostOutput(db, postRows, backendUrls)
       : {
-          batchResults: {} as Record<string, (string | number | null)[][]>,
-          detailRows: [] as (string | number | null)[][],
+          batchResults: {} as Record<string, DbRow[]>,
+          detailRows: [] as DbRow[],
         }
   const notifsResult =
     notifRows.length > 0
       ? executeNotificationOutput(db, notifRows)
-      : { detailRows: [] as (string | number | null)[][] }
+      : { detailRows: [] as DbRow[] }
 
   return {
     displayOrder,
@@ -150,8 +152,8 @@ function executePostOutput(
   rows: NodeOutputRow[],
   backendUrls: string[],
 ): {
-  detailRows: (string | number | null)[][]
-  batchResults: Record<string, (string | number | null)[][]>
+  detailRows: DbRow[]
+  batchResults: Record<string, DbRow[]>
 } {
   let postIds = rows.map((r) => r.id)
 
@@ -194,7 +196,7 @@ function executeNotificationOutput(
   db: DbExec,
   rows: NodeOutputRow[],
 ): {
-  detailRows: (string | number | null)[][]
+  detailRows: DbRow[]
 } {
   const notifIds = rows.map((r) => r.id)
   const placeholders = notifIds.map(() => '?').join(',')
@@ -226,11 +228,11 @@ function executeBatchQueries(
   db: DbExec,
   postIds: number[],
   templates: { [K in keyof typeof BATCH_SQL_TEMPLATES]: string },
-): Record<string, (string | number | null)[][]> {
+): Record<string, DbRow[]> {
   if (postIds.length === 0) return {}
 
   const placeholders = postIds.map(() => '?').join(',')
-  const results: Record<string, (string | number | null)[][]> = {}
+  const results: Record<string, DbRow[]> = {}
 
   for (const [key, sqlTemplate] of Object.entries(templates)) {
     const sql = sqlTemplate.replaceAll('{IDS}', placeholders)

--- a/src/util/db/query-ir/migrateInputBindings.ts
+++ b/src/util/db/query-ir/migrateInputBindings.ts
@@ -1,9 +1,16 @@
-import type { FilterCondition, GetIdsNode } from './nodes'
-
-type GetIdsConfig = Pick<
+import type {
+  FilterCondition,
+  GetIdsInputBinding,
   GetIdsNode,
-  'filters' | 'inputBinding' | 'inputBindings' | 'table'
->
+  QueryPlanV2,
+} from './nodes'
+
+type GetIdsConfig = {
+  filters: GetIdsNode['filters']
+  inputBinding?: { column: string }
+  inputBindings?: GetIdsInputBinding[]
+  table: GetIdsNode['table']
+}
 
 /**
  * 旧 inputBindings を FilterCondition.upstreamSourceNodeId に変換する。
@@ -47,5 +54,17 @@ export function migrateInputBindings<T extends GetIdsConfig>(config: T): T {
     filters: nextFilters,
     inputBinding: undefined,
     inputBindings: undefined,
+  }
+}
+
+/** QueryPlanV2 内の全 GetIds ノードから旧 inputBindings を移行する。 */
+export function migrateQueryPlanInputBindings(plan: QueryPlanV2): QueryPlanV2 {
+  return {
+    ...plan,
+    nodes: plan.nodes.map((entry) =>
+      entry.node.kind === 'get-ids'
+        ? { ...entry, node: migrateInputBindings(entry.node) }
+        : entry,
+    ),
   }
 }

--- a/src/util/db/query-ir/nodes.ts
+++ b/src/util/db/query-ir/nodes.ts
@@ -425,10 +425,10 @@ export function queryPlanV2ReferencedTables(plan: QueryPlanV2): Set<string> {
   for (const entry of plan.nodes) {
     switch (entry.node.kind) {
       case 'get-ids':
-        tables.add((entry.node as GetIdsNode).table)
+        tables.add(entry.node.table)
         break
       case 'lookup-related':
-        tables.add((entry.node as LookupRelatedNode).lookupTable)
+        tables.add(entry.node.lookupTable)
         break
     }
   }

--- a/src/util/db/query-ir/resolve.ts
+++ b/src/util/db/query-ir/resolve.ts
@@ -128,9 +128,9 @@ export function resolveTableDependency(
         const entry = registry[table]
         if (!entry) {
           return {
-            cardinality: '1:1' as Cardinality,
+            cardinality: '1:1',
             joinPath: null,
-            strategy: 'direct' as JoinStrategy,
+            strategy: 'direct',
             table,
           }
         }

--- a/src/util/db/query-ir/v2/filterMapping.ts
+++ b/src/util/db/query-ir/v2/filterMapping.ts
@@ -6,7 +6,6 @@ import type {
   FilterCondition,
   FilterNode,
   GetIdsFilter,
-  OrGroup,
   TableFilter,
   TimelineScope,
 } from '../nodes'
@@ -84,7 +83,7 @@ export function partitionOrGroups(filters: FilterNode[]): {
   const orBranches: FilterNode[][] = []
   for (const f of filters) {
     if (isOrGroup(f)) {
-      orBranches.push(...(f as OrGroup).branches)
+      orBranches.push(...f.branches)
     } else {
       base.push(f)
     }

--- a/src/util/db/query-ir/v2/migrateV1ToV2.ts
+++ b/src/util/db/query-ir/v2/migrateV1ToV2.ts
@@ -41,10 +41,10 @@ function appendFilterConversion(
     return
   }
   const g = filterNodeToGetIdsFilter(f)
-  if (g != null) {
-    filters.push(g)
-  } else {
+  if (g === null) {
     overlay.push(f)
+  } else {
+    filters.push(g)
   }
 }
 

--- a/src/util/db/sqlite/__tests__/cleanup-batchLoop.test.ts
+++ b/src/util/db/sqlite/__tests__/cleanup-batchLoop.test.ts
@@ -65,9 +65,17 @@ function installMockHandle(
   })
 
   vi.mocked(getSqliteDb).mockResolvedValue({
+    cancelStaleRequests: vi.fn(),
     execAsync,
+    execAsyncTimed: vi.fn(),
+    execBatch: vi.fn(),
+    executeFlatFetch: vi.fn(),
+    executeGraphPlan: vi.fn(),
+    executeQueryPlan: vi.fn(),
+    fetchTimeline: vi.fn(),
+    persistence: 'memory',
     sendCommand,
-  } as unknown as Awaited<ReturnType<typeof getSqliteDb>>)
+  })
   return { calls, execAsync, sendCommand }
 }
 
@@ -154,9 +162,17 @@ describe('enforceMaxLength — batch loop', () => {
     })
     const execAsync = vi.fn(async () => [[0, 0, 0]])
     vi.mocked(getSqliteDb).mockResolvedValue({
+      cancelStaleRequests: vi.fn(),
       execAsync,
+      execAsyncTimed: vi.fn(),
+      execBatch: vi.fn(),
+      executeFlatFetch: vi.fn(),
+      executeGraphPlan: vi.fn(),
+      executeQueryPlan: vi.fn(),
+      fetchTimeline: vi.fn(),
+      persistence: 'memory',
       sendCommand,
-    } as unknown as Awaited<ReturnType<typeof getSqliteDb>>)
+    })
 
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 

--- a/src/util/db/sqlite/__tests__/handlers-account.test.ts
+++ b/src/util/db/sqlite/__tests__/handlers-account.test.ts
@@ -11,6 +11,8 @@ import {
 } from 'util/db/sqlite/worker/handlers/accountHandlers'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+type SqlValue = string | number | null
+
 // ─── Mock DB factory ────────────────────────────────────────────
 
 type ExecCall = { sql: string; opts?: Parameters<DbExecCompat['exec']>[1] }
@@ -32,7 +34,7 @@ function createMockDb(selectResults: unknown[] = []): {
       if (opts?.returnValue === 'resultRows') {
         const result = selectResults[selectIndex]
         selectIndex++
-        return result !== undefined ? [[result]] : []
+        return result === undefined ? [] : [[result]]
       }
       return undefined
     }),
@@ -102,7 +104,7 @@ describe('handleEnsureLocalAccount', () => {
     expect(localAccountUpsert?.sql).toContain('remote_account_id')
 
     // bind にバックエンドURL, アカウント情報が含まれる
-    const bind = localAccountUpsert?.opts?.bind as (string | number | null)[]
+    const bind = localAccountUpsert?.opts?.bind as SqlValue[]
     expect(bind).toContain(1) // server_id
     expect(bind).toContain('https://mastodon.social') // backend_url
     expect(bind).toContain('testuser@mastodon.social') // acct
@@ -143,7 +145,7 @@ describe('handleEnsureLocalAccount', () => {
     expect(localAccountUpsert).toBeDefined()
     expect(localAccountUpsert?.sql).toContain('profile_id')
 
-    const bind = localAccountUpsert?.opts?.bind as (string | number | null)[]
+    const bind = localAccountUpsert?.opts?.bind as SqlValue[]
     expect(bind).toContain(42) // profile_id from ensureProfile
   })
 
@@ -167,7 +169,7 @@ describe('handleEnsureLocalAccount', () => {
     const localAccountUpsert = calls.find(
       (c) => c.sql.includes('INSERT') && c.sql.includes('local_accounts'),
     )
-    const bind = localAccountUpsert?.opts?.bind as (string | number | null)[]
+    const bind = localAccountUpsert?.opts?.bind as SqlValue[]
     expect(bind).toContain(99) // server_id
   })
 })
@@ -207,7 +209,7 @@ describe('handleBulkUpsertCustomEmojis', () => {
 
     // BEGIN + COMMIT が呼ばれる
     expect(calls[0].sql).toBe('BEGIN;')
-    expect(calls[calls.length - 1].sql).toBe('COMMIT;')
+    expect(calls.at(-1)?.sql).toBe('COMMIT;')
 
     // ensureCustomEmoji で custom_emojis に INSERT される
     const emojiInserts = calls.filter(

--- a/src/util/db/sqlite/__tests__/handlers-cleanup.test.ts
+++ b/src/util/db/sqlite/__tests__/handlers-cleanup.test.ts
@@ -35,7 +35,7 @@ function createMockDb(selectResults: unknown[][] = []): {
       if (opts?.returnValue === 'resultRows') {
         const result = selectResults[selectIndex]
         selectIndex++
-        return result !== undefined ? result : []
+        return result ?? []
       }
       return undefined
     }),

--- a/src/util/db/sqlite/__tests__/handlers-interaction.test.ts
+++ b/src/util/db/sqlite/__tests__/handlers-interaction.test.ts
@@ -73,7 +73,7 @@ function createMockDb(
             ? selectResults({ opts, selectIndex, sql })
             : selectResults[selectIndex]
         selectIndex++
-        return result !== undefined ? result : []
+        return result ?? []
       }
       return undefined
     }),

--- a/src/util/db/sqlite/__tests__/handlers-notification.test.ts
+++ b/src/util/db/sqlite/__tests__/handlers-notification.test.ts
@@ -1,3 +1,4 @@
+import type { Entity } from 'megalodon'
 import {
   ensureProfile,
   ensureServer,
@@ -94,27 +95,35 @@ function createMockDb(queryMap: Record<string, unknown[][][]> = {}): {
 
 function makeNotification(
   overrides: Record<string, unknown> = {},
-): Record<string, unknown> {
+): Entity.Notification {
   return {
     account: {
       acct: 'actor@example.com',
       avatar: '',
       avatar_static: '',
       bot: false,
+      created_at: '2024-01-01T00:00:00.000Z',
       display_name: 'Actor',
       emojis: [],
+      fields: [],
+      followers_count: 0,
+      following_count: 0,
+      group: null,
       header: '',
       header_static: '',
       id: 'actor-1',
+      limited: null,
       locked: false,
+      moved: null,
+      noindex: null,
       note: '',
+      statuses_count: 0,
+      suspended: null,
       url: 'https://example.com/@actor',
       username: 'actor',
     },
     created_at: '2024-01-15T10:00:00.000Z',
     id: 'notif-1',
-    reaction: null,
-    status: null,
     type: 'favourite',
     ...overrides,
   }
@@ -221,11 +230,7 @@ describe('upsertNotification', () => {
 
     const notification = makeNotification()
 
-    const result = upsertNotification(
-      db,
-      notification as never,
-      'https://example.com',
-    )
+    const result = upsertNotification(db, notification, 'https://example.com')
 
     expect(typeof result).toBe('boolean')
 
@@ -256,7 +261,7 @@ describe('upsertNotification', () => {
 
     const notification = makeNotification()
 
-    upsertNotification(db, notification as never, 'https://example.com')
+    upsertNotification(db, notification, 'https://example.com')
 
     // UPSERT SQL を確認: ON CONFLICT(local_account_id, local_id) DO UPDATE
     const insertCall = calls.find((c) =>
@@ -281,7 +286,7 @@ describe('upsertNotification', () => {
 
     const notification = makeNotification()
 
-    upsertNotification(db, notification as never, 'https://example.com')
+    upsertNotification(db, notification, 'https://example.com')
 
     // INSERT SQL に server_id が含まれないことを確認
     const insertCall = calls.find((c) =>
@@ -307,7 +312,7 @@ describe('upsertNotification', () => {
       },
       type: 'emoji_reaction',
     })
-    upsertNotification(db, notification as never, 'https://example.com')
+    upsertNotification(db, notification, 'https://example.com')
 
     const insertCall = calls.find((c) =>
       c.sql.includes('INSERT INTO notifications'),
@@ -475,7 +480,7 @@ describe('handleBulkAddNotifications', () => {
 
     // BEGIN + COMMIT が呼ばれる
     expect(calls[0].sql).toBe('BEGIN;')
-    expect(calls[calls.length - 1].sql).toBe('COMMIT;')
+    expect(calls.at(-1)?.sql).toBe('COMMIT;')
 
     // 3件の通知 INSERT が発行される
     const notifInserts = calls.filter((c) =>

--- a/src/util/db/sqlite/__tests__/handlers-postSync.test.ts
+++ b/src/util/db/sqlite/__tests__/handlers-postSync.test.ts
@@ -8,6 +8,8 @@ import {
 import type { DbExec } from 'util/db/sqlite/worker/handlers/types'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+type SqlValue = string | number | null
+
 // ================================================================
 // ヘルパー
 // ================================================================
@@ -16,18 +18,18 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 function createMockDb(
   execImpl?: (
     sql: string,
-    opts?: { bind?: (string | number | null)[]; returnValue?: 'resultRows' },
+    opts?: { bind?: SqlValue[]; returnValue?: 'resultRows' },
   ) => unknown,
 ): {
   db: DbExec
   calls: {
     sql: string
-    opts?: { bind?: (string | number | null)[]; returnValue?: 'resultRows' }
+    opts?: { bind?: SqlValue[]; returnValue?: 'resultRows' }
   }[]
 } {
   const calls: {
     sql: string
-    opts?: { bind?: (string | number | null)[]; returnValue?: 'resultRows' }
+    opts?: { bind?: SqlValue[]; returnValue?: 'resultRows' }
   }[] = []
 
   const db: DbExec = {
@@ -35,7 +37,7 @@ function createMockDb(
       (
         sql: string,
         opts?: {
-          bind?: (string | number | null)[]
+          bind?: SqlValue[]
           returnValue?: 'resultRows'
         },
       ) => {
@@ -66,15 +68,20 @@ function createMockStatus(
       fields: [],
       followers_count: 10,
       following_count: 20,
+      group: null,
       header: 'https://example.com/header.png',
       header_static: 'https://example.com/header_static.png',
       id: 'account-1',
+      limited: null,
       locked: false,
+      moved: null,
+      noindex: null,
       note: '',
       statuses_count: 100,
+      suspended: null,
       url: 'https://example.com/@alice',
       username: 'alice',
-    } as Entity.Account,
+    },
     bookmarked: false,
     content: '<p>Hello, world!</p>',
     created_at: '2024-06-15T12:30:00.000Z',
@@ -347,7 +354,7 @@ describe('syncPostMedia', () => {
     expect(insertCalls).toHaveLength(1)
 
     // width, height が null として渡される
-    const bind = insertCalls[0].opts?.bind as (string | number | null)[]
+    const bind = insertCalls[0].opts?.bind as SqlValue[]
     // url の後に width, height が来る。null が含まれていることを確認
     const nullCount = bind.filter((v) => v === null).length
     expect(nullCount).toBeGreaterThanOrEqual(2) // width=null, height=null (最低限)
@@ -440,7 +447,7 @@ describe('syncPostMedia', () => {
     expect(insertCalls).toHaveLength(1)
 
     // bind に sort_order 0 と 1 が含まれる
-    const bind = insertCalls[0].opts?.bind as (string | number | null)[]
+    const bind = insertCalls[0].opts?.bind as SqlValue[]
     expect(bind).toContain(0) // sort_order for first
     expect(bind).toContain(1) // sort_order for second
     expect(bind).toContain('media-1')
@@ -498,7 +505,7 @@ describe('syncPostStats', () => {
     const sql = calls[0].sql
     expect(sql).toContain('emoji_reactions_json')
 
-    const bind = calls[0].opts?.bind as (string | number | null)[]
+    const bind = calls[0].opts?.bind as SqlValue[]
     // emoji_reactions_json が JSON 文字列として bind に含まれる
     const jsonBind = bind.find((v) => typeof v === 'string' && v.includes('👍'))
     expect(jsonBind).toBeDefined()
@@ -514,7 +521,7 @@ describe('syncPostStats', () => {
 
     syncPostStats(db, 100, status)
 
-    const bind = calls[0].opts?.bind as (string | number | null)[]
+    const bind = calls[0].opts?.bind as SqlValue[]
     // emoji_reactions_json は空JSON配列文字列
     // post_id(100), replies_count, reblogs_count, favourites_count, emoji_reactions_json, updated_at
     // '[]' が含まれていることを確認（emoji_reactions_json 位置）

--- a/src/util/db/sqlite/__tests__/handlers-status.test.ts
+++ b/src/util/db/sqlite/__tests__/handlers-status.test.ts
@@ -2,20 +2,22 @@ import type { Entity } from 'megalodon'
 import type { DbExec } from 'util/db/sqlite/worker/handlers/types'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+type SqlValue = string | number | null
+
 // ================================================================
 // ヘルパー
 // ================================================================
 
 type ExecCall = {
   sql: string
-  opts?: { bind?: (string | number | null)[]; returnValue?: 'resultRows' }
+  opts?: { bind?: SqlValue[]; returnValue?: 'resultRows' }
 }
 
 /** db.exec のモックを作成する */
 function createMockDb(
   execImpl?: (
     sql: string,
-    opts?: { bind?: (string | number | null)[]; returnValue?: 'resultRows' },
+    opts?: { bind?: SqlValue[]; returnValue?: 'resultRows' },
   ) => unknown,
 ): {
   db: DbExec
@@ -28,7 +30,7 @@ function createMockDb(
       (
         sql: string,
         opts?: {
-          bind?: (string | number | null)[]
+          bind?: SqlValue[]
           returnValue?: 'resultRows'
         },
       ) => {
@@ -59,15 +61,20 @@ function createMockStatus(
       fields: [],
       followers_count: 10,
       following_count: 20,
+      group: null,
       header: 'https://example.com/header.png',
       header_static: 'https://example.com/header_static.png',
       id: 'account-1',
+      limited: null,
       locked: false,
+      moved: null,
+      noindex: null,
       note: '',
       statuses_count: 100,
+      suspended: null,
       url: 'https://example.com/@alice',
       username: 'alice',
-    } as Entity.Account,
+    },
     bookmarked: false,
     content: '<p>Hello, world!</p>',
     created_at: '2024-06-15T12:30:00.000Z',
@@ -239,7 +246,7 @@ describe('handleUpsertStatus', () => {
     expect(backendIdInserts[0].sql).toContain('local_account_id')
 
     // bind に localAccountId (100), localId ('12345'), serverId (1) が含まれること
-    const bind = backendIdInserts[0].opts?.bind as (string | number | null)[]
+    const bind = backendIdInserts[0].opts?.bind as SqlValue[]
     expect(bind).toContain(100) // localAccountId
     expect(bind).toContain('12345') // status.id
     expect(bind).toContain(1) // serverId
@@ -466,7 +473,7 @@ describe('handleUpsertStatus', () => {
     expect(timelineInserts.length).toBe(1)
 
     // display_post_id が null ではなく、reblogOfPostId (500) であること
-    const bind = timelineInserts[0].opts?.bind as (string | number | null)[]
+    const bind = timelineInserts[0].opts?.bind as SqlValue[]
     expect(bind).toContain(500)
   })
 
@@ -666,7 +673,7 @@ describe('handleUpsertStatus', () => {
 
     // BEGIN と COMMIT が発行されること
     expect(calls[0].sql).toContain('BEGIN')
-    expect(calls[calls.length - 1].sql).toContain('COMMIT')
+    expect(calls.at(-1)?.sql).toContain('COMMIT')
   })
 
   it('extractPostColumns を使用する（extractStatusColumns ではない）', () => {
@@ -751,7 +758,7 @@ describe('handleBulkUpsertStatuses', () => {
 
     // BEGIN が最初で COMMIT が最後
     expect(calls[0].sql).toContain('BEGIN')
-    expect(calls[calls.length - 1].sql).toContain('COMMIT')
+    expect(calls.at(-1)?.sql).toContain('COMMIT')
   })
 
   it('posts_backends / posts_reblogs テーブルを使用しない', () => {

--- a/src/util/db/sqlite/__tests__/handlers-statusUpdate.test.ts
+++ b/src/util/db/sqlite/__tests__/handlers-statusUpdate.test.ts
@@ -2,20 +2,22 @@ import type { Entity } from 'megalodon'
 import type { DbExec } from 'util/db/sqlite/worker/handlers/types'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+type SqlValue = string | number | null
+
 // ================================================================
 // ヘルパー
 // ================================================================
 
 type ExecCall = {
   sql: string
-  opts?: { bind?: (string | number | null)[]; returnValue?: 'resultRows' }
+  opts?: { bind?: SqlValue[]; returnValue?: 'resultRows' }
 }
 
 /** db.exec のモックを作成する */
 function createMockDb(
   execImpl?: (
     sql: string,
-    opts?: { bind?: (string | number | null)[]; returnValue?: 'resultRows' },
+    opts?: { bind?: SqlValue[]; returnValue?: 'resultRows' },
   ) => unknown,
 ): {
   db: DbExec
@@ -28,7 +30,7 @@ function createMockDb(
       (
         sql: string,
         opts?: {
-          bind?: (string | number | null)[]
+          bind?: SqlValue[]
           returnValue?: 'resultRows'
         },
       ) => {
@@ -59,15 +61,20 @@ function createMockStatus(
       fields: [],
       followers_count: 10,
       following_count: 20,
+      group: null,
       header: 'https://example.com/header.png',
       header_static: 'https://example.com/header_static.png',
       id: 'account-1',
+      limited: null,
       locked: false,
+      moved: null,
+      noindex: null,
       note: '',
       statuses_count: 100,
+      suspended: null,
       url: 'https://example.com/@alice',
       username: 'alice',
-    } as Entity.Account,
+    },
     bookmarked: false,
     content: '<p>Hello, world!</p>',
     created_at: '2024-06-15T12:30:00.000Z',
@@ -270,7 +277,7 @@ describe('handleUpdateStatus', () => {
     expect(updateSql).not.toContain('reblog_of_uri')
 
     // bind に新カラムの値が含まれること
-    const bind = updateCalls[0].opts?.bind as (string | number | null)[]
+    const bind = updateCalls[0].opts?.bind as SqlValue[]
     expect(bind).toContain(1718460000000) // edited_at_ms
     expect(bind).toContain('Edited content') // plain_content
     expect(bind).toContain('bob@remote.example') // in_reply_to_account_acct

--- a/src/util/db/sqlite/__tests__/handlers-timeline.test.ts
+++ b/src/util/db/sqlite/__tests__/handlers-timeline.test.ts
@@ -60,7 +60,7 @@ describe('handleRemoveFromTimeline', () => {
 
     // BEGIN + COMMIT
     expect(calls[0].sql).toBe('BEGIN;')
-    expect(calls[calls.length - 1].sql).toBe('COMMIT;')
+    expect(calls.at(-1)?.sql).toBe('COMMIT;')
 
     // DELETE FROM timeline_entries
     const deleteEntry = calls.find(
@@ -180,7 +180,7 @@ describe('handleDeleteEvent', () => {
 
     // BEGIN + COMMIT
     expect(calls[1].sql).toBe('BEGIN;')
-    expect(calls[calls.length - 1].sql).toBe('COMMIT;')
+    expect(calls.at(-1)?.sql).toBe('COMMIT;')
 
     // post_backend_ids からの DELETE
     const deleteBackend = calls.find(

--- a/src/util/db/sqlite/__tests__/helpers-profile.test.ts
+++ b/src/util/db/sqlite/__tests__/helpers-profile.test.ts
@@ -14,6 +14,8 @@ import {
 import type { DbExecCompat } from 'util/db/sqlite/helpers/types'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+type SqlValue = string | number | null
+
 // ─── Mock DB factory ────────────────────────────────────────────
 
 /**
@@ -154,7 +156,7 @@ describe('ensureProfile', () => {
     expect(calls[0].sql).not.toContain('"domain"')
 
     // bind パラメータの確認
-    const bind = calls[0].opts?.bind as (string | number | null)[]
+    const bind = calls[0].opts?.bind as SqlValue[]
     expect(bind[0]).toBe('https://example.com/@alice') // actor_uri
     expect(bind[1]).toBe('alice') // username
     expect(bind[2]).toBe(1) // server_id
@@ -206,7 +208,7 @@ describe('ensureProfile', () => {
     expect(calls).toHaveLength(4)
 
     // 2回目の UPSERT で新しい display_name が使われる
-    const secondBind = calls[2].opts?.bind as (string | number | null)[]
+    const secondBind = calls[2].opts?.bind as SqlValue[]
     expect(secondBind[5]).toBe('Bob v2') // display_name
     expect(secondBind[7]).toBe('https://example.com/bob_v2.png') // avatar_url
   })
@@ -248,7 +250,7 @@ describe('ensureProfile', () => {
     expect(id).toBe(5)
 
     // UPSERT の bind で server_id = 3 を使っている
-    const bind = calls[0].opts?.bind as (string | number | null)[]
+    const bind = calls[0].opts?.bind as SqlValue[]
     expect(bind[1]).toBe('localuser') // username
     expect(bind[2]).toBe(3) // server_id
     expect(bind[3]).toBe('localuser') // acct
@@ -278,7 +280,7 @@ describe('ensureProfile', () => {
     expect(id).toBe(11)
 
     // UPSERT bind に server_id が含まれる
-    const bind = calls[0].opts?.bind as (string | number | null)[]
+    const bind = calls[0].opts?.bind as SqlValue[]
     expect(bind[2]).toBe(42) // server_id
 
     // SELECT bind にも canonical_acct が含まれる
@@ -310,7 +312,7 @@ describe('syncProfileStats', () => {
     expect(calls[0].sql).toContain('statuses_count')
     expect(calls[0].sql).toContain('updated_at')
 
-    const bind = calls[0].opts?.bind as (string | number | null)[]
+    const bind = calls[0].opts?.bind as SqlValue[]
     expect(bind[0]).toBe(10) // profile_id
     expect(bind[1]).toBe(100) // followers_count
     expect(bind[2]).toBe(200) // following_count
@@ -346,7 +348,7 @@ describe('syncProfileFields', () => {
 
     // 2回目: multi-value INSERT
     expect(calls[1].sql).toContain('INSERT INTO profile_fields')
-    const bind = calls[1].opts?.bind as (string | number | null)[]
+    const bind = calls[1].opts?.bind as SqlValue[]
     // 1つ目のフィールド
     expect(bind[0]).toBe(10) // profile_id
     expect(bind[1]).toBe(0) // sort_order
@@ -382,7 +384,7 @@ describe('syncProfileFields', () => {
     expect(calls[2].opts?.bind).toEqual([5])
 
     // 2回目の multi-value INSERT で新しいフィールドが追加される
-    const bind = calls[3].opts?.bind as (string | number | null)[]
+    const bind = calls[3].opts?.bind as SqlValue[]
     expect(bind[2]).toBe('New Field')
     expect(bind[7]).toBe('Another Field')
   })

--- a/src/util/db/sqlite/__tests__/migrations.test.ts
+++ b/src/util/db/sqlite/__tests__/migrations.test.ts
@@ -11,7 +11,6 @@ import {
 } from 'util/db/sqlite/migrations/helpers'
 import type { Migration } from 'util/db/sqlite/migrations/types'
 import { encodeSemVer, LATEST_VERSION } from 'util/db/sqlite/schema/version'
-import type { SchemaDbHandle } from 'util/db/sqlite/worker/workerSchema'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 // ─── Mock DB factory ────────────────────────────────────────────
@@ -30,7 +29,7 @@ function createMockDb(userVersion: number) {
       return undefined
     }),
   }
-  return { db, execCalls, handle: { db } as SchemaDbHandle }
+  return { db, execCalls, handle: { db } }
 }
 
 describe('runMigrations', () => {

--- a/src/util/db/sqlite/__tests__/queries-statusMapper.test.ts
+++ b/src/util/db/sqlite/__tests__/queries-statusMapper.test.ts
@@ -12,6 +12,8 @@ import {
 } from 'util/db/sqlite/queries/statusMapper'
 import { describe, expect, it } from 'vitest'
 
+type SqlValue = string | number | null
+
 // ─── helpers ────────────────────────────────────────────────────
 
 /**
@@ -45,8 +47,8 @@ import { describe, expect, it } from 'vitest'
  *   [62] author_account_id [63] rb_author_account_id
  *   [64] emoji_reactions_json [65] rb_emoji_reactions_json
  */
-function makeRow(): (string | number | null)[] {
-  const row: (string | number | null)[] = new Array(66).fill(null)
+function makeRow(): SqlValue[] {
+  const row: SqlValue[] = new Array(66).fill(null)
   // 最低限のデフォルト値（nullish-safety）
   row[0] = 42 // post_id
   row[1] = 'https://example.com' // backendUrl
@@ -95,8 +97,8 @@ function makeRow(): (string | number | null)[] {
  *   [47] rb_local_id     [48] author_account_id [49] rb_author_account_id
  *   [50] emoji_reactions_json [51] rb_emoji_reactions_json
  */
-function makeBaseRow(): (string | number | null)[] {
-  const row: (string | number | null)[] = new Array(52).fill(null)
+function makeBaseRow(): SqlValue[] {
+  const row: SqlValue[] = new Array(52).fill(null)
   row[0] = 42 // post_id
   row[1] = 'https://example.com' // backendUrl
   row[2] = '12345' // local_id

--- a/src/util/db/sqlite/__tests__/queries-statusRead.test.ts
+++ b/src/util/db/sqlite/__tests__/queries-statusRead.test.ts
@@ -25,8 +25,8 @@ const source = [
 describe('Phase 1 クエリが timeline_entries を使用する', () => {
   it('getStatusesByTimelineType の Phase 1 SQL が timeline_entries を含む', () => {
     // getStatusesByTimelineType 関数のソースを抽出
-    const fnMatch = source.match(
-      /async function getStatusesByTimelineType[\s\S]*?^}/m,
+    const fnMatch = /async function getStatusesByTimelineType[\s\S]*?^}/m.exec(
+      source,
     )
     expect(fnMatch).not.toBeNull()
     const fnSource = fnMatch?.[0]
@@ -34,8 +34,8 @@ describe('Phase 1 クエリが timeline_entries を使用する', () => {
   })
 
   it('getStatusesByCustomQuery の ptt JOIN が timeline_entries を含む', () => {
-    const fnMatch = source.match(
-      /async function getStatusesByCustomQuery[\s\S]*?^}/m,
+    const fnMatch = /async function getStatusesByCustomQuery[\s\S]*?^}/m.exec(
+      source,
     )
     expect(fnMatch).not.toBeNull()
     const fnSource = fnMatch?.[0]
@@ -48,8 +48,8 @@ describe('Phase 1 クエリが timeline_entries を使用する', () => {
 
 describe('Phase 1 クエリが timeline_items を使用しない', () => {
   it('getStatusesByTimelineType が timeline_items を含まない', () => {
-    const fnMatch = source.match(
-      /async function getStatusesByTimelineType[\s\S]*?^}/m,
+    const fnMatch = /async function getStatusesByTimelineType[\s\S]*?^}/m.exec(
+      source,
     )
     expect(fnMatch).not.toBeNull()
     const fnSource = fnMatch?.[0]
@@ -57,8 +57,8 @@ describe('Phase 1 クエリが timeline_items を使用しない', () => {
   })
 
   it('getStatusesByCustomQuery が timeline_items を含まない', () => {
-    const fnMatch = source.match(
-      /async function getStatusesByCustomQuery[\s\S]*?^}/m,
+    const fnMatch = /async function getStatusesByCustomQuery[\s\S]*?^}/m.exec(
+      source,
     )
     expect(fnMatch).not.toBeNull()
     const fnSource = fnMatch?.[0]
@@ -70,8 +70,8 @@ describe('Phase 1 クエリが timeline_items を使用しない', () => {
 
 describe('getDistinctTimelineTypes が timeline_entries を使用する', () => {
   it('getDistinctTimelineTypes の SQL が timeline_entries を含む', () => {
-    const fnMatch = source.match(
-      /async function getDistinctTimelineTypes[\s\S]*?^}/m,
+    const fnMatch = /async function getDistinctTimelineTypes[\s\S]*?^}/m.exec(
+      source,
     )
     expect(fnMatch).not.toBeNull()
     const fnSource = fnMatch?.[0]
@@ -79,8 +79,8 @@ describe('getDistinctTimelineTypes が timeline_entries を使用する', () => 
   })
 
   it('getDistinctTimelineTypes が timeline_key を使用する（code ではない）', () => {
-    const fnMatch = source.match(
-      /async function getDistinctTimelineTypes[\s\S]*?^}/m,
+    const fnMatch = /async function getDistinctTimelineTypes[\s\S]*?^}/m.exec(
+      source,
     )
     expect(fnMatch).not.toBeNull()
     const fnSource = fnMatch?.[0]
@@ -88,8 +88,8 @@ describe('getDistinctTimelineTypes が timeline_entries を使用する', () => 
   })
 
   it('getDistinctTimelineTypes が channel_kinds を使用しない', () => {
-    const fnMatch = source.match(
-      /async function getDistinctTimelineTypes[\s\S]*?^}/m,
+    const fnMatch = /async function getDistinctTimelineTypes[\s\S]*?^}/m.exec(
+      source,
     )
     expect(fnMatch).not.toBeNull()
     const fnSource = fnMatch?.[0]
@@ -97,8 +97,8 @@ describe('getDistinctTimelineTypes が timeline_entries を使用する', () => 
   })
 
   it('getDistinctTimelineTypes が timelines テーブルを JOIN しない', () => {
-    const fnMatch = source.match(
-      /async function getDistinctTimelineTypes[\s\S]*?^}/m,
+    const fnMatch = /async function getDistinctTimelineTypes[\s\S]*?^}/m.exec(
+      source,
     )
     expect(fnMatch).not.toBeNull()
     const fnSource = fnMatch?.[0]
@@ -132,8 +132,8 @@ describe('post_engagements テーブルを使用しない', () => {
   })
 
   it('getBookmarkedStatuses が post_interactions を使用する', () => {
-    const fnMatch = source.match(
-      /async function getBookmarkedStatuses[\s\S]*?^}/m,
+    const fnMatch = /async function getBookmarkedStatuses[\s\S]*?^}/m.exec(
+      source,
     )
     expect(fnMatch).not.toBeNull()
     const fnSource = fnMatch?.[0]

--- a/src/util/db/sqlite/__tests__/schema.test.ts
+++ b/src/util/db/sqlite/__tests__/schema.test.ts
@@ -11,7 +11,6 @@ import { createPostTables } from 'util/db/sqlite/schema/tables/posts'
 import { createProfileTables } from 'util/db/sqlite/schema/tables/profiles'
 import { createRegistryTables } from 'util/db/sqlite/schema/tables/registries'
 import { createTimelineTables } from 'util/db/sqlite/schema/tables/timeline'
-import type { SchemaDbHandle } from 'util/db/sqlite/worker/workerSchema'
 import { describe, expect, it, vi } from 'vitest'
 
 // ─── Mock DB factory ────────────────────────────────────────────
@@ -458,7 +457,7 @@ describe('スキーマ定義', () => {
   describe('createFreshSchema', () => {
     it('12個の create*Tables 関数をFK依存順に呼び出す', () => {
       const { db, execCalls } = createMockDb()
-      const handle = { db } as SchemaDbHandle
+      const handle = { db }
       createFreshSchema(handle)
 
       // FK 依存順を確認: lookup → registries → profiles → accounts → posts → ...
@@ -490,7 +489,7 @@ describe('スキーマ定義', () => {
 
     it('合計30テーブルの CREATE TABLE 文を生成する', () => {
       const { db, execCalls } = createMockDb()
-      const handle = { db } as SchemaDbHandle
+      const handle = { db }
       createFreshSchema(handle)
 
       const createTableCalls = execCalls.filter((sql) =>
@@ -504,7 +503,7 @@ describe('スキーマ定義', () => {
   describe('dropAllTables', () => {
     it('sqlite_master から全テーブル名を取得する', () => {
       const { db } = createMockDb()
-      const handle = { db } as SchemaDbHandle
+      const handle = { db }
       dropAllTables(handle)
 
       expect(db.exec).toHaveBeenCalledWith(
@@ -524,7 +523,7 @@ describe('スキーマ定義', () => {
           return undefined
         }),
       }
-      const handle = { db } as SchemaDbHandle
+      const handle = { db }
       dropAllTables(handle)
 
       const fkOffIdx = execCalls.indexOf('PRAGMA foreign_keys = OFF;')
@@ -551,7 +550,7 @@ describe('スキーマ定義', () => {
           return undefined
         }),
       }
-      const handle = { db } as SchemaDbHandle
+      const handle = { db }
       dropAllTables(handle)
 
       const dropIdx = execCalls.findIndex((sql) => sql.includes('DROP TABLE'))

--- a/src/util/db/sqlite/__tests__/v2-0-6-migration.test.ts
+++ b/src/util/db/sqlite/__tests__/v2-0-6-migration.test.ts
@@ -1,5 +1,4 @@
 import { v2_0_6_migration } from 'util/db/sqlite/migrations/v2.0.6'
-import type { SchemaDbHandle } from 'util/db/sqlite/worker/workerSchema'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 function createMockDb(indexExists: boolean) {
@@ -24,7 +23,7 @@ function createMockDb(indexExists: boolean) {
       return undefined
     }),
   }
-  return { db, execCalls, handle: { db } as SchemaDbHandle }
+  return { db, execCalls, handle: { db } }
 }
 
 describe('v2.0.6 マイグレーション', () => {

--- a/src/util/db/sqlite/__tests__/v2-0-7-migration.test.ts
+++ b/src/util/db/sqlite/__tests__/v2-0-7-migration.test.ts
@@ -1,5 +1,4 @@
 import { v2_0_7_migration } from 'util/db/sqlite/migrations/v2.0.7'
-import type { SchemaDbHandle } from 'util/db/sqlite/worker/workerSchema'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 function createMockDb(indexExists: boolean) {
@@ -20,7 +19,7 @@ function createMockDb(indexExists: boolean) {
       return undefined
     }),
   }
-  return { db, execCalls, handle: { db } as SchemaDbHandle }
+  return { db, execCalls, handle: { db } }
 }
 
 describe('v2.0.7 マイグレーション', () => {

--- a/src/util/db/sqlite/__tests__/v2-migration.test.ts
+++ b/src/util/db/sqlite/__tests__/v2-migration.test.ts
@@ -10,7 +10,6 @@ import { migrations, runMigrations } from 'util/db/sqlite/migrations'
 import { v2_0_0_migration } from 'util/db/sqlite/migrations/v2.0.0'
 import { createFreshSchema, dropAllTables } from 'util/db/sqlite/schema'
 import { encodeSemVer } from 'util/db/sqlite/schema/version'
-import type { SchemaDbHandle } from 'util/db/sqlite/worker/workerSchema'
 
 // ─── Mock DB factory ────────────────────────────────────────────
 function createMockDb(userVersion: number) {
@@ -26,7 +25,7 @@ function createMockDb(userVersion: number) {
       return undefined
     }),
   }
-  return { db, handle: { db } as SchemaDbHandle }
+  return { db, handle: { db } }
 }
 
 type V2MigrationMockState = {
@@ -150,7 +149,7 @@ function createV2MigrationMockDb(v2Encoded: number) {
       return undefined
     }),
   }
-  return { db, handle: { db } as SchemaDbHandle }
+  return { db, handle: { db } }
 }
 
 describe('v2.0.0 マイグレーション', () => {
@@ -245,7 +244,7 @@ describe('v2.0.0 マイグレーション', () => {
           return undefined
         }),
       }
-      const handle = { db } as SchemaDbHandle
+      const handle = { db }
       expect(v2_0_0_migration.validate).toBeDefined()
       expect(v2_0_0_migration.validate?.(handle)).toBe(true)
       // 28テーブル分のクエリが発行される
@@ -273,7 +272,7 @@ describe('v2.0.0 マイグレーション', () => {
           return undefined
         }),
       }
-      const handle = { db } as SchemaDbHandle
+      const handle = { db }
       expect(v2_0_0_migration.validate?.(handle)).toBe(false)
       expect(consoleSpy).toHaveBeenCalledWith(
         expect.stringContaining("table 'posts' not found"),

--- a/src/util/db/sqlite/explainLogger.ts
+++ b/src/util/db/sqlite/explainLogger.ts
@@ -42,10 +42,13 @@ function flushQueue(): void {
   // Worker 環境のみ postMessage を使用する
   // Window 環境（fallback DB 実装）では window.postMessage となり
   // targetOrigin 引数が必須のため、ここでは送信せずにキューを破棄する。
-  if (typeof window !== 'undefined' && self === window) {
+  if (
+    typeof globalThis.window !== 'undefined' &&
+    globalThis === globalThis.window
+  ) {
     return
   }
-  self.postMessage(message)
+  globalThis.postMessage(message)
 }
 
 /**
@@ -66,7 +69,7 @@ function sanitizeSql(sql: string): string {
   // Bearer トークンや長い文字列リテラルをマスクする
   const masked = normalized
     // e.g. "Authorization: Bearer abcdef..." のようなパターン
-    .replace(/\bBearer\s+[A-Za-z0-9._~+/\\-]+=*/gi, 'Bearer [REDACTED]')
+    .replace(/\bBearer\s+[A-Z0-9._~+/\\-]+=*/gi, 'Bearer [REDACTED]')
     // シングルクォートで囲まれた不自然に長いリテラル
     .replace(/'[^']{50,}'/g, "'[REDACTED]'")
     // ダブルクォートで囲まれた不自然に長いリテラル
@@ -141,7 +144,9 @@ export function logSlowQueryExplain(
     sql: sanitizeSql(sql),
     timestamp: new Date().toISOString(),
     userAgent:
-      typeof navigator !== 'undefined' ? navigator.userAgent : 'unknown',
+      typeof globalThis.navigator === 'undefined'
+        ? 'unknown'
+        : globalThis.navigator.userAgent,
   }
   logQueue.push(entry)
 

--- a/src/util/db/sqlite/helpers/cache.ts
+++ b/src/util/db/sqlite/helpers/cache.ts
@@ -18,11 +18,17 @@ export const emojiIdCache = new Map<string, number>()
 /** backend_url → local_accounts.id | null */
 export const localAccountIdCache = new Map<string, number | null>()
 
+const allCaches: { clear(): void }[] = [
+  serverIdCache,
+  serverHostCache,
+  profileIdCache,
+  emojiIdCache,
+  localAccountIdCache,
+]
+
 /** 全キャッシュをクリアする */
 export function clearAllCaches(): void {
-  serverIdCache.clear()
-  serverHostCache.clear()
-  profileIdCache.clear()
-  emojiIdCache.clear()
-  localAccountIdCache.clear()
+  for (const cache of allCaches) {
+    cache.clear()
+  }
 }

--- a/src/util/db/sqlite/helpers/emoji.ts
+++ b/src/util/db/sqlite/helpers/emoji.ts
@@ -1,4 +1,8 @@
-import type { WrittenTableCollector } from '../protocol'
+import type {
+  BindValue,
+  SqliteResultRows,
+  WrittenTableCollector,
+} from '../protocol'
 import { emojiIdCache } from './cache'
 
 /**
@@ -9,7 +13,7 @@ export function ensureCustomEmoji(
     exec: (
       sql: string,
       opts?: {
-        bind?: (string | number | null)[]
+        bind?: BindValue[]
         returnValue?: 'resultRows'
       },
     ) => unknown
@@ -63,7 +67,7 @@ export function syncPostCustomEmojis(
     exec: (
       sql: string,
       opts?: {
-        bind?: (string | number | null)[]
+        bind?: BindValue[]
         returnValue?: 'resultRows'
       },
     ) => unknown
@@ -112,7 +116,7 @@ export function syncPostCustomEmojis(
 // ================================================================
 
 /** :shortcode: または :shortcode@host: パターンを抽出する正規表現 */
-export const CUSTOM_EMOJI_RE = /:([a-zA-Z0-9_]+)(?:@[\w.-]+)?:/g
+export const CUSTOM_EMOJI_RE = /:(\w+)(?:@[\w.-]+)?:/g
 
 /**
  * テキスト中の :shortcode: パターンから DB 上のカスタム絵文字を解決する。
@@ -126,7 +130,7 @@ export function resolveEmojisFromDb(
     exec: (
       sql: string,
       opts?: {
-        bind?: (string | number | null)[]
+        bind?: BindValue[]
         returnValue?: 'resultRows'
       },
     ) => unknown
@@ -158,7 +162,7 @@ export function resolveEmojisFromDb(
     const rows = db.exec(
       'SELECT url, static_url, visible_in_picker FROM custom_emojis WHERE server_id = ? AND shortcode = ?;',
       { bind: [serverId, shortcode], returnValue: 'resultRows' },
-    ) as (string | number | null)[][]
+    ) as SqliteResultRows
 
     if (rows.length > 0) {
       result.push({

--- a/src/util/db/sqlite/helpers/post.ts
+++ b/src/util/db/sqlite/helpers/post.ts
@@ -45,7 +45,7 @@ export function extractPostColumns(status: Entity.Status): PostColumns {
   // quote 関連: megalodon の型定義にはないが実データに存在し得るフィールド
   const statusAny = status as Record<string, unknown>
   const quote = statusAny.quote as Entity.Status | null | undefined
-  const quoteState: string | null = quote != null ? 'accepted' : null
+  const quoteState: string | null = quote == null ? null : 'accepted'
 
   // plain_content: megalodon の型定義にはないがバックエンドによっては存在する
   const plainContent =

--- a/src/util/db/sqlite/migrations/index.ts
+++ b/src/util/db/sqlite/migrations/index.ts
@@ -152,7 +152,7 @@ export function stampSchemaVersion(
   try {
     db.exec(
       `INSERT OR REPLACE INTO schema_version (version, applied_at, description)
-       VALUES ('${formatSemVer(version)}', ${Date.now()}, '${description.replace(/'/g, "''")}')`,
+       VALUES ('${formatSemVer(version)}', ${Date.now()}, '${description.replaceAll("'", "''")}')`,
     )
   } catch {
     // schema_version テーブルがまだ存在しない場合は無視

--- a/src/util/db/sqlite/queries/__tests__/executionEngine.test.ts
+++ b/src/util/db/sqlite/queries/__tests__/executionEngine.test.ts
@@ -1,15 +1,16 @@
+import { describe, expect, it } from 'vitest'
 import type { SerializedExecutionPlan } from '../../protocol'
 import type { DbExec } from '../executionEngine'
 import { executeQueryPlan } from '../executionEngine'
 
-function createMockDb(
-  responses: Map<string, (string | number | null)[][]>,
-): DbExec {
+type SqlValue = string | number | null
+
+function createMockDb(responses: Map<string, SqlValue[][]>): DbExec {
   return {
     exec: (
       sql: string,
       _opts: {
-        bind?: (string | number | null)[]
+        bind?: SqlValue[]
         returnValue: 'resultRows'
       },
     ) => {
@@ -26,7 +27,7 @@ function createMockDb(
 describe('executeQueryPlan', () => {
   describe('IdCollectStep', () => {
     it('Phase1 クエリを実行して行データを返す', () => {
-      const mockRawRows: (string | number | null)[][] = [
+      const mockRawRows: SqlValue[][] = [
         [1, 1000],
         [2, 2000],
         [3, 3000],
@@ -60,7 +61,7 @@ describe('executeQueryPlan', () => {
     })
 
     it('バインドパラメータ付きクエリを実行する', () => {
-      let capturedBinds: (string | number | null)[] | undefined
+      let capturedBinds: SqlValue[] | undefined
       const db: DbExec = {
         exec: (_sql, opts) => {
           capturedBinds = opts.bind ?? undefined

--- a/src/util/db/sqlite/queries/assembleStatusFromBatch.ts
+++ b/src/util/db/sqlite/queries/assembleStatusFromBatch.ts
@@ -111,7 +111,7 @@ export function assembleStatusFromBatch(
       bookmarked: rbInteractions?.is_bookmarked === 1,
       card: null,
       content: (row[26] as string) ?? '',
-      created_at: row[34] ? new Date(row[34] as number).toISOString() : '',
+      created_at: row[34] ? new Date(row[34]).toISOString() : '',
       edited_at: editedAtMsToIso(rbEditedAtMs),
       emoji_reactions: mergeLocalReaction(
         parseEmojiReactions(rbEmojiReactionsJson),

--- a/src/util/db/sqlite/queries/rowToStoredStatus.ts
+++ b/src/util/db/sqlite/queries/rowToStoredStatus.ts
@@ -145,7 +145,7 @@ export function rowToStoredStatus(
       ),
       card: null,
       content: (row[34] as string) ?? '',
-      created_at: row[42] ? new Date(row[42] as number).toISOString() : '',
+      created_at: row[42] ? new Date(row[42]).toISOString() : '',
       edited_at: editedAtMsToIso(rbEditedAtMs),
       emoji_reactions: mergeLocalReaction(
         parseEmojiReactions(rbEmojiReactionsJson),

--- a/src/util/db/sqlite/queries/statusBatch.ts
+++ b/src/util/db/sqlite/queries/statusBatch.ts
@@ -5,6 +5,7 @@
  */
 
 import type { getSqliteDb } from '../connection'
+import type { SqliteResultRows } from '../protocol'
 
 // ================================================================
 // SqliteHandle 型
@@ -250,14 +251,14 @@ export const BATCH_SQL_TEMPLATES = {
 
 /** FetchTimelineResult.batchResults の型（Worker からの生行データ） */
 export type BatchResultRows = {
-  interactions: (string | number | null)[][]
-  media: (string | number | null)[][]
-  mentions: (string | number | null)[][]
-  timelineTypes: (string | number | null)[][]
-  belongingTags: (string | number | null)[][]
-  customEmojis: (string | number | null)[][]
-  profileEmojis: (string | number | null)[][]
-  polls: (string | number | null)[][]
+  interactions: SqliteResultRows
+  media: SqliteResultRows
+  mentions: SqliteResultRows
+  timelineTypes: SqliteResultRows
+  belongingTags: SqliteResultRows
+  customEmojis: SqliteResultRows
+  profileEmojis: SqliteResultRows
+  polls: SqliteResultRows
 }
 
 // ================================================================
@@ -418,32 +419,32 @@ export async function executeBatchQueries(
         kind: 'timeline',
         returnValue: 'resultRows',
       },
-    ) as Promise<(string | number | null)[][]>,
+    ) as Promise<SqliteResultRows>,
     handle.execAsync(replacePlaceholders(BATCH_MEDIA_SQL, count), {
       bind: allPostIds,
       kind: 'timeline',
       returnValue: 'resultRows',
-    }) as Promise<(string | number | null)[][]>,
+    }) as Promise<SqliteResultRows>,
     handle.execAsync(replacePlaceholders(BATCH_MENTIONS_SQL, count), {
       bind: allPostIds,
       kind: 'timeline',
       returnValue: 'resultRows',
-    }) as Promise<(string | number | null)[][]>,
+    }) as Promise<SqliteResultRows>,
     handle.execAsync(replacePlaceholders(BATCH_TIMELINE_TYPES_SQL, count), {
       bind: allPostIds,
       kind: 'timeline',
       returnValue: 'resultRows',
-    }) as Promise<(string | number | null)[][]>,
+    }) as Promise<SqliteResultRows>,
     handle.execAsync(replacePlaceholders(BATCH_BELONGING_TAGS_SQL, count), {
       bind: allPostIds,
       kind: 'timeline',
       returnValue: 'resultRows',
-    }) as Promise<(string | number | null)[][]>,
+    }) as Promise<SqliteResultRows>,
     handle.execAsync(replacePlaceholders(BATCH_CUSTOM_EMOJIS_SQL, count), {
       bind: allPostIds,
       kind: 'timeline',
       returnValue: 'resultRows',
-    }) as Promise<(string | number | null)[][]>,
+    }) as Promise<SqliteResultRows>,
     handle.execAsync(
       replacePlaceholders(BATCH_PROFILE_CUSTOM_EMOJIS_SQL, count),
       {
@@ -451,12 +452,12 @@ export async function executeBatchQueries(
         kind: 'timeline',
         returnValue: 'resultRows',
       },
-    ) as Promise<(string | number | null)[][]>,
+    ) as Promise<SqliteResultRows>,
     handle.execAsync(replacePlaceholders(BATCH_POLLS_SQL, count), {
       bind: pollsBind,
       kind: 'timeline',
       returnValue: 'resultRows',
-    }) as Promise<(string | number | null)[][]>,
+    }) as Promise<SqliteResultRows>,
   ])
 
   // 結果を Map に変換

--- a/src/util/db/sqlite/queries/statusCustomQuery.ts
+++ b/src/util/db/sqlite/queries/statusCustomQuery.ts
@@ -36,7 +36,7 @@ export function sanitizeWhereClause(input: string): string {
   return (
     input
       // セミコロンを除去（複文実行防止）
-      .replace(/;/g, '')
+      .replaceAll(';', '')
       // LIMIT/OFFSET を除去（自動設定のため）
       .replace(/\bLIMIT\b\s+\d+/gi, '')
       .replace(/\bOFFSET\b\s+\d+/gi, '')

--- a/src/util/db/sqlite/queries/statusMapperParsers.ts
+++ b/src/util/db/sqlite/queries/statusMapperParsers.ts
@@ -238,7 +238,7 @@ export function parseBatchPoll(json: string): Entity.Poll {
  * edited_at_ms (INTEGER | null) を ISO 文字列 | null に変換する
  */
 export function editedAtMsToIso(ms: number | null): string | null {
-  return ms != null ? new Date(ms).toISOString() : null
+  return ms == null ? null : new Date(ms).toISOString()
 }
 
 /** interactions JSON をパースして返す（null なら null） */

--- a/src/util/db/sqlite/queries/statusSelect.ts
+++ b/src/util/db/sqlite/queries/statusSelect.ts
@@ -266,7 +266,9 @@ export const STATUS_BASE_SELECT = `
  */
 export function buildSpbFilter(backendUrls: string[]): string {
   if (backendUrls.length === 0) return ''
-  const quoted = backendUrls.map((u) => `'${u.replace(/'/g, "''")}'`).join(',')
+  const quoted = backendUrls
+    .map((u) => `'${u.replaceAll("'", "''")}'`)
+    .join(',')
   return `AND spb_min.server_id IN (SELECT la.server_id FROM local_accounts la WHERE la.backend_url IN (${quoted}))`
 }
 
@@ -288,7 +290,9 @@ export function buildScopedEngagementsSql(
       ? BATCH_SQL_TEMPLATES.interactions
       : BATCH_INTERACTIONS_SQL
   }
-  const quoted = backendUrls.map((u) => `'${u.replace(/'/g, "''")}'`).join(',')
+  const quoted = backendUrls
+    .map((u) => `'${u.replaceAll("'", "''")}'`)
+    .join(',')
   return `
   SELECT pi.post_id,
     json_object(

--- a/src/util/db/sqlite/stores/statusStore.ts
+++ b/src/util/db/sqlite/stores/statusStore.ts
@@ -94,11 +94,9 @@ export async function upsertStatus(
   }
 
   // タイマーが未設定なら設定
-  if (flushTimer === null) {
-    flushTimer = setTimeout(() => {
-      flushAllBuffers()
-    }, FLUSH_INTERVAL_MS)
-  }
+  flushTimer ??= setTimeout(() => {
+    flushAllBuffers()
+  }, FLUSH_INTERVAL_MS)
 }
 
 /**

--- a/src/util/db/sqlite/worker/handlers/statusHandlers.ts
+++ b/src/util/db/sqlite/worker/handlers/statusHandlers.ts
@@ -542,7 +542,7 @@ function upsertSingleStatus(
     collector,
   )
 
-  const isReblog = status.reblog != null ? 1 : 0
+  const isReblog = status.reblog == null ? 0 : 1
   const reblogOfUri = status.reblog?.uri ?? null
 
   if (isReblog === 1 && status.reblog) {
@@ -575,18 +575,7 @@ function upsertSingleStatus(
     isReblog === 1 ? resolveRepostOfPostId(db, reblogOfUri) : null
 
   let postId: number
-  if (existingPostId !== undefined) {
-    updateExistingPostRow(
-      db,
-      existingPostId,
-      now,
-      visibilityId,
-      cols,
-      isReblog,
-      reblogOfPostId,
-    )
-    postId = existingPostId
-  } else {
+  if (existingPostId === undefined) {
     postId = insertNewPostRow(db, {
       cols,
       existingIsOriginal,
@@ -598,6 +587,17 @@ function upsertSingleStatus(
       serverId,
       visibilityId,
     })
+  } else {
+    updateExistingPostRow(
+      db,
+      existingPostId,
+      now,
+      visibilityId,
+      cols,
+      isReblog,
+      reblogOfPostId,
+    )
+    postId = existingPostId
   }
   collector?.add('posts')
 

--- a/src/util/db/sqlite/worker/handlers/statusUpdateHandler.ts
+++ b/src/util/db/sqlite/worker/handlers/statusUpdateHandler.ts
@@ -151,7 +151,7 @@ function applyStatusUpdate(
     )
   }
 
-  const isReblog = status.reblog != null ? 1 : 0
+  const isReblog = status.reblog == null ? 0 : 1
   const reblogOfUri = status.reblog?.uri ?? null
   const reblogOfPostId =
     isReblog === 1 ? resolveRepostOfPostId(db, reblogOfUri) : null

--- a/src/util/db/sqlite/worker/sqlite.worker.ts
+++ b/src/util/db/sqlite/worker/sqlite.worker.ts
@@ -372,7 +372,7 @@ function dispatchWorkerRequest(msg: WorkerRequest, db: WorkerDb): void {
   }
 }
 
-self.onmessage = (
+globalThis.onmessage = (
   event: MessageEvent<WorkerRequest | { type: '__init'; origin: string }>,
 ) => {
   const msg = event.data

--- a/src/util/emojiReplacer.ts
+++ b/src/util/emojiReplacer.ts
@@ -23,5 +23,5 @@ export function replaceEmojis(
 }
 
 function escapeForRegex(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return s.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`)
 }

--- a/src/util/escapeHtml.ts
+++ b/src/util/escapeHtml.ts
@@ -4,9 +4,9 @@
  */
 export function escapeHtml(text: string): string {
   return text
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;')
 }

--- a/src/util/explainQueryPlan/formatSql.ts
+++ b/src/util/explainQueryPlan/formatSql.ts
@@ -10,7 +10,7 @@ export function formatSql(sql: string): string {
   // 空行を除いた各行の先頭スペース数を取得し、最小値を共通インデントとする
   const indents = lines
     .filter((l) => l.trim().length > 0)
-    .map((l) => l.match(/^(\s*)/)?.[1].length ?? 0)
+    .map((l) => /^(\s*)/.exec(l)?.[1].length ?? 0)
   const minIndent = indents.length > 0 ? Math.min(...indents) : 0
 
   return lines

--- a/src/util/explainQueryPlan/queryBuilders.ts
+++ b/src/util/explainQueryPlan/queryBuilders.ts
@@ -441,8 +441,8 @@ function buildCustomStatusQuery(
   if (refs.pbt) {
     joinLines.push(
       'LEFT JOIN post_hashtags pht\n          ON p.id = pht.post_id',
+      'LEFT JOIN hashtags ht\n          ON pht.hashtag_id = ht.id',
     )
-    joinLines.push('LEFT JOIN hashtags ht\n          ON pht.hashtag_id = ht.id')
   }
   if (refs.pme)
     joinLines.push(

--- a/src/util/hooks/useTimelineDataSource.ts
+++ b/src/util/hooks/useTimelineDataSource.ts
@@ -17,7 +17,7 @@ import type {
   TimelineConfigV2,
 } from 'types/types'
 import { configToQueryPlanV2 } from 'util/db/query-ir/configToQueryPlanV2'
-import type { SerializedGraphPlan } from 'util/db/query-ir/executor/types'
+import { migrateQueryPlanInputBindings } from 'util/db/query-ir/migrateInputBindings'
 import {
   isQueryPlanV2,
   type PaginationCursor,
@@ -29,6 +29,7 @@ import {
   patchPlanForFetch,
   patchPlanForStreamingFetch,
 } from 'util/db/query-ir/patchPlanForFetch'
+import { migrateQueryPlanV1ToV2 } from 'util/db/query-ir/v2/migrateV1ToV2'
 import {
   type ChangeHint,
   getSqliteDb,
@@ -116,7 +117,10 @@ export function useTimelineDataSource(
   // biome-ignore lint/correctness/useExhaustiveDependencies: refreshToken は外部からの設定変更を検知するために必要
   const basePlan: QueryPlanV2 | null = useMemo(() => {
     if (config.queryPlan) {
-      return config.queryPlan as QueryPlanV2
+      const queryPlanV2 = isQueryPlanV2(config.queryPlan)
+        ? config.queryPlan
+        : migrateQueryPlanV1ToV2(config.queryPlan)
+      return migrateQueryPlanInputBindings(queryPlanV2)
     }
     if (localAccountIds.length === 0) return null
     return configToQueryPlanV2(config, {
@@ -192,7 +196,7 @@ export function useTimelineDataSource(
       try {
         const handle = await getSqliteDb()
         const result = await handle.executeGraphPlan(
-          plan as unknown as SerializedGraphPlan,
+          plan,
           { backendUrls: targetBackendUrls },
           fetchOptions?.sessionTag,
         )

--- a/src/util/misskey/accountOperations.ts
+++ b/src/util/misskey/accountOperations.ts
@@ -6,7 +6,11 @@ import {
   NotImplementedError,
   wrapResponse,
 } from './helpers'
-import { mapUserDetailedToAccount, mapUserLiteToAccount } from './mappers'
+import {
+  mapNoteToStatus,
+  mapUserDetailedToAccount,
+  mapUserLiteToAccount,
+} from './mappers'
 
 // =============================================
 // OAuth / App Registration
@@ -179,12 +183,12 @@ export async function getAccountStatuses(
     ...(options?.max_id ? { untilId: options.max_id } : {}),
     ...(options?.since_id ? { sinceId: options.since_id } : {}),
     ...(options?.only_media ? { withFiles: true } : {}),
-    ...(options?.exclude_replies != null
-      ? { withReplies: !options.exclude_replies }
-      : {}),
-    ...(options?.exclude_reblogs != null
-      ? { withRenotes: !options.exclude_reblogs }
-      : {}),
+    ...(options?.exclude_replies == null
+      ? {}
+      : { withReplies: !options.exclude_replies }),
+    ...(options?.exclude_reblogs == null
+      ? {}
+      : { withRenotes: !options.exclude_reblogs }),
   })
   return wrapResponse(notes.map((n) => mapNoteToStatus(n, ctx.origin)))
 }
@@ -414,7 +418,7 @@ export async function searchAccount(
   },
 ): Promise<Response<Array<Entity.Account>>> {
   // acct 形式 (user@host) の場合は users/search-by-username-and-host を使用
-  const acctMatch = q.match(/^@?(\w[\w.-]*)@([\w.-]+\.\w+)$/)
+  const acctMatch = /^@?(\w[\w.-]*)@([\w.-]+\.\w+)$/.exec(q)
   if (acctMatch) {
     const username = acctMatch[1]
     const host = acctMatch[2]
@@ -512,6 +516,3 @@ export async function rejectFollowRequest(
   await ctx.client.request('following/requests/reject', { userId: id })
   return getRelationship(ctx, id)
 }
-
-// Re-export mapNoteToStatus for use in getAccountStatuses
-import { mapNoteToStatus } from './mappers'

--- a/src/util/misskey/mappers.ts
+++ b/src/util/misskey/mappers.ts
@@ -385,15 +385,15 @@ export function mapNoteToStatus(
         }
       : null,
     quote:
-      note.renote && !isRenote
-        ? {
+      isRenote || note.renote == null
+        ? null
+        : {
             quoted_status: mapNoteToStatus(note.renote, instanceHost),
             state: 'accepted' as Entity.QuoteState,
-          }
-        : null,
+          },
     quote_approval: null as unknown as Entity.Status['quote_approval'],
     reblog,
-    reblogged: ext.myRenoteId != null ? true : null,
+    reblogged: ext.myRenoteId == null ? null : true,
     reblogs_count: note.renoteCount ?? 0,
     replies_count: note.repliesCount ?? 0,
     sensitive: (note.files ?? []).some((f) => f.isSensitive),

--- a/src/util/misskey/mfmRenderer.ts
+++ b/src/util/misskey/mfmRenderer.ts
@@ -51,7 +51,7 @@ function childrenToHtml(node: { children?: MfmNode[] }, host: string): string {
 function nodeToHtml(node: MfmNode, host: string): string {
   switch (node.type) {
     case 'text':
-      return escapeHtml(node.props.text).replace(/\n/g, '<br>')
+      return escapeHtml(node.props.text).replaceAll('\n', '<br>')
     case 'bold':
       return `<strong>${childrenToHtml(node, host)}</strong>`
     case 'italic':
@@ -140,7 +140,7 @@ function renderAnimationFn(
 
 function renderSpinFn(args: MfmFnArgs, children: string): string {
   const speed = sanitizeDuration(args.speed) ?? '1.5s'
-  const direction = args.alternate != null ? 'alternate' : 'normal'
+  const direction = args.alternate == null ? 'normal' : 'alternate'
   const axis = getSpinAxis(args)
   const cls = axis ? `mfm-spin-${axis}` : 'mfm-spin'
   return `<span class="${cls}" style="animation-duration:${speed};animation-direction:${direction}">${children}</span>`
@@ -254,30 +254,28 @@ const fnHtmlRenderers: Partial<Record<string, FnHtmlRenderer>> = {
 
 // escapeHtml is imported from util/escapeHtml
 
+type MfmFnArgValue = string | true | undefined
+
 /** CSS duration (e.g. "1s", "500ms", "0.5s") を検証 */
-function sanitizeDuration(
-  value: string | true | undefined,
-): string | undefined {
+function sanitizeDuration(value: MfmFnArgValue): string | undefined {
   if (value == null || value === true) return undefined
   return /^\d+(\.\d+)?(s|ms)$/.test(value) ? value : undefined
 }
 
 /** 数値文字列を検証 (負数・小数を許容) */
-function sanitizeNumber(value: string | true | undefined): string | undefined {
+function sanitizeNumber(value: MfmFnArgValue): string | undefined {
   if (value == null || value === true) return undefined
   return /^-?\d+(\.\d+)?$/.test(value) ? value : undefined
 }
 
 /** CSS カラー値を検証 (hex のみ許容) */
-function sanitizeColor(value: string | true | undefined): string | undefined {
+function sanitizeColor(value: MfmFnArgValue): string | undefined {
   if (value == null || value === true) return undefined
   return /^[0-9a-fA-F]{3,8}$/.test(value) ? `#${value}` : undefined
 }
 
 /** border-style を検証 */
-function sanitizeBorderStyle(
-  value: string | true | undefined,
-): string | undefined {
+function sanitizeBorderStyle(value: MfmFnArgValue): string | undefined {
   if (value == null || value === true) return undefined
   const allowed = ['solid', 'dashed', 'dotted', 'double', 'none', 'hidden']
   return allowed.includes(value) ? value : undefined

--- a/src/util/misskey/notificationOperations.ts
+++ b/src/util/misskey/notificationOperations.ts
@@ -48,7 +48,7 @@ export async function dismissNotifications(
   ctx: MisskeyClientContext,
 ): Promise<Response<Record<string, never>>> {
   await ctx.client.request('notifications/mark-all-as-read', {})
-  return wrapResponse({} as Record<string, never>)
+  return wrapResponse({})
 }
 
 export async function dismissNotification(
@@ -65,7 +65,7 @@ export async function readNotifications(
   },
 ): Promise<Response<Record<string, never>>> {
   await ctx.client.request('notifications/mark-all-as-read', {})
-  return wrapResponse({} as Record<string, never>)
+  return wrapResponse({})
 }
 
 // =============================================

--- a/src/util/misskey/statusOperations.ts
+++ b/src/util/misskey/statusOperations.ts
@@ -106,7 +106,7 @@ export async function deleteStatus(
   id: string,
 ): Promise<Response<Record<string, never>>> {
   await ctx.client.request('notes/delete', { noteId: id })
-  return wrapResponse({} as Record<string, never>)
+  return wrapResponse({})
 }
 
 export async function getStatusContext(
@@ -290,7 +290,7 @@ export async function uploadMedia(
   },
 ): Promise<Response<Entity.Attachment | Entity.AsyncAttachment>> {
   const params: Record<string, unknown> = {
-    file: file as Blob,
+    file,
   }
   if (options?.description) {
     params.comment = options.description

--- a/src/util/panelNavigation.ts
+++ b/src/util/panelNavigation.ts
@@ -106,7 +106,7 @@ export function detailToPath(params: SetDetailParams): string {
     case 'Status':
       // id が空（SQLite キャッシュ由来で local_id 未解決）の場合は
       // URL を変えず、DetailPanel 側で search API で解決させる
-      if (!params.content.id) return window.location.pathname
+      if (!params.content.id) return globalThis.location.pathname
       return `/status/${params.content.appIndex}/${params.content.id}`
     case 'Account':
       return `/profile/@${params.content.acct}`

--- a/src/util/provider/HomeTimelineProvider.tsx
+++ b/src/util/provider/HomeTimelineProvider.tsx
@@ -119,6 +119,19 @@ export const HomeTimelineProvider = ({ children }: { children: ReactNode }) => {
     onFirstFetch: onNotifFirstFetch,
   })
 
+  const homeStatuses = useMemo(
+    () =>
+      homeTimeline.filter((item): item is StatusAddAppIndex => 'uri' in item),
+    [homeTimeline],
+  )
+  const notificationItems = useMemo(
+    () =>
+      notifications.filter(
+        (item): item is NotificationAddAppIndex => 'type' in item,
+      ),
+    [notifications],
+  )
+
   // 既存APIとの互換性を保つためのラッパー
   // appIndex → backendUrl への変換をここで行う
   const setReblogged = useCallback(
@@ -157,10 +170,8 @@ export const HomeTimelineProvider = ({ children }: { children: ReactNode }) => {
   )
 
   return (
-    <HomeTimelineContext.Provider value={homeTimeline as StatusAddAppIndex[]}>
-      <NotificationsContext.Provider
-        value={notifications as NotificationAddAppIndex[]}
-      >
+    <HomeTimelineContext.Provider value={homeStatuses}>
+      <NotificationsContext.Provider value={notificationItems}>
         <SetActionsContext.Provider value={setActionsValue}>
           {children}
         </SetActionsContext.Provider>

--- a/src/util/queryBuilder/buildQueryFromConfig.ts
+++ b/src/util/queryBuilder/buildQueryFromConfig.ts
@@ -437,7 +437,7 @@ function buildTagCondition(tagConfig: TagConfig): string {
  * SQL 文字列リテラル内の単純なエスケープ
  */
 function escapeSqlString(value: string): string {
-  return value.replace(/'/g, "''")
+  return value.replaceAll("'", "''")
 }
 
 /**

--- a/src/util/queryBuilder/legacyRewrite.ts
+++ b/src/util/queryBuilder/legacyRewrite.ts
@@ -247,9 +247,10 @@ export function extractNotificationTypeCodes(
   }
 
   // 単一値: ntt.code = 'favourite' or ntt.name = 'favourite'
-  const singleMatch = whereClause.match(
-    /\b(?:ntt?|notification_types?)\.(?:code|name)\s*=\s*'([^']+)'/i,
-  )
+  const singleMatch =
+    /\b(?:ntt?|notification_types?)\.(?:code|name)\s*=\s*'([^']+)'/i.exec(
+      whereClause,
+    )
   if (singleMatch) return [singleMatch[1]]
 
   return null

--- a/src/util/queryBuilder/parseQueryToConfig.ts
+++ b/src/util/queryBuilder/parseQueryToConfig.ts
@@ -16,12 +16,9 @@ function parseQuotedList(raw: string): string[] {
     .filter(Boolean)
 }
 
-function matchFirst(
-  query: string,
-  patterns: RegExp[],
-): RegExpMatchArray | null {
+function matchFirst(query: string, patterns: RegExp[]): RegExpExecArray | null {
   for (const pattern of patterns) {
-    const match = query.match(pattern)
+    const match = pattern.exec(query)
     if (match) return match
   }
   return null
@@ -66,10 +63,11 @@ function applyMediaFilters(
     result.onlyMedia = true
   }
 
-  const mediaCountMatchV2 = query.match(
-    /\(\s*SELECT\s+COUNT\s*\(\s*\*\s*\)\s+FROM\s+post_media\b[^)]*\)\s*>=\s*(\d+)/i,
-  )
-  const mediaCountMatch = query.match(/p\.media_count\s*>=\s*(\d+)/i)
+  const mediaCountMatchV2 =
+    /\(\s*SELECT\s+COUNT\s*\(\s*\*\s*\)\s+FROM\s+post_media\b[^)]*\)\s*>=\s*(\d+)/i.exec(
+      query,
+    )
+  const mediaCountMatch = /p\.media_count\s*>=\s*(\d+)/i.exec(query)
   const mediaCountResult = mediaCountMatchV2 ?? mediaCountMatch
   if (!mediaCountResult) return
 
@@ -87,11 +85,11 @@ function applyVisibilityFilter(
   result: Partial<TimelineConfigV2>,
 ): void {
   const visibilityResult =
-    query.match(
-      /vt\.name\s+IN\s*\(\s*('(?:[^']|'')+'\s*(?:,\s*'(?:[^']|'')+'\s*)*)\)/i,
+    /vt\.name\s+IN\s*\(\s*('(?:[^']|'')+'\s*(?:,\s*'(?:[^']|'')+'\s*)*)\)/i.exec(
+      query,
     ) ??
-    query.match(
-      /p\.visibility\s+IN\s*\(\s*('(?:[^']|'')+'\s*(?:,\s*'(?:[^']|'')+'\s*)*)\)/i,
+    /p\.visibility\s+IN\s*\(\s*('(?:[^']|'')+'\s*(?:,\s*'(?:[^']|'')+'\s*)*)\)/i.exec(
+      query,
     )
   if (!visibilityResult) return
 
@@ -106,9 +104,10 @@ function applyLanguageFilter(
   query: string,
   result: Partial<TimelineConfigV2>,
 ): void {
-  const languageMatch = query.match(
-    /p\.language\s+IN\s*\(\s*('(?:[^']|'')+'\s*(?:,\s*'(?:[^']|'')+'\s*)*)\)/i,
-  )
+  const languageMatch =
+    /p\.language\s+IN\s*\(\s*('(?:[^']|'')+'\s*(?:,\s*'(?:[^']|'')+'\s*)*)\)/i.exec(
+      query,
+    )
   if (!languageMatch) return
 
   const languages = parseQuotedList(languageMatch[1])
@@ -206,7 +205,7 @@ function applyBackendFilter(
 
   const urls = backendInMatch[1]
     .split(',')
-    .map((v) => v.trim().replace(/^'|'$/g, '').replace(/''/g, "'"))
+    .map((v) => v.trim().replace(/^'|'$/g, '').replaceAll("''", "'"))
     .filter(Boolean)
 
   if (urls.length === 1) {

--- a/src/util/timelineFetcher.ts
+++ b/src/util/timelineFetcher.ts
@@ -129,7 +129,7 @@ export async function fetchMoreData(
 
         let tagMaxId = maxId
         if (rows.length > 0) {
-          tagMaxId = rows[0][0] as string
+          tagMaxId = rows[0][0]
         }
 
         const res = await client.getTagTimeline(tag, {


### PR DESCRIPTION
## Summary

- resolve all 272 currently open SonarQube findings across app, Query IR, SQLite, adapters, and tests
- exclude generated `src/zenstack/**` from analysis instead of editing generated code
- migrate deprecated Query IR input bindings on both editor and live timeline execution paths
- add an accessible WebVTT descriptions track for audio attachments

## Review

- Cursor `/review-bugbot`: no bugs after one finding was fixed
- Cursor `/review-security`: no issues
- independent semantic and React quality reviews: no remaining findings

## Validation

- `yarn check`
- `yarn test:run --coverage` — 88 files, 1,727 tests passed
- `yarn build`
- `git diff --check`

After merge, the main-branch SonarQube scan must complete before confirming the server-side Open issue count is zero.