### PR TITLE
fix(sonar): preserve generated asset exclusions

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,2 +1,3 @@
 sonar.projectKey=WakuwakuP_miyulab-fe_2b9f1381-5c7d-4b89-8aca-9a9a897900dc
-sonar.exclusions=src/zenstack/**
+# Analysis parameters override project settings, so retain the server-side public exclusion here.
+sonar.exclusions=public/*,src/zenstack/**

--- a/src/app/_parts/Panel.tsx
+++ b/src/app/_parts/Panel.tsx
@@ -20,12 +20,12 @@ export const Panel = ({
   const ref = useRef<HTMLDivElement>(null)
   const offset = headerOffset ?? '0px'
   const mainAreaHeight =
-    name !== undefined
-      ? `calc(100vh - 0.75rem - 2rem - ${offset})`
-      : `calc(100vh - 0.75rem - ${offset})`
+    name === undefined
+      ? `calc(100vh - 0.75rem - ${offset})`
+      : `calc(100vh - 0.75rem - 2rem - ${offset})`
 
   const durationTitle =
-    queryDuration != null ? `Query: ${queryDuration.toFixed(2)} ms` : undefined
+    queryDuration == null ? undefined : `Query: ${queryDuration.toFixed(2)} ms`
 
   return (
     <section>

--- a/src/app/_parts/StatusRichTextarea.tsx
+++ b/src/app/_parts/StatusRichTextarea.tsx
@@ -231,7 +231,7 @@ export const StatusRichTextarea = ({
 
   const mentionMatch = pos === null ? null : MENTION_REG.exec(targetText)
   const emojiMatch = pos ? EMOJI_REG.exec(targetText) : null
-  const tagMatch = pos !== null ? TAG_REG.exec(targetText) : null
+  const tagMatch = pos === null ? null : TAG_REG.exec(targetText)
 
   const mentionName = mentionMatch?.[1] ?? ''
   const emojiName = emojiMatch?.[1] ?? ''

--- a/src/util/db/sqlite/explainLogger.ts
+++ b/src/util/db/sqlite/explainLogger.ts
@@ -42,10 +42,7 @@ function flushQueue(): void {
   // Worker 環境のみ postMessage を使用する
   // Window 環境（fallback DB 実装）では window.postMessage となり
   // targetOrigin 引数が必須のため、ここでは送信せずにキューを破棄する。
-  if (
-    typeof globalThis.window !== 'undefined' &&
-    globalThis === globalThis.window
-  ) {
+  if (globalThis.window !== undefined && globalThis === globalThis.window) {
     return
   }
   globalThis.postMessage(message)
@@ -144,7 +141,7 @@ export function logSlowQueryExplain(
     sql: sanitizeSql(sql),
     timestamp: new Date().toISOString(),
     userAgent:
-      typeof globalThis.navigator === 'undefined'
+      globalThis.navigator === undefined
         ? 'unknown'
         : globalThis.navigator.userAgent,
   }


### PR DESCRIPTION
## Summary

- preserve the existing SonarQube project exclusion `public/*` while adding `src/zenstack/**`
- resolve the five new source findings raised by the post-merge analyzer update
- keep generated SQLite WASM assets out of source analysis instead of modifying vendored build output

## Root cause

PR #857 added a repository `sonar.exclusions` value for `src/zenstack/**`. Scanner analysis parameters override SonarQube project settings, so this unintentionally replaced the existing server-side `public/*` exclusion and surfaced 2,104 issues in generated SQLite assets. This PR keeps both patterns and documents the precedence.

The remaining Media S4084 issue was resolved as a false positive with an audit comment in SonarQube: `media.description` is federated attachment alt text correctly exposed through a `kind=descriptions` WebVTT track. Relabeling it as captions would falsely claim it is an audio transcript, which Cursor Bugbot also flagged.

## Review

- Cursor `/review-bugbot`: no bugs after reverting the semantically incorrect captions change
- Cursor `/review-security`: no issues

## Validation

- `yarn check`
- `yarn test:run --coverage` — 88 files, 1,727 tests passed
- `yarn build`
- `git diff --check`

After merge, the main SonarQube scan will verify the Open issue count.