### PR TITLE
test(sqlite): enforce 90% coverage gate

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -10,18 +10,30 @@ jobs:
   build:
     name: Build and analyze
     runs-on: ubuntu-latest
-    
+
+    permissions:
+      contents: read
+
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - run: corepack enable yarn
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: yarn
+      - name: Install dependencies
+        run: yarn --immutable
+      - name: Run tests with coverage
+        run: yarn test:coverage
       - uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6.0.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
-      # If you wish to fail your job when the Quality Gate is red, uncomment the
-      # following lines. This would typically be used to fail a deployment.
-      # - uses: SonarSource/sonarqube-quality-gate-action@cf038b0e0cdecfa9e56c198bbb7d21d751d62c3b # v1.2.0
-      #   timeout-minutes: 5
-      #   env:
-      #     SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      - uses: SonarSource/sonarqube-quality-gate-action@cf038b0e0cdecfa9e56c198bbb7d21d751d62c3b # v1.2.0
+        timeout-minutes: 5
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}

--- a/docs/domain/10-development-workflow.md
+++ b/docs/domain/10-development-workflow.md
@@ -139,7 +139,13 @@ export default defineConfig({
     coverage: {
       include: ['src/util/db/sqlite/**'],
       provider: 'v8',
-      reporter: ['text', 'json', 'json-summary'],
+      reporter: ['text', 'json', 'json-summary', 'lcov'],
+      thresholds: {
+        branches: 90,
+        functions: 90,
+        lines: 90,
+        statements: 90,
+      },
     },
     environment: 'node',
     globals: true,
@@ -153,6 +159,8 @@ export default defineConfig({
 - **グローバル API**: `describe`, `it`, `expect` 等をインポートなしで使用可能
 - **パスエイリアス**: `tsconfig.json` の `baseUrl: "src"` に合わせたエイリアス設定
 - **カバレッジ対象**: `src/util/db/sqlite/` 配下に限定（V8 プロバイダー使用）
+- **カバレッジゲート**: statements / branches / functions / lines の全指標で 90% 以上
+- **SonarQube 連携**: `coverage/lcov.info` を生成し、解析ジョブへ渡す
 
 ### Biome リント・フォーマット設定
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,3 +1,7 @@
 sonar.projectKey=WakuwakuP_miyulab-fe_2b9f1381-5c7d-4b89-8aca-9a9a897900dc
+sonar.sources=src
+sonar.tests=src
+sonar.test.inclusions=src/**/*.test.ts
+sonar.javascript.lcov.reportPaths=coverage/lcov.info
 # Analysis parameters override project settings, so retain the server-side public exclusion here.
 sonar.exclusions=public/*,src/zenstack/**

--- a/src/util/db/sqlite/__tests__/cleanup-batchLoop.test.ts
+++ b/src/util/db/sqlite/__tests__/cleanup-batchLoop.test.ts
@@ -252,4 +252,165 @@ describe('enforceMaxLength — batch loop', () => {
 
     infoSpy.mockRestore()
   })
+
+  it('件数クエリが空でも各テーブルをゼロとしてログ出力する', async () => {
+    const sendCommand = vi.fn().mockResolvedValue(undefined)
+    const execAsync = vi.fn().mockResolvedValue([])
+    vi.mocked(getSqliteDb).mockResolvedValue({
+      cancelStaleRequests: vi.fn(),
+      execAsync,
+      execAsyncTimed: vi.fn(),
+      execBatch: vi.fn(),
+      executeFlatFetch: vi.fn(),
+      executeGraphPlan: vi.fn(),
+      executeQueryPlan: vi.fn(),
+      fetchTimeline: vi.fn(),
+      persistence: 'memory',
+      sendCommand,
+    })
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
+
+    await enforceMaxLength()
+
+    const countsLine = infoSpy.mock.calls.find((args) =>
+      String(args[0]).includes('table counts after'),
+    )
+    expect(countsLine?.[0]).toContain('timeline_entries=0')
+    expect(countsLine?.[0]).toContain('notifications=0')
+    expect(countsLine?.[0]).toContain('posts=0')
+  })
+
+  it('null のテーブル件数をゼロへ正規化する', async () => {
+    const sendCommand = vi.fn().mockResolvedValue({ hasMore: false })
+    const execAsync = vi.fn().mockResolvedValue([[null, null, null]])
+    vi.mocked(getSqliteDb).mockResolvedValue({
+      cancelStaleRequests: vi.fn(),
+      execAsync,
+      execAsyncTimed: vi.fn(),
+      execBatch: vi.fn(),
+      executeFlatFetch: vi.fn(),
+      executeGraphPlan: vi.fn(),
+      executeQueryPlan: vi.fn(),
+      fetchTimeline: vi.fn(),
+      persistence: 'memory',
+      sendCommand,
+    })
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
+
+    await enforceMaxLength()
+
+    expect(
+      infoSpy.mock.calls.find((args) =>
+        String(args[0]).includes('table counts after'),
+      )?.[0],
+    ).toContain(
+      'timeline_entries=0 (n/a), notifications=0 (n/a), posts=0 (n/a)',
+    )
+  })
+
+  it('複数バッチの phase timings を合計し最大値を記録する', async () => {
+    const phase = (total: number) => ({
+      notifications: total + 1,
+      phase1Total: total + 2,
+      phase2Total: total + 3,
+      postsCount: total + 4,
+      postsDelete: total + 5,
+      timeline: total + 6,
+      total: total + 7,
+    })
+    const sendCommand = vi
+      .fn()
+      .mockResolvedValueOnce({
+        hasMore: true,
+        phaseTimings: phase(20),
+      })
+      .mockResolvedValueOnce({
+        hasMore: false,
+        phaseTimings: phase(10),
+      })
+    const execAsync = vi.fn().mockResolvedValue([[0, 0, 0]])
+    vi.mocked(getSqliteDb).mockResolvedValue({
+      cancelStaleRequests: vi.fn(),
+      execAsync,
+      execAsyncTimed: vi.fn(),
+      execBatch: vi.fn(),
+      executeFlatFetch: vi.fn(),
+      executeGraphPlan: vi.fn(),
+      executeQueryPlan: vi.fn(),
+      fetchTimeline: vi.fn(),
+      persistence: 'memory',
+      sendCommand,
+    })
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
+
+    await enforceMaxLength()
+
+    const timingsLine = String(
+      infoSpy.mock.calls.find((args) =>
+        String(args[0]).includes('phase timings'),
+      )?.[0],
+    )
+    expect(timingsLine).toContain('phase2Total=36 (maxBatch=23)')
+    expect(timingsLine).toContain('postsDelete=40 (maxBatch=25)')
+    expect(timingsLine).toContain('workerTotal=44')
+  })
+
+  it('中断時も収集済み phase timings と件数を警告ログへ残す', async () => {
+    const sendCommand = vi
+      .fn()
+      .mockResolvedValueOnce({
+        hasMore: true,
+        phaseTimings: {
+          notifications: 1,
+          phase1Total: 2,
+          phase2Total: 3,
+          postsCount: 4,
+          postsDelete: 5,
+          timeline: 6,
+          total: 7,
+        },
+      })
+      .mockRejectedValueOnce(new Error('worker stopped'))
+    const execAsync = vi.fn().mockResolvedValue([[1, 2, 3]])
+    vi.mocked(getSqliteDb).mockResolvedValue({
+      cancelStaleRequests: vi.fn(),
+      execAsync,
+      execAsyncTimed: vi.fn(),
+      execBatch: vi.fn(),
+      executeFlatFetch: vi.fn(),
+      executeGraphPlan: vi.fn(),
+      executeQueryPlan: vi.fn(),
+      fetchTimeline: vi.fn(),
+      persistence: 'memory',
+      sendCommand,
+    })
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await expect(enforceMaxLength()).rejects.toThrow('worker stopped')
+
+    expect(
+      warnSpy.mock.calls.some((args) =>
+        String(args[0]).includes('phase timings'),
+      ),
+    ).toBe(true)
+    expect(
+      warnSpy.mock.calls.some((args) =>
+        String(args[0]).includes('table counts after aborted'),
+      ),
+    ).toBe(true)
+  })
+
+  it('安全上限の100バッチで停止して次回継続を警告する', async () => {
+    const { sendCommand } = installMockHandle(
+      Array.from({ length: 100 }, () => ({ hasMore: true })),
+    )
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await enforceMaxLength()
+
+    expect(sendCommand).toHaveBeenCalledTimes(100)
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('reached MAX_BATCH_ITERATIONS (100)'),
+    )
+  })
 })

--- a/src/util/db/sqlite/__tests__/cleanup-scheduler.test.ts
+++ b/src/util/db/sqlite/__tests__/cleanup-scheduler.test.ts
@@ -1,0 +1,211 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { getSqliteDb, isTimelineQueueSaturated } = vi.hoisted(() => ({
+  getSqliteDb: vi.fn(),
+  isTimelineQueueSaturated: vi.fn(),
+}))
+
+vi.mock('util/db/sqlite/connection', () => ({
+  getSqliteDb,
+}))
+
+vi.mock('util/db/dbQueue', () => ({
+  isTimelineQueueSaturated,
+}))
+
+import {
+  __CLEANUP_CONSTANTS,
+  __resetCleanupStateForTest,
+  startPeriodicCleanup,
+} from 'util/db/sqlite/cleanup'
+
+function installHandle(
+  sendCommand: ReturnType<typeof vi.fn> = vi
+    .fn()
+    .mockResolvedValue({ hasMore: false }),
+): ReturnType<typeof vi.fn> {
+  getSqliteDb.mockResolvedValue({
+    execAsync: vi.fn().mockResolvedValue([[0, 0, 0]]),
+    sendCommand,
+  })
+  return sendCommand
+}
+
+describe('cleanup scheduling', () => {
+  const stops: (() => void)[] = []
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-30T00:00:00.000Z'))
+    vi.clearAllMocks()
+    __resetCleanupStateForTest()
+    isTimelineQueueSaturated.mockReturnValue(false)
+    vi.spyOn(console, 'info').mockImplementation(() => {})
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    for (const stop of stops.splice(0)) stop()
+    __resetCleanupStateForTest()
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  function start(): () => void {
+    const stop = startPeriodicCleanup()
+    stops.push(stop)
+    return stop
+  }
+
+  it('waits for the initial delay and then uses the periodic interval', async () => {
+    const sendCommand = installHandle()
+    start()
+
+    await vi.advanceTimersByTimeAsync(__CLEANUP_CONSTANTS.INITIAL_DELAY_MS - 1)
+    expect(sendCommand).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1)
+    expect(sendCommand).toHaveBeenCalledWith(
+      {
+        mode: 'periodic',
+        targetRatio: __CLEANUP_CONSTANTS.EMERGENCY_TARGET_RATIO,
+        type: 'enforceMaxLength',
+      },
+      { kind: 'priority' },
+    )
+
+    await vi.advanceTimersByTimeAsync(__CLEANUP_CONSTANTS.PERIODIC_INTERVAL_MS)
+    expect(sendCommand).toHaveBeenCalledTimes(2)
+  })
+
+  it('retries failures twice, then waits for the next full period', async () => {
+    let attempt = 0
+    const sendCommand = vi.fn().mockImplementation(async () => {
+      attempt++
+      if (attempt <= __CLEANUP_CONSTANTS.MAX_CONSECUTIVE_FAILURES) {
+        throw new Error(`failure ${attempt}`)
+      }
+      return { hasMore: false }
+    })
+    installHandle(sendCommand)
+    start()
+
+    await vi.advanceTimersByTimeAsync(__CLEANUP_CONSTANTS.INITIAL_DELAY_MS)
+    expect(sendCommand).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(__CLEANUP_CONSTANTS.RETRY_DELAY_MS)
+    expect(sendCommand).toHaveBeenCalledTimes(2)
+    await vi.advanceTimersByTimeAsync(__CLEANUP_CONSTANTS.RETRY_DELAY_MS)
+    expect(sendCommand).toHaveBeenCalledTimes(3)
+
+    await vi.advanceTimersByTimeAsync(
+      __CLEANUP_CONSTANTS.PERIODIC_INTERVAL_MS - 1,
+    )
+    expect(sendCommand).toHaveBeenCalledTimes(3)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(sendCommand).toHaveBeenCalledTimes(4)
+  })
+
+  it('cancels the periodic timer when stopped', async () => {
+    const sendCommand = installHandle()
+    const stop = start()
+
+    stop()
+    await vi.advanceTimersByTimeAsync(
+      __CLEANUP_CONSTANTS.INITIAL_DELAY_MS +
+        __CLEANUP_CONSTANTS.PERIODIC_INTERVAL_MS,
+    )
+
+    expect(sendCommand).not.toHaveBeenCalled()
+  })
+
+  it('triggers emergency cleanup after sustained post-grace saturation', async () => {
+    const sendCommand = installHandle()
+    isTimelineQueueSaturated.mockReturnValue(true)
+    start()
+
+    await vi.advanceTimersByTimeAsync(__CLEANUP_CONSTANTS.INITIAL_GRACE_MS - 1)
+    expect(sendCommand).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(1)
+
+    expect(sendCommand).toHaveBeenCalledWith(
+      {
+        mode: 'emergency',
+        targetRatio: __CLEANUP_CONSTANTS.EMERGENCY_TARGET_RATIO,
+        type: 'enforceMaxLength',
+      },
+      { kind: 'priority' },
+    )
+  })
+
+  it('requires a new sustained interval after saturation clears', async () => {
+    const sendCommand = installHandle()
+    isTimelineQueueSaturated.mockReturnValue(true)
+    start()
+
+    await vi.advanceTimersByTimeAsync(3_000)
+    isTimelineQueueSaturated.mockReturnValue(false)
+    await vi.advanceTimersByTimeAsync(1_000)
+    isTimelineQueueSaturated.mockReturnValue(true)
+    await vi.advanceTimersByTimeAsync(
+      __CLEANUP_CONSTANTS.INITIAL_GRACE_MS - 4_001,
+    )
+    expect(sendCommand).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1)
+    expect(sendCommand).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not overlap emergency cleanup while one is running', async () => {
+    let resolveEmergency: ((value: { hasMore: boolean }) => void) | undefined
+    const sendCommand = vi.fn(
+      () =>
+        new Promise<{ hasMore: boolean }>((resolve) => {
+          resolveEmergency = resolve
+        }),
+    )
+    installHandle(sendCommand)
+    isTimelineQueueSaturated.mockReturnValue(true)
+    start()
+
+    await vi.advanceTimersByTimeAsync(__CLEANUP_CONSTANTS.INITIAL_GRACE_MS)
+    expect(sendCommand).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(
+      __CLEANUP_CONSTANTS.SATURATION_DURATION_MS * 3,
+    )
+    expect(sendCommand).toHaveBeenCalledTimes(1)
+
+    resolveEmergency?.({ hasMore: false })
+    await Promise.resolve()
+  })
+
+  it('honors the emergency cooldown before firing again', async () => {
+    const sendCommand = installHandle()
+    isTimelineQueueSaturated.mockReturnValue(true)
+    start()
+
+    await vi.advanceTimersByTimeAsync(__CLEANUP_CONSTANTS.INITIAL_GRACE_MS)
+    expect(sendCommand).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(
+      __CLEANUP_CONSTANTS.EMERGENCY_COOLDOWN_MS - 1,
+    )
+    expect(sendCommand).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(sendCommand).toHaveBeenCalledTimes(2)
+  })
+
+  it('shares one saturation watcher until the final owner stops', () => {
+    installHandle()
+    const firstStop = start()
+    const secondStop = start()
+
+    expect(vi.getTimerCount()).toBe(3)
+    firstStop()
+    expect(vi.getTimerCount()).toBe(2)
+    firstStop()
+    expect(vi.getTimerCount()).toBe(2)
+    secondStop()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})

--- a/src/util/db/sqlite/__tests__/connection-branches.test.ts
+++ b/src/util/db/sqlite/__tests__/connection-branches.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+async function loadConnection(saturated: boolean) {
+  const getDb = vi.fn().mockResolvedValue({ persistence: 'memory' })
+  vi.doMock('util/db/dbQueue', () => ({
+    isTimelineQueueSaturated: vi.fn().mockReturnValue(saturated),
+  }))
+  vi.doMock('util/db/sqlite/initSqlite', () => ({ getDb }))
+  const connection = await import('util/db/sqlite/connection')
+  return { connection, getDb }
+}
+
+describe('SQLite connection branches', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+    vi.doUnmock('util/db/dbQueue')
+    vi.doUnmock('util/db/sqlite/initSqlite')
+  })
+
+  it('uses the longer debounce while the timeline queue is saturated', async () => {
+    const { connection } = await loadConnection(true)
+    const listener = vi.fn()
+    const unsubscribe = connection.subscribe('posts', listener)
+
+    connection.notifyChange('posts', { timelineType: 'home' })
+    await vi.advanceTimersByTimeAsync(299)
+    expect(listener).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(1)
+    expect(listener).toHaveBeenCalledWith([{ timelineType: 'home' }])
+
+    unsubscribe()
+  })
+
+  it('flushes notifications safely when a table has no listeners', async () => {
+    const { connection } = await loadConnection(false)
+
+    connection.notifyChange('posts', { timelineType: 'home' })
+
+    await vi.advanceTimersByTimeAsync(80)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('isolates listener failures and continues notifying later listeners', async () => {
+    const { connection } = await loadConnection(false)
+    const failure = new Error('listener failed')
+    const failingListener = vi.fn(() => {
+      throw failure
+    })
+    const healthyListener = vi.fn()
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const unsubscribeFailing = connection.subscribe('posts', failingListener)
+    const unsubscribeHealthy = connection.subscribe('posts', healthyListener)
+
+    connection.notifyChange('posts')
+    await vi.advanceTimersByTimeAsync(80)
+
+    expect(error).toHaveBeenCalledWith('Change listener error:', failure)
+    expect(healthyListener).toHaveBeenCalledWith([])
+    unsubscribeFailing()
+    unsubscribeHealthy()
+  })
+
+  it('initializes SQLite once and reuses the same ready promise', async () => {
+    const { connection, getDb } = await loadConnection(false)
+
+    const first = connection.getSqliteDb()
+    const second = connection.getSqliteDb()
+
+    expect(second).toBe(first)
+    await expect(first).resolves.toEqual({ persistence: 'memory' })
+    expect(getDb).toHaveBeenCalledOnce()
+    expect(getDb).toHaveBeenCalledWith(connection.notifyChange)
+  })
+})

--- a/src/util/db/sqlite/__tests__/dbExport-followStore.test.ts
+++ b/src/util/db/sqlite/__tests__/dbExport-followStore.test.ts
@@ -1,0 +1,116 @@
+import type { Entity } from 'megalodon'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { getSqliteDb } = vi.hoisted(() => ({
+  getSqliteDb: vi.fn(),
+}))
+
+vi.mock('util/db/sqlite/connection', () => ({
+  getSqliteDb,
+}))
+
+import { exportDatabase, startPeriodicExport } from 'util/db/sqlite/dbExport'
+import { syncFollows } from 'util/db/sqlite/followStore'
+
+describe('database export', () => {
+  const sendCommand = vi.fn()
+
+  beforeEach(() => {
+    getSqliteDb.mockReset()
+    sendCommand.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('skips exports for an in-memory database', async () => {
+    getSqliteDb.mockResolvedValue({
+      persistence: 'memory',
+      sendCommand,
+    })
+
+    await exportDatabase()
+
+    expect(sendCommand).not.toHaveBeenCalled()
+  })
+
+  it('delegates OPFS exports to the worker', async () => {
+    getSqliteDb.mockResolvedValue({
+      persistence: 'opfs',
+      sendCommand,
+    })
+
+    await exportDatabase()
+
+    expect(sendCommand).toHaveBeenCalledWith({ type: 'exportDatabase' })
+  })
+
+  it('runs delayed and periodic exports until cleanup', async () => {
+    vi.useFakeTimers()
+    getSqliteDb.mockResolvedValue({
+      persistence: 'opfs',
+      sendCommand,
+    })
+
+    const stop = startPeriodicExport()
+
+    await vi.advanceTimersByTimeAsync(119_999)
+    expect(sendCommand).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(1)
+    expect(sendCommand).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(180_000)
+    expect(sendCommand).toHaveBeenCalledTimes(2)
+
+    stop()
+    await vi.advanceTimersByTimeAsync(600_000)
+    expect(sendCommand).toHaveBeenCalledTimes(2)
+  })
+
+  it('logs periodic export failures without leaking a rejection', async () => {
+    vi.useFakeTimers()
+    getSqliteDb.mockRejectedValue(new Error('OPFS unavailable'))
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const stop = startPeriodicExport()
+    await vi.advanceTimersByTimeAsync(120_000)
+
+    expect(error).toHaveBeenCalledWith(
+      'Failed to export database:',
+      expect.objectContaining({ message: 'OPFS unavailable' }),
+    )
+    stop()
+  })
+})
+
+describe('syncFollows', () => {
+  const sendCommand = vi.fn()
+
+  beforeEach(() => {
+    getSqliteDb.mockReset()
+    sendCommand.mockReset()
+  })
+
+  it('does not initialize SQLite for an empty follow list', async () => {
+    await syncFollows([], 'https://example.com')
+
+    expect(getSqliteDb).not.toHaveBeenCalled()
+  })
+
+  it('serializes accounts and delegates follow synchronization', async () => {
+    const accounts = [
+      { acct: 'alice', id: '1' },
+      { acct: 'bob@example.net', id: '2' },
+    ] as Entity.Account[]
+    getSqliteDb.mockResolvedValue({ sendCommand })
+
+    await syncFollows(accounts, 'https://example.com')
+
+    expect(sendCommand).toHaveBeenCalledWith({
+      accountsJson: accounts.map((account) => JSON.stringify(account)),
+      backendUrl: 'https://example.com',
+      type: 'syncFollows',
+    })
+  })
+})

--- a/src/util/db/sqlite/__tests__/explainLogger.test.ts
+++ b/src/util/db/sqlite/__tests__/explainLogger.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('logSlowQueryExplain', () => {
+  const postMessage = vi.fn()
+
+  beforeEach(() => {
+    vi.resetModules()
+    vi.useFakeTimers()
+    postMessage.mockReset()
+    vi.stubGlobal('postMessage', postMessage)
+    vi.stubGlobal('navigator', { userAgent: 'vitest-agent' })
+  })
+
+  afterEach(async () => {
+    await vi.runOnlyPendingTimersAsync()
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('ignores queries below the slow-query threshold', async () => {
+    const { logSlowQueryExplain } = await import('util/db/sqlite/explainLogger')
+    const db = { exec: vi.fn() }
+
+    logSlowQueryExplain(db, 'SELECT 1', undefined, 999.9)
+
+    expect(db.exec).not.toHaveBeenCalled()
+    expect(vi.getTimerCount()).toBe(0)
+    expect(postMessage).not.toHaveBeenCalled()
+  })
+
+  it('logs the explain plan and flushes a structured entry', async () => {
+    const { logSlowQueryExplain } = await import('util/db/sqlite/explainLogger')
+    const db = {
+      exec: vi.fn().mockReturnValue([
+        [2, 0, 0, 'SEARCH posts USING INDEX posts_created_at_idx'],
+        [5, 2],
+      ]),
+    }
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.setSystemTime(new Date('2026-07-30T00:00:00.000Z'))
+
+    logSlowQueryExplain(db, '  SELECT   *\nFROM posts  ', [42, null], 1250.4)
+
+    expect(db.exec).toHaveBeenCalledWith(
+      'EXPLAIN QUERY PLAN   SELECT   *\nFROM posts  ',
+      { bind: [42, null], returnValue: 'resultRows' },
+    )
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('SEARCH posts USING INDEX posts_created_at_idx'),
+    )
+    expect(vi.getTimerCount()).toBe(1)
+
+    await vi.advanceTimersByTimeAsync(5_000)
+
+    expect(postMessage).toHaveBeenCalledWith({
+      logs: [
+        {
+          bind: '[42,null]',
+          durationMs: 1250,
+          explainPlan:
+            '    SEARCH posts USING INDEX posts_created_at_idx\n    5,2',
+          sql: 'SELECT * FROM posts',
+          timestamp: '2026-07-30T00:00:00.000Z',
+          userAgent: 'vitest-agent',
+        },
+      ],
+      type: 'slowQueryLogs',
+    })
+  })
+
+  it('records an entry even when EXPLAIN QUERY PLAN fails', async () => {
+    const { logSlowQueryExplain } = await import('util/db/sqlite/explainLogger')
+    const db = {
+      exec: vi.fn().mockImplementation(() => {
+        throw new Error('unsupported')
+      }),
+    }
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    logSlowQueryExplain(db, 'PRAGMA optimize', [], 1000)
+    await vi.advanceTimersByTimeAsync(5_000)
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('(EXPLAIN QUERY PLAN failed)'),
+    )
+    expect(postMessage.mock.calls[0][0].logs[0]).toMatchObject({
+      bind: '[]',
+      explainPlan: '(EXPLAIN QUERY PLAN failed)',
+      sql: 'PRAGMA optimize',
+    })
+  })
+
+  it('redacts tokens, long literals, and long bind values', async () => {
+    const { logSlowQueryExplain } = await import('util/db/sqlite/explainLogger')
+    const longSingleQuoted = `'${'s'.repeat(60)}'`
+    const longDoubleQuoted = `"${'d'.repeat(60)}"`
+    const trailingSql = ` ${'x'.repeat(600)}`
+    const db = { exec: vi.fn().mockReturnValue([]) }
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    logSlowQueryExplain(
+      db,
+      `SELECT 'Authorization: Bearer secret-token_123', ${longSingleQuoted}, ${longDoubleQuoted}${trailingSql}`,
+      ['b'.repeat(101), 'short', 3],
+      1500,
+    )
+    await vi.advanceTimersByTimeAsync(5_000)
+
+    const entry = postMessage.mock.calls[0][0].logs[0]
+    expect(entry.bind).toBe('["[REDACTED]","short",3]')
+    expect(entry.sql).toContain('Bearer [REDACTED]')
+    expect(entry.sql).toContain("'[REDACTED]'")
+    expect(entry.sql).toContain('"[REDACTED]"')
+    expect(entry.sql).toHaveLength(500)
+  })
+
+  it('flushes immediately after ten entries and cancels the timer', async () => {
+    const { logSlowQueryExplain } = await import('util/db/sqlite/explainLogger')
+    const db = { exec: vi.fn().mockReturnValue([]) }
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    for (let i = 0; i < 10; i++) {
+      logSlowQueryExplain(db, `SELECT ${i}`, undefined, 1000 + i)
+    }
+
+    expect(postMessage).toHaveBeenCalledOnce()
+    expect(postMessage.mock.calls[0][0].logs).toHaveLength(10)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('discards queued logs in the main-window fallback environment', async () => {
+    vi.stubGlobal('window', globalThis)
+    const { logSlowQueryExplain } = await import('util/db/sqlite/explainLogger')
+    const db = { exec: vi.fn().mockReturnValue([]) }
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    logSlowQueryExplain(db, 'SELECT 1', undefined, 1000)
+    await vi.advanceTimersByTimeAsync(5_000)
+
+    expect(postMessage).not.toHaveBeenCalled()
+  })
+})

--- a/src/util/db/sqlite/__tests__/handlers-notification.test.ts
+++ b/src/util/db/sqlite/__tests__/handlers-notification.test.ts
@@ -5,6 +5,8 @@ import {
   resolveLocalAccountId,
   resolvePostId,
   syncPollData,
+  syncPostCustomEmojis,
+  syncProfileCustomEmojis,
   updateInteraction,
 } from 'util/db/sqlite/helpers'
 import type { DbExecCompat } from 'util/db/sqlite/helpers/types'
@@ -323,6 +325,144 @@ describe('upsertNotification', () => {
     expect(bind).toContain(':blobcat:')
     expect(bind).toContain('https://example.com/emoji/blobcat.png')
   })
+
+  it('ローカルアカウントが未登録なら通知を保存しない', () => {
+    vi.mocked(resolveLocalAccountId).mockReturnValue(null)
+    const { db, calls } = createMockDb()
+
+    expect(
+      upsertNotification(db, makeNotification(), 'https://example.com'),
+    ).toBe(false)
+    expect(
+      calls.some((call) => call.sql.includes('INSERT INTO notifications')),
+    ).toBe(false)
+  })
+
+  it('actor が無い通知は actor_profile_id を null で保存する', () => {
+    const { db, calls } = createMockDb()
+
+    upsertNotification(
+      db,
+      makeNotification({ account: undefined }),
+      'https://example.com',
+    )
+
+    const insertCall = calls.find((call) =>
+      call.sql.includes('INSERT INTO notifications'),
+    )
+    expect(insertCall?.opts?.bind?.[4]).toBeNull()
+    expect(ensureProfile).not.toHaveBeenCalled()
+  })
+
+  it('actor のカスタム絵文字をプロフィールへ同期する', () => {
+    const notification = makeNotification()
+    const actorEmoji = {
+      shortcode: 'actor_emoji',
+      static_url: 'https://example.com/emoji/actor-static.webp',
+      url: 'https://example.com/emoji/actor.webp',
+      visible_in_picker: true,
+    }
+    if (notification.account === null) {
+      throw new Error('expected notification actor')
+    }
+    notification.account.emojis = [actorEmoji]
+    const { db } = createMockDb()
+
+    upsertNotification(db, notification, 'https://example.com')
+
+    expect(syncProfileCustomEmojis).toHaveBeenCalledWith(db, 10, 1, [
+      actorEmoji,
+    ])
+  })
+
+  it('URL 無しのカスタムリアクションを DB の static URL で補完する', () => {
+    const { db, calls } = createMockDb({
+      'SELECT url, static_url FROM custom_emojis': [
+        [
+          [
+            'https://example.com/emoji/blobcat.webp',
+            'https://example.com/emoji/blobcat-static.webp',
+          ],
+        ],
+      ],
+    })
+
+    upsertNotification(
+      db,
+      makeNotification({
+        reaction: {
+          name: ':blobcat:',
+          static_url: null,
+          url: null,
+        },
+        type: 'emoji_reaction',
+      }),
+      'https://example.com',
+    )
+
+    const lookup = calls.find((call) =>
+      call.sql.includes('SELECT url, static_url FROM custom_emojis'),
+    )
+    const insertCall = calls.find((call) =>
+      call.sql.includes('INSERT INTO notifications'),
+    )
+    expect(lookup?.opts?.bind).toEqual([1, 'blobcat'])
+    expect(insertCall?.opts?.bind?.[7]).toBe(
+      'https://example.com/emoji/blobcat-static.webp',
+    )
+  })
+
+  it('DB の static URL が null ならカスタムリアクションの通常 URL を使う', () => {
+    const { db, calls } = createMockDb({
+      'SELECT url, static_url FROM custom_emojis': [
+        [['https://example.com/emoji/blobfox.webp', null]],
+      ],
+    })
+
+    upsertNotification(
+      db,
+      makeNotification({
+        reaction: {
+          name: ':blobfox:',
+          static_url: null,
+          url: null,
+        },
+        type: 'emoji_reaction',
+      }),
+      'https://example.com',
+    )
+
+    const insertCall = calls.find((call) =>
+      call.sql.includes('INSERT INTO notifications'),
+    )
+    expect(insertCall?.opts?.bind?.[7]).toBe(
+      'https://example.com/emoji/blobfox.webp',
+    )
+  })
+
+  it('DB に無いカスタムリアクションは Misskey 形式の URL で補完する', () => {
+    const { db, calls } = createMockDb()
+
+    upsertNotification(
+      db,
+      makeNotification({
+        reaction: {
+          name: ':party cat:',
+          static_url: null,
+          url: null,
+        },
+        type: 'emoji_reaction',
+      }),
+      'https://example.com',
+    )
+
+    const insertCall = calls.find((call) =>
+      call.sql.includes('INSERT INTO notifications'),
+    )
+    expect(insertCall?.opts?.bind?.[7]).toBe(
+      'https://example.com/emoji/party%20cat.webp',
+    )
+  })
 })
 
 // ================================================================
@@ -453,6 +593,281 @@ describe('handleAddNotification', () => {
     expect(result.changedTables).toContain('posts')
     expect(syncPollData).toHaveBeenCalled()
   })
+
+  it('不正な backend URL はその文字列自体を host として扱う', () => {
+    const { db } = createMockDb()
+
+    handleAddNotification(db, JSON.stringify(makeNotification()), 'not a url')
+
+    expect(ensureServer).toHaveBeenCalledWith(db, 'not a url')
+  })
+
+  it('同じ URI の投稿を再利用して backend ID を対応付ける', () => {
+    vi.mocked(resolvePostId).mockReturnValue(undefined)
+    const { db, calls } = createMockDb({
+      'SELECT id FROM posts WHERE object_uri = ?;': [[[77]]],
+    })
+    const status = makeStatus({ id: 'uri-status' })
+
+    const result = handleAddNotification(
+      db,
+      JSON.stringify(makeNotification({ status })),
+      'https://example.com',
+    )
+
+    expect(result).toEqual({ changedTables: ['notifications'] })
+    expect(calls.some((call) => call.sql.includes('INSERT INTO posts'))).toBe(
+      false,
+    )
+    const mapping = calls.find((call) =>
+      call.sql.includes('INSERT OR IGNORE INTO post_backend_ids'),
+    )
+    expect(mapping?.opts?.bind).toEqual([42, 'uri-status', 77])
+    const notificationInsert = calls.find((call) =>
+      call.sql.includes('INSERT INTO notifications'),
+    )
+    expect(notificationInsert?.opts?.bind?.[5]).toBe(77)
+  })
+
+  it('同じ URI の既存投稿にも最新 poll を同期する', () => {
+    vi.mocked(resolvePostId).mockReturnValue(undefined)
+    const poll = {
+      expired: true,
+      expires_at: '2024-02-01T00:00:00.000Z',
+      id: 'poll-uri',
+      multiple: false,
+      options: [{ title: 'A', votes_count: 10 }],
+      votes_count: 10,
+    }
+    const { db } = createMockDb({
+      'SELECT id FROM posts WHERE object_uri = ?;': [[[78]]],
+    })
+
+    const result = handleAddNotification(
+      db,
+      JSON.stringify(
+        makeNotification({
+          status: makeStatus({ id: 'uri-poll-status', poll }),
+          type: 'poll_expired',
+        }),
+      ),
+      'https://example.com',
+    )
+
+    expect(syncPollData).toHaveBeenCalledWith(db, 78, poll)
+    expect(result).toEqual({ changedTables: ['notifications', 'posts'] })
+  })
+
+  it('新規投稿の絵文字・メディア・メンション・poll を同期する', () => {
+    vi.mocked(resolvePostId).mockReturnValue(undefined)
+    const profileEmoji = {
+      shortcode: 'profile_emoji',
+      static_url: 'https://example.com/profile-static.webp',
+      url: 'https://example.com/profile.webp',
+      visible_in_picker: true,
+    }
+    const postEmoji = {
+      shortcode: 'post_emoji',
+      static_url: 'https://example.com/post-static.webp',
+      url: 'https://example.com/post.webp',
+      visible_in_picker: true,
+    }
+    const poll = {
+      expired: false,
+      expires_at: '2024-02-01T00:00:00.000Z',
+      id: 'new-post-poll',
+      multiple: false,
+      options: [{ title: 'A', votes_count: 1 }],
+      votes_count: 1,
+    }
+    const baseAccount = makeStatus().account
+    if (baseAccount === null) {
+      throw new Error('expected status account')
+    }
+    const status = makeStatus({
+      account: {
+        ...baseAccount,
+        emojis: [profileEmoji],
+      },
+      emojis: [postEmoji],
+      id: 'rich-status',
+      media_attachments: [
+        {
+          blurhash: null,
+          description: 'image',
+          id: 'media-1',
+          meta: null,
+          preview_url: 'https://example.com/preview.webp',
+          remote_url: null,
+          static_url: 'https://example.com/image.webp',
+          type: 'image',
+          url: 'https://example.com/image.webp',
+        },
+      ],
+      mentions: [
+        {
+          acct: 'mentioned@example.net',
+          id: 'mentioned-1',
+          url: 'https://example.net/@mentioned',
+          username: 'mentioned',
+        },
+      ],
+      poll,
+      uri: '   ',
+    })
+    const { db, calls } = createMockDb({
+      last_insert_rowid: [[[91]]],
+      'SELECT id FROM media_types WHERE name = ?;': [[[1]]],
+    })
+
+    const result = handleAddNotification(
+      db,
+      JSON.stringify(makeNotification({ status })),
+      'https://example.com',
+    )
+
+    expect(syncProfileCustomEmojis).toHaveBeenCalledWith(db, 10, 1, [
+      profileEmoji,
+    ])
+    expect(syncPostCustomEmojis).toHaveBeenCalledWith(db, 91, 1, [postEmoji])
+    expect(syncPollData).toHaveBeenCalledWith(db, 91, poll)
+    expect(
+      calls.some((call) => call.sql.includes('INSERT INTO post_media')),
+    ).toBe(true)
+    expect(
+      calls.some((call) => call.sql.includes('INSERT INTO post_mentions')),
+    ).toBe(true)
+    expect(result).toEqual({ changedTables: ['notifications', 'posts'] })
+  })
+
+  it.each([
+    ['既存リブログ元', [[88]], 88],
+    ['未保存リブログ元', [], null],
+  ])(
+    '新規投稿の reblog_of_post_id を解決する: %s',
+    (_label, reblogRows, expectedReblogPostId) => {
+      vi.mocked(resolvePostId).mockReturnValue(undefined)
+      const original = makeStatus({
+        id: 'original-status',
+        poll: null,
+        uri: 'https://remote.example/notes/original',
+      })
+      const status = makeStatus({
+        id: 'wrapper-status',
+        reblog: original,
+        uri: ' ',
+      })
+      const { db, calls } = createMockDb({
+        last_insert_rowid: [[[92]]],
+        "object_uri != '' LIMIT 1": [reblogRows],
+      })
+
+      handleAddNotification(
+        db,
+        JSON.stringify(makeNotification({ status })),
+        'https://example.com',
+      )
+
+      const postInsert = calls.find((call) =>
+        call.sql.includes('INSERT INTO posts'),
+      )
+      expect(postInsert?.opts?.bind?.[14]).toBe(expectedReblogPostId)
+    },
+  )
+
+  it('リブログ元の既存投稿へ poll を同期する', () => {
+    const poll = {
+      expired: false,
+      expires_at: null,
+      id: 'reblog-poll',
+      multiple: false,
+      options: [{ title: 'A', votes_count: 2 }],
+      votes_count: 2,
+    }
+    vi.mocked(resolvePostId).mockReturnValueOnce(50).mockReturnValueOnce(60)
+    const { db } = createMockDb()
+    const status = makeStatus({
+      reblog: makeStatus({ id: 'original-status', poll }),
+    })
+
+    const result = handleAddNotification(
+      db,
+      JSON.stringify(makeNotification({ status })),
+      'https://example.com',
+    )
+
+    expect(syncPollData).toHaveBeenCalledWith(db, 60, poll)
+    expect(result).toEqual({ changedTables: ['notifications', 'posts'] })
+  })
+
+  it('リブログ元が未保存なら poll 付き投稿として追加する', () => {
+    const poll = {
+      expired: false,
+      expires_at: null,
+      id: 'new-reblog-poll',
+      multiple: false,
+      options: [{ title: 'A', votes_count: 3 }],
+      votes_count: 3,
+    }
+    vi.mocked(resolvePostId)
+      .mockReturnValueOnce(50)
+      .mockReturnValueOnce(undefined)
+      .mockReturnValueOnce(undefined)
+    const { db, calls } = createMockDb({
+      last_insert_rowid: [[[93]]],
+    })
+    const status = makeStatus({
+      reblog: makeStatus({
+        id: 'new-original-status',
+        poll,
+        uri: 'https://remote.example/notes/new-original',
+      }),
+    })
+
+    const result = handleAddNotification(
+      db,
+      JSON.stringify(makeNotification({ status })),
+      'https://example.com',
+    )
+
+    expect(calls.some((call) => call.sql.includes('INSERT INTO posts'))).toBe(
+      true,
+    )
+    expect(syncPollData).toHaveBeenCalledWith(db, 93, poll)
+    expect(result).toEqual({ changedTables: ['notifications', 'posts'] })
+  })
+
+  it('ラッパー投稿の poll 同期済みならリブログ元同期を短絡する', () => {
+    const wrapperPoll = {
+      expired: false,
+      expires_at: null,
+      id: 'wrapper-poll',
+      multiple: false,
+      options: [],
+      votes_count: 0,
+    }
+    const originalPoll = {
+      ...wrapperPoll,
+      id: 'original-poll',
+    }
+    vi.mocked(resolvePostId).mockReturnValue(50)
+    const { db } = createMockDb()
+    const status = makeStatus({
+      poll: wrapperPoll,
+      reblog: makeStatus({ id: 'original-status', poll: originalPoll }),
+    })
+
+    const result = handleAddNotification(
+      db,
+      JSON.stringify(makeNotification({ status })),
+      'https://example.com',
+    )
+
+    expect(resolvePostId).toHaveBeenCalledTimes(1)
+    expect(syncPollData).toHaveBeenCalledTimes(1)
+    expect(syncPollData).toHaveBeenCalledWith(db, 50, wrapperPoll)
+    expect(result).toEqual({ changedTables: ['notifications', 'posts'] })
+  })
 })
 
 // ================================================================
@@ -534,6 +949,34 @@ describe('handleBulkAddNotifications', () => {
 
     const rollback = calls.find((c) => c.sql === 'ROLLBACK;')
     expect(rollback).toBeDefined()
+  })
+
+  it('1件でも poll を同期した場合は posts も変更対象にする', () => {
+    vi.mocked(resolvePostId).mockReturnValue(50)
+    const poll = {
+      expired: false,
+      expires_at: null,
+      id: 'bulk-poll',
+      multiple: false,
+      options: [],
+      votes_count: 0,
+    }
+    const notifications = [
+      makeNotification({
+        id: 'bulk-poll-notification',
+        status: makeStatus({ id: 'poll-status', poll }),
+      }),
+      makeNotification({ id: 'bulk-follow', type: 'follow' }),
+    ]
+    const { db } = createMockDb()
+
+    const result = handleBulkAddNotifications(
+      db,
+      notifications.map((notification) => JSON.stringify(notification)),
+      'https://example.com',
+    )
+
+    expect(result).toEqual({ changedTables: ['notifications', 'posts'] })
   })
 })
 
@@ -642,6 +1085,22 @@ describe('handleUpdateNotificationStatusAction', () => {
       'https://example.com',
       'status-123',
       'favourited',
+      true,
+    )
+
+    expect(updateInteraction).not.toHaveBeenCalled()
+    expect(result).toEqual({ changedTables: [] })
+  })
+
+  it('未知のアクションは何もしない', () => {
+    vi.mocked(resolvePostId).mockReturnValue(100)
+    const { db } = createMockDb()
+
+    const result = handleUpdateNotificationStatusAction(
+      db,
+      'https://example.com',
+      'status-123',
+      'unknown' as 'favourited',
       true,
     )
 

--- a/src/util/db/sqlite/__tests__/handlers-status.test.ts
+++ b/src/util/db/sqlite/__tests__/handlers-status.test.ts
@@ -916,3 +916,413 @@ describe('handleBulkUpsertStatuses', () => {
     expect(delayedCalls).toHaveLength(0)
   })
 })
+
+// ================================================================
+// 分岐・フォールバック動作
+// ================================================================
+
+describe('status handler branch behavior', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(helpersModule.ensureProfile).mockReturnValue(10)
+    vi.mocked(helpersModule.ensureServer).mockReturnValue(1)
+    vi.mocked(helpersModule.resolveEmojisFromDb).mockReturnValue([])
+    vi.mocked(helpersModule.resolveLocalAccountId).mockReturnValue(100)
+    vi.mocked(statusHelpersModule.deriveAccountDomain).mockReturnValue(
+      'example.com',
+    )
+    vi.mocked(statusHelpersModule.getLastInsertRowId).mockReturnValue(999)
+    vi.mocked(statusHelpersModule.resolvePostIdInternal).mockReturnValue(
+      undefined,
+    )
+    vi.mocked(statusHelpersModule.resolveRepostOfPostId).mockReturnValue(null)
+    vi.mocked(statusHelpersModule.resolveVisibilityId).mockReturnValue(1)
+  })
+
+  it('null interaction flags are treated as unavailable data', () => {
+    vi.mocked(statusHelpersModule.resolveVisibilityId).mockReturnValue(null)
+    const { db } = createMockDb()
+    const status = createMockStatus({
+      bookmarked: null,
+      favourited: null,
+      reblogged: null,
+      uri: '',
+    })
+
+    handleUpsertStatus(
+      db,
+      JSON.stringify(status),
+      'https://example.com',
+      'home',
+    )
+
+    expect(helpersModule.updateInteraction).not.toHaveBeenCalled()
+    expect(
+      vi.mocked(helpersModule.extractPostColumns).mock.calls.at(-1)?.[0].uri,
+    ).toBe('')
+  })
+
+  it('uses supplied post and profile emojis without database fallback', () => {
+    const postEmoji = {
+      shortcode: 'party',
+      static_url: 'https://example.com/party-static.png',
+      url: 'https://example.com/party.png',
+      visible_in_picker: true,
+    }
+    const profileEmoji = {
+      shortcode: 'wave',
+      static_url: 'https://example.com/wave-static.png',
+      url: 'https://example.com/wave.png',
+      visible_in_picker: true,
+    }
+    const status = createMockStatus({ emojis: [postEmoji] })
+    status.account.emojis = [profileEmoji]
+    const { db } = createMockDb()
+
+    handleUpsertStatus(
+      db,
+      JSON.stringify(status),
+      'https://example.com',
+      'home',
+    )
+
+    expect(helpersModule.resolveEmojisFromDb).not.toHaveBeenCalled()
+    expect(helpersModule.syncProfileCustomEmojis).toHaveBeenCalledWith(
+      db,
+      10,
+      1,
+      [profileEmoji],
+      expect.any(Set),
+    )
+    expect(helpersModule.syncPostCustomEmojis).toHaveBeenCalledWith(
+      db,
+      999,
+      1,
+      [postEmoji, profileEmoji],
+      expect.any(Set),
+    )
+  })
+
+  it('resolves missing emoji metadata with null text defaults', () => {
+    const status = createMockStatus()
+    status.plain_content = null
+    status.account.display_name = null as unknown as string
+    const { db } = createMockDb()
+
+    handleUpsertStatus(
+      db,
+      JSON.stringify(status),
+      'https://example.com',
+      'home',
+    )
+
+    expect(helpersModule.resolveEmojisFromDb).toHaveBeenCalledWith(
+      db,
+      1,
+      null,
+      'example.com',
+    )
+  })
+
+  it('skips profile emoji work during a profile-skipping bulk refresh', () => {
+    const status = createMockStatus()
+    status.account.emojis = [
+      {
+        shortcode: 'wave',
+        static_url: 'https://example.com/wave-static.png',
+        url: 'https://example.com/wave.png',
+        visible_in_picker: true,
+      },
+    ]
+    const { db } = createMockDb()
+
+    handleBulkUpsertStatuses(
+      db,
+      [JSON.stringify(status)],
+      'https://example.com',
+      'home',
+      undefined,
+      true,
+    )
+
+    expect(helpersModule.syncProfileCustomEmojis).not.toHaveBeenCalled()
+    expect(helpersModule.ensureProfile).toHaveBeenCalledWith(
+      db,
+      expect.anything(),
+      1,
+      expect.any(Set),
+      true,
+    )
+  })
+
+  it('does not create account mappings or interactions without a local account', () => {
+    vi.mocked(helpersModule.resolveLocalAccountId).mockReturnValue(null)
+    const { calls, db } = createMockDb()
+
+    handleUpsertStatus(
+      db,
+      JSON.stringify(createMockStatus()),
+      'https://example.com',
+      'public',
+    )
+
+    expect(
+      calls.some(
+        ({ sql }) =>
+          sql.includes('post_backend_ids') || sql.includes('timeline_entries'),
+      ),
+    ).toBe(false)
+    expect(statusHelpersModule.resolvePostIdInternal).not.toHaveBeenCalled()
+    expect(helpersModule.updateInteraction).not.toHaveBeenCalled()
+  })
+
+  it('reuses the bulk URI cache for duplicate status objects', () => {
+    const status = createMockStatus({
+      id: 'same',
+      uri: 'https://example.com/statuses/same',
+    })
+    const { calls, db } = createMockDb()
+
+    handleBulkUpsertStatuses(
+      db,
+      [JSON.stringify(status), JSON.stringify(status)],
+      'https://example.com',
+      'home',
+    )
+
+    const uriLookups = calls.filter(({ sql }) =>
+      sql.includes('SELECT id, is_reblog FROM posts'),
+    )
+    expect(uriLookups).toHaveLength(1)
+    expect(calls.some(({ sql }) => sql.includes('UPDATE posts SET'))).toBe(true)
+  })
+
+  it('inserts a reblog with an empty URI when it aliases the original', () => {
+    const original = createMockStatus({
+      id: 'original',
+      uri: 'https://example.com/statuses/original',
+    })
+    const reblog = createMockStatus({
+      id: 'reblog',
+      reblog: original,
+      uri: original.uri,
+    })
+    const { calls, db } = createMockDb()
+
+    handleBulkUpsertStatuses(
+      db,
+      [JSON.stringify(reblog)],
+      'https://example.com',
+      'home',
+    )
+
+    const insert = calls.find(({ sql }) => sql.includes('INSERT INTO posts ('))
+    expect(insert?.opts?.bind?.[0]).toBe('')
+  })
+
+  it('does not overwrite an original row when a reblog URI resolves to it', () => {
+    const original = createMockStatus({
+      id: 'original',
+      uri: 'https://example.com/statuses/original',
+    })
+    const reblog = createMockStatus({
+      id: 'reblog',
+      reblog: original,
+      uri: 'https://example.com/statuses/reblog',
+    })
+    const { calls, db } = createMockDb((sql) => {
+      if (sql.includes('SELECT id, is_reblog FROM posts')) return [[42, 0]]
+      if (sql.includes('JOIN profiles')) return []
+      return undefined
+    })
+
+    handleUpsertStatus(
+      db,
+      JSON.stringify(reblog),
+      'https://example.com',
+      'home',
+    )
+
+    const insert = calls.find(({ sql }) => sql.includes('INSERT INTO posts ('))
+    expect(insert?.opts?.bind?.[0]).toBe('')
+    expect(
+      calls.some(
+        ({ sql, opts }) =>
+          sql.includes('UPDATE posts SET') && opts?.bind?.at(-1) === 42,
+      ),
+    ).toBe(false)
+  })
+
+  it('deduplicates a reblog by author and backfills its canonical URI', () => {
+    const original = createMockStatus({
+      id: 'original',
+      uri: 'https://example.com/statuses/original',
+    })
+    const reblog = createMockStatus({
+      id: 'reblog',
+      reblog: original,
+      uri: 'https://example.com/statuses/reblog',
+    })
+    const { calls, db } = createMockDb((sql) => {
+      if (sql.includes('SELECT id, is_reblog FROM posts')) return []
+      if (sql.includes('JOIN profiles')) return [[77]]
+      return undefined
+    })
+
+    handleBulkUpsertStatuses(
+      db,
+      [JSON.stringify(reblog)],
+      'https://example.com',
+      'home',
+    )
+
+    expect(
+      calls.some(
+        ({ sql, opts }) =>
+          sql.includes("WHERE id = ? AND object_uri = ''") &&
+          opts?.bind?.[0] === reblog.uri &&
+          opts.bind[1] === 77,
+      ),
+    ).toBe(true)
+  })
+
+  it('skips author reblog lookup when an account domain cannot be derived', () => {
+    vi.mocked(statusHelpersModule.deriveAccountDomain).mockReturnValue('')
+    const original = createMockStatus({
+      id: 'original',
+      uri: 'https://example.com/statuses/original',
+    })
+    const reblog = createMockStatus({
+      id: 'reblog',
+      reblog: original,
+      uri: 'https://example.com/statuses/reblog',
+    })
+    const { calls, db } = createMockDb()
+
+    handleUpsertStatus(
+      db,
+      JSON.stringify(reblog),
+      'https://example.com',
+      'home',
+    )
+
+    expect(calls.some(({ sql }) => sql.includes('JOIN profiles'))).toBe(false)
+  })
+
+  it('uses extracted visibility when the visibility lookup misses', () => {
+    vi.mocked(statusHelpersModule.resolveVisibilityId).mockReturnValue(null)
+    const { calls, db } = createMockDb((sql) => {
+      if (sql.includes('SELECT id, is_reblog FROM posts')) return [[42, 0]]
+      return undefined
+    })
+
+    handleUpsertStatus(
+      db,
+      JSON.stringify(createMockStatus()),
+      'https://example.com',
+      'home',
+    )
+
+    const update = calls.find(({ sql }) => sql.includes('UPDATE posts SET'))
+    expect(update?.opts?.bind?.[1]).toBe(1)
+  })
+
+  it('links a normalized tag when the tag exists', () => {
+    const { calls, db } = createMockDb((sql) => {
+      if (sql.includes('SELECT id FROM hashtags')) return [[5]]
+      return []
+    })
+
+    const result = handleUpsertStatus(
+      db,
+      JSON.stringify(createMockStatus()),
+      'https://example.com',
+      'tag',
+      'TypeScript',
+    )
+
+    expect(
+      calls.some(
+        ({ sql, opts }) =>
+          sql.includes('post_hashtags') &&
+          opts?.bind?.[0] === 999 &&
+          opts.bind[1] === 5,
+      ),
+    ).toBe(true)
+    expect(result.changedTables).toEqual(
+      expect.arrayContaining(['hashtags', 'post_hashtags']),
+    )
+  })
+
+  it('continues a tagged bulk batch when a tag row cannot be resolved', () => {
+    const { calls, db } = createMockDb()
+
+    handleBulkUpsertStatuses(
+      db,
+      [JSON.stringify(createMockStatus())],
+      'https://example.com',
+      'tag',
+      'Missing',
+    )
+
+    expect(
+      calls.some(({ sql }) => sql.includes('INSERT INTO post_hashtags')),
+    ).toBe(false)
+    expect(calls.at(-1)?.sql).toBe('COMMIT;')
+  })
+
+  it('rolls back a single upsert when setup fails', () => {
+    vi.mocked(helpersModule.ensureServer).mockImplementationOnce(() => {
+      throw new Error('server lookup failed')
+    })
+    const { calls, db } = createMockDb()
+
+    expect(() =>
+      handleUpsertStatus(
+        db,
+        JSON.stringify(createMockStatus()),
+        'https://example.com',
+        'home',
+      ),
+    ).toThrow('server lookup failed')
+
+    expect(calls.map(({ sql }) => sql)).toEqual(['BEGIN;', 'ROLLBACK;'])
+  })
+
+  it('isolates malformed entries in a bulk upsert with a savepoint', () => {
+    const { calls, db } = createMockDb()
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    handleBulkUpsertStatuses(
+      db,
+      ['not-json', JSON.stringify(createMockStatus())],
+      'https://example.com',
+      'home',
+    )
+
+    expect(calls.some(({ sql }) => sql === 'ROLLBACK TO sp_status;')).toBe(true)
+    expect(calls.at(-1)?.sql).toBe('COMMIT;')
+    expect(error).toHaveBeenCalledWith(
+      'Failed to upsert single status, skipping:',
+      expect.any(SyntaxError),
+    )
+  })
+
+  it('rolls back the whole bulk transaction when shared setup fails', () => {
+    vi.mocked(helpersModule.ensureServer).mockImplementationOnce(() => {
+      throw new Error('server lookup failed')
+    })
+    const { calls, db } = createMockDb()
+
+    expect(() =>
+      handleBulkUpsertStatuses(
+        db,
+        [JSON.stringify(createMockStatus())],
+        'https://example.com',
+        'home',
+      ),
+    ).toThrow('server lookup failed')
+
+    expect(calls.map(({ sql }) => sql)).toEqual(['BEGIN;', 'ROLLBACK;'])
+  })
+})

--- a/src/util/db/sqlite/__tests__/handlers-statusUpdate.test.ts
+++ b/src/util/db/sqlite/__tests__/handlers-statusUpdate.test.ts
@@ -415,6 +415,38 @@ describe('handleUpdateStatus', () => {
     expect(result.changedTables).toHaveLength(0)
   })
 
+  it('解決した投稿 ID が posts に存在しない場合は更新しない', () => {
+    const { db, calls } = createMockDb((sql, opts) => {
+      if (sql.includes('object_uri')) return [[42]]
+      if (opts?.returnValue === 'resultRows') return []
+      return undefined
+    })
+
+    const result = handleUpdateStatus(
+      db,
+      JSON.stringify(createMockStatus()),
+      'https://example.com',
+    )
+
+    expect(result.changedTables).toEqual([])
+    expect(calls.some((call) => call.sql === 'BEGIN;')).toBe(false)
+  })
+
+  it('URI とローカルアカウントがない場合は投稿 ID を検索しない', () => {
+    vi.mocked(helpersModule.resolveLocalAccountId).mockReturnValue(null)
+    const { db } = createMockDb()
+    const status = createMockStatus({ uri: undefined })
+
+    const result = handleUpdateStatus(
+      db,
+      JSON.stringify(status),
+      'https://example.com',
+    )
+
+    expect(result.changedTables).toEqual([])
+    expect(statusHelpersModule.resolvePostIdInternal).not.toHaveBeenCalled()
+  })
+
   it('URI が空の場合 post_backend_ids で検索する', () => {
     vi.mocked(statusHelpersModule.resolvePostIdInternal).mockReturnValue(42)
 
@@ -480,6 +512,98 @@ describe('handleUpdateStatus', () => {
     handleUpdateStatus(db, JSON.stringify(status), 'https://example.com')
 
     expect(helpersModule.extractPostColumns).toHaveBeenCalled()
+  })
+
+  it('可視性 ID の解決に失敗した場合は抽出済み ID を使用する', () => {
+    vi.mocked(statusHelpersModule.resolveVisibilityId).mockReturnValue(null)
+    vi.mocked(helpersModule.extractPostColumns).mockReturnValue({
+      application_name: null,
+      canonical_url: null,
+      content_html: '',
+      created_at_ms: 1,
+      edited_at_ms: null,
+      in_reply_to_account_acct: null,
+      in_reply_to_uri: null,
+      is_local_only: 0,
+      is_sensitive: 0,
+      language: null,
+      object_uri: 'https://example.com/status/12345',
+      plain_content: '',
+      quote_state: null,
+      spoiler_text: '',
+      visibility_id: 7,
+    })
+    const { db, calls } = createDbWithExistingPost()
+
+    handleUpdateStatus(
+      db,
+      JSON.stringify(createMockStatus()),
+      'https://example.com',
+    )
+
+    const update = calls.find((call) => call.sql.includes('UPDATE posts SET'))
+    expect(update?.opts?.bind?.[1]).toBe(7)
+  })
+
+  it('プロフィール絵文字を同期し、投稿絵文字欠落時も処理する', () => {
+    const status = createMockStatus({
+      account: {
+        ...createMockStatus().account,
+        emojis: [
+          {
+            shortcode: 'wave',
+            static_url: 'https://example.com/emoji/wave.png',
+            url: 'https://example.com/emoji/wave.gif',
+            visible_in_picker: true,
+          },
+        ],
+      },
+      emojis: undefined,
+    })
+    const { db } = createDbWithExistingPost()
+
+    handleUpdateStatus(db, JSON.stringify(status), 'https://example.com')
+
+    expect(helpersModule.syncProfileCustomEmojis).toHaveBeenCalledWith(
+      db,
+      10,
+      1,
+      status.account.emojis,
+      expect.anything(),
+    )
+    expect(helpersModule.syncPostCustomEmojis).toHaveBeenCalledWith(
+      db,
+      42,
+      1,
+      status.account.emojis,
+      expect.anything(),
+    )
+  })
+
+  it('ローカルアカウントがなければインタラクションを同期しない', () => {
+    vi.mocked(helpersModule.resolveLocalAccountId).mockReturnValue(null)
+    const { db } = createDbWithExistingPost()
+
+    handleUpdateStatus(
+      db,
+      JSON.stringify(createMockStatus()),
+      'https://example.com',
+    )
+
+    expect(helpersModule.updateInteraction).not.toHaveBeenCalled()
+  })
+
+  it('未指定のインタラクション状態は同期しない', () => {
+    const { db } = createDbWithExistingPost()
+    const status = createMockStatus({
+      bookmarked: undefined,
+      favourited: undefined,
+      reblogged: undefined,
+    })
+
+    handleUpdateStatus(db, JSON.stringify(status), 'https://example.com')
+
+    expect(helpersModule.updateInteraction).not.toHaveBeenCalled()
   })
 
   it('posts PK が id であること（post_id ではない）', () => {
@@ -551,6 +675,24 @@ describe('handleUpdateStatus', () => {
     const commitCalls = calls.filter((c) => c.sql.includes('COMMIT'))
     expect(beginCalls).toHaveLength(1)
     expect(commitCalls).toHaveLength(1)
+  })
+
+  it('更新処理で例外が発生した場合はロールバックする', () => {
+    vi.mocked(postSyncModule.syncPostMedia).mockImplementationOnce(() => {
+      throw new Error('media sync failed')
+    })
+    const { db, calls } = createDbWithExistingPost()
+
+    expect(() =>
+      handleUpdateStatus(
+        db,
+        JSON.stringify(createMockStatus()),
+        'https://example.com',
+      ),
+    ).toThrow('media sync failed')
+
+    expect(calls.some((call) => call.sql === 'ROLLBACK;')).toBe(true)
+    expect(calls.some((call) => call.sql === 'COMMIT;')).toBe(false)
   })
 
   it('posts_reblogs テーブルを使用しない', () => {

--- a/src/util/db/sqlite/__tests__/helpers-profile.test.ts
+++ b/src/util/db/sqlite/__tests__/helpers-profile.test.ts
@@ -290,6 +290,159 @@ describe('ensureProfile', () => {
     expect(bind[12]).toBe(1) // is_locked (locked: true → 1)
     expect(bind[13]).toBe(1) // is_bot (bot: true → 1)
   })
+
+  it('キャッシュにない server host を DB から解決して再利用する', () => {
+    serverHostCache.clear()
+    const calls: {
+      sql: string
+      opts?: Parameters<DbExecCompat['exec']>[1]
+    }[] = []
+    const db: DbExecCompat = {
+      exec: vi.fn((sql, opts) => {
+        calls.push({ opts, sql })
+        if (sql.includes('SELECT host FROM servers')) {
+          return [['resolved.example']]
+        }
+        if (sql.includes('SELECT id FROM profiles')) return [[17]]
+        return undefined
+      }),
+    }
+    const account = createMockAccount({
+      acct: 'local',
+      username: 'local',
+    })
+
+    expect(ensureProfile(db, account, 9)).toBe(17)
+    profileIdCache.clear()
+    expect(ensureProfile(db, account, 9)).toBe(17)
+
+    expect(
+      calls.filter(({ sql }) => sql.includes('SELECT host FROM servers')),
+    ).toHaveLength(1)
+    expect(serverHostCache.get(9)).toBe('resolved.example')
+  })
+
+  it('uses an empty host when the server cannot be resolved', () => {
+    serverHostCache.clear()
+    const db: DbExecCompat = {
+      exec: vi.fn((sql) => {
+        if (sql.includes('SELECT host FROM servers')) return []
+        if (sql.includes('SELECT id FROM profiles')) return [[21]]
+        return undefined
+      }),
+    }
+    const account = createMockAccount({
+      acct: 'local',
+      username: 'local',
+    })
+
+    expect(ensureProfile(db, account, 10)).toBe(21)
+    expect(profileIdCache.get('local@')).toBe(21)
+  })
+
+  it('skipUpdate returns a cached profile without writing', () => {
+    const { db, calls } = createMockDb()
+    profileIdCache.set('cached@example.com', 88)
+    const collector = { add: vi.fn() }
+
+    expect(
+      ensureProfile(
+        db,
+        createMockAccount({
+          acct: 'cached@example.com',
+          username: 'cached',
+        }),
+        1,
+        collector,
+        true,
+      ),
+    ).toBe(88)
+
+    expect(calls).toHaveLength(0)
+    expect(collector.add).not.toHaveBeenCalled()
+  })
+
+  it('skipUpdate inserts without overwriting and caches the selected id', () => {
+    const { db, calls } = createMockDb([[73]])
+    const collector = { add: vi.fn() }
+
+    expect(
+      ensureProfile(
+        db,
+        createMockAccount({
+          acct: 'new@example.com',
+          username: 'new',
+        }),
+        1,
+        collector,
+        true,
+      ),
+    ).toBe(73)
+
+    expect(calls[0].sql).toContain('INSERT OR IGNORE INTO profiles')
+    expect(calls[1].sql).toContain('SELECT id FROM profiles')
+    expect(collector.add).toHaveBeenCalledWith('profiles')
+    expect(profileIdCache.get('new@example.com')).toBe(73)
+  })
+
+  it('skipUpdate applies optional-field defaults and boolean flags', () => {
+    const { db, calls } = createMockDb([[74]])
+    const account = createMockAccount({
+      acct: 'defaults@example.com',
+      avatar: undefined as unknown as string,
+      avatar_static: undefined as unknown as string,
+      bot: true,
+      display_name: undefined as unknown as string,
+      header: undefined as unknown as string,
+      header_static: undefined as unknown as string,
+      locked: true,
+      note: undefined as unknown as string,
+      url: undefined as unknown as string,
+      username: 'defaults',
+    })
+
+    expect(ensureProfile(db, account, 1, undefined, true)).toBe(74)
+
+    expect(calls[0].opts?.bind).toEqual([
+      null,
+      'defaults',
+      1,
+      'defaults@example.com',
+      'defaults@example.com',
+      '',
+      '',
+      '',
+      '',
+      '',
+      '',
+      '',
+      1,
+      1,
+      expect.any(Number),
+    ])
+  })
+
+  it('normal updates record the written table and default optional fields', () => {
+    const { db, calls } = createMockDb([[31]])
+    const collector = { add: vi.fn() }
+    const account = createMockAccount({
+      acct: 'defaults@example.com',
+      avatar: undefined as unknown as string,
+      avatar_static: undefined as unknown as string,
+      display_name: undefined as unknown as string,
+      header: undefined as unknown as string,
+      header_static: undefined as unknown as string,
+      note: undefined as unknown as string,
+      url: undefined as unknown as string,
+      username: 'defaults',
+    })
+
+    expect(ensureProfile(db, account, 1, collector)).toBe(31)
+
+    const bind = calls[0].opts?.bind
+    expect(bind?.slice(5, 12)).toEqual(['', '', '', '', '', '', ''])
+    expect(collector.add).toHaveBeenCalledWith('profiles')
+  })
 })
 
 // ─── syncProfileStats ───────────────────────────────────────────
@@ -318,6 +471,14 @@ describe('syncProfileStats', () => {
     expect(bind[2]).toBe(200) // following_count
     expect(bind[3]).toBe(500) // statuses_count
     expect(typeof bind[4]).toBe('number') // updated_at (Date.now())
+  })
+
+  it('欠けている統計値をゼロで保存する', () => {
+    const { db, calls } = createMockDb()
+
+    syncProfileStats(db, 10, {})
+
+    expect(calls[0].opts?.bind?.slice(0, 4)).toEqual([10, 0, 0, 0])
   })
 })
 
@@ -387,6 +548,19 @@ describe('syncProfileFields', () => {
     const bind = calls[3].opts?.bind as SqlValue[]
     expect(bind[2]).toBe('New Field')
     expect(bind[7]).toBe('Another Field')
+  })
+
+  it('空リストでは既存フィールドの削除だけを行う', () => {
+    const { db, calls } = createMockDb()
+
+    syncProfileFields(db, 5, [])
+
+    expect(calls).toEqual([
+      {
+        opts: { bind: [5] },
+        sql: 'DELETE FROM profile_fields WHERE profile_id = ?;',
+      },
+    ])
   })
 })
 
@@ -465,5 +639,29 @@ describe('syncProfileCustomEmojis', () => {
     )
     expect(deleteCalls).toHaveLength(1)
     expect(deleteCalls[0].opts?.bind).toEqual([10])
+  })
+
+  it('空リストの削除を collector に記録する', () => {
+    const { db } = createMockDb()
+    const collector = { add: vi.fn() }
+
+    syncProfileCustomEmojis(db, 10, 1, [], collector)
+
+    expect(collector.add).toHaveBeenCalledWith('profile_custom_emojis')
+  })
+
+  it('絵文字同期後のリンク更新を collector に記録する', () => {
+    const { db } = createMockDb()
+    const collector = { add: vi.fn() }
+
+    syncProfileCustomEmojis(
+      db,
+      10,
+      1,
+      [{ shortcode: 'wave', url: 'https://example.com/wave.png' }],
+      collector,
+    )
+
+    expect(collector.add).toHaveBeenCalledWith('profile_custom_emojis')
   })
 })

--- a/src/util/db/sqlite/__tests__/helpers-statusHelpers.test.ts
+++ b/src/util/db/sqlite/__tests__/helpers-statusHelpers.test.ts
@@ -80,6 +80,13 @@ describe('resolveVisibilityId', () => {
     expect(result).toBe(1)
     expect(db.exec).not.toHaveBeenCalled()
   })
+
+  it('未知の visibility は null を返しキャッシュしない', () => {
+    const db = createMockDb(() => [])
+
+    expect(resolveVisibilityId(db, 'unsupported')).toBeNull()
+    expect(visibilityCache.has('unsupported')).toBe(false)
+  })
 })
 
 // ================================================================
@@ -95,6 +102,41 @@ describe('resolveMediaTypeId', () => {
     expect(db.exec).toHaveBeenCalledWith(
       'SELECT id FROM media_types WHERE name = ?;',
       { bind: ['image'], returnValue: 'resultRows' },
+    )
+  })
+
+  it('キャッシュヒット時は DB にアクセスしない', () => {
+    mediaTypeCache.set('video', 2)
+    const db = createMockDb()
+
+    expect(resolveMediaTypeId(db, 'video')).toBe(2)
+    expect(db.exec).not.toHaveBeenCalled()
+  })
+
+  it('未知の media type は unknown の ID にフォールバックしてキャッシュする', () => {
+    const db = createMockDb((sql) =>
+      String(sql).includes("name = 'unknown'") ? [[9]] : [],
+    )
+
+    expect(resolveMediaTypeId(db, 'model')).toBe(9)
+    expect(mediaTypeCache.get('model')).toBe(9)
+  })
+
+  it('unknown の行も存在しない場合は明示的に失敗する', () => {
+    const db = createMockDb(() => [])
+
+    expect(() => resolveMediaTypeId(db, 'model')).toThrow(
+      "media_types table missing 'unknown' entry (lookup for: model)",
+    )
+  })
+
+  it('unknown の先頭行が欠けている場合も明示的に失敗する', () => {
+    const db = createMockDb((sql) =>
+      String(sql).includes('WHERE name = ?') ? [] : [undefined],
+    )
+
+    expect(() => resolveMediaTypeId(db, 'model')).toThrow(
+      "media_types table missing 'unknown' entry (lookup for: model)",
     )
   })
 })
@@ -113,6 +155,19 @@ describe('resolveReplyToPostId', () => {
       'SELECT post_id FROM post_backend_ids WHERE local_account_id = ? AND local_id = ? LIMIT 1;',
       { bind: [42, '99999'], returnValue: 'resultRows' },
     )
+  })
+
+  it('返信先 ID が空の場合は DB を参照せず null を返す', () => {
+    const db = createMockDb()
+
+    expect(resolveReplyToPostId(db, null, 42)).toBeNull()
+    expect(db.exec).not.toHaveBeenCalled()
+  })
+
+  it('対応する返信先がない場合は null を返す', () => {
+    const db = createMockDb(() => [])
+
+    expect(resolveReplyToPostId(db, 'missing', 42)).toBeNull()
   })
 })
 
@@ -136,6 +191,19 @@ describe('resolveRepostOfPostId', () => {
         returnValue: 'resultRows',
       },
     )
+  })
+
+  it('リポスト元 URI が空の場合は DB を参照せず null を返す', () => {
+    const db = createMockDb()
+
+    expect(resolveRepostOfPostId(db, null)).toBeNull()
+    expect(db.exec).not.toHaveBeenCalled()
+  })
+
+  it('対応するリポスト元がない場合は null を返す', () => {
+    const db = createMockDb(() => [])
+
+    expect(resolveRepostOfPostId(db, 'https://example.com/missing')).toBeNull()
   })
 })
 
@@ -190,5 +258,21 @@ describe('getLastInsertRowId', () => {
     expect(db.exec).toHaveBeenCalledWith('SELECT last_insert_rowid();', {
       returnValue: 'resultRows',
     })
+  })
+
+  it('SQLite が行を返さない場合は失敗する', () => {
+    const db = createMockDb(() => [])
+
+    expect(() => getLastInsertRowId(db)).toThrow(
+      'last_insert_rowid() returned no rows',
+    )
+  })
+
+  it('SQLite の先頭行が欠けている場合も失敗する', () => {
+    const db = createMockDb(() => [undefined])
+
+    expect(() => getLastInsertRowId(db)).toThrow(
+      'last_insert_rowid() returned no rows',
+    )
   })
 })

--- a/src/util/db/sqlite/__tests__/initSqlite.test.ts
+++ b/src/util/db/sqlite/__tests__/initSqlite.test.ts
@@ -1,0 +1,885 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type {
+  FetchTimelineRequest,
+  SendCommandPayload,
+  TableName,
+} from '../protocol'
+
+const mocks = vi.hoisted(() => ({
+  buildTimelineKey: vi.fn(),
+  databaseConstructor: vi.fn(),
+  ensureSchema: vi.fn(),
+  executeFlatFetch: vi.fn(),
+  executeGraphPlan: vi.fn(),
+  executeQueryPlan: vi.fn(),
+  fetch: vi.fn(),
+  handleAddNotification: vi.fn(),
+  handleBulkAddNotifications: vi.fn(),
+  handleBulkUpsertCustomEmojis: vi.fn(),
+  handleBulkUpsertStatuses: vi.fn(),
+  handleDeleteEvent: vi.fn(),
+  handleEnforceMaxLength: vi.fn(),
+  handleEnsureLocalAccount: vi.fn(),
+  handleRemoveFromTimeline: vi.fn(),
+  handleToggleReaction: vi.fn(),
+  handleUpdateNotificationStatusAction: vi.fn(),
+  handleUpdateStatus: vi.fn(),
+  handleUpdateStatusAction: vi.fn(),
+  handleUpsertStatus: vi.fn(),
+  initSqlite: vi.fn(),
+  loadSqliteWasmInitializer: vi.fn(),
+  logSlowQueryExplain: vi.fn(),
+  rawExec: vi.fn(),
+  resolveLocalAccountId: vi.fn(),
+  resolvePostIdInternal: vi.fn(),
+  wasmArrayBuffer: vi.fn(),
+  worker: {
+    cancelStaleRequests: vi.fn(),
+    execAsync: vi.fn(),
+    execAsyncTimed: vi.fn(),
+    execBatch: vi.fn(),
+    executeFlatFetch: vi.fn(),
+    executeGraphPlan: vi.fn(),
+    executeQueryPlan: vi.fn(),
+    fetchTimeline: vi.fn(),
+    initWorker: vi.fn(),
+    sendCommand: vi.fn(),
+  },
+}))
+
+vi.mock('util/db/sqlite/explainLogger', () => ({
+  logSlowQueryExplain: mocks.logSlowQueryExplain,
+}))
+
+vi.mock('util/db/sqlite/helpers', () => ({
+  buildTimelineKey: mocks.buildTimelineKey,
+  resolveLocalAccountId: mocks.resolveLocalAccountId,
+}))
+
+vi.mock('util/db/sqlite/sqliteWasmLoader', () => ({
+  loadSqliteWasmInitializer: mocks.loadSqliteWasmInitializer,
+}))
+
+vi.mock('util/db/sqlite/worker/handlers/statusHelpers', () => ({
+  resolvePostIdInternal: mocks.resolvePostIdInternal,
+}))
+
+vi.mock('util/db/sqlite/workerClient', () => mocks.worker)
+
+vi.mock('util/db/sqlite/schema', () => ({
+  ensureSchema: mocks.ensureSchema,
+}))
+
+vi.mock('util/db/sqlite/worker/workerStatusStore', () => ({
+  handleBulkUpsertCustomEmojis: mocks.handleBulkUpsertCustomEmojis,
+  handleBulkUpsertStatuses: mocks.handleBulkUpsertStatuses,
+  handleDeleteEvent: mocks.handleDeleteEvent,
+  handleEnsureLocalAccount: mocks.handleEnsureLocalAccount,
+  handleRemoveFromTimeline: mocks.handleRemoveFromTimeline,
+  handleToggleReaction: mocks.handleToggleReaction,
+  handleUpdateStatus: mocks.handleUpdateStatus,
+  handleUpdateStatusAction: mocks.handleUpdateStatusAction,
+  handleUpsertStatus: mocks.handleUpsertStatus,
+}))
+
+vi.mock('util/db/sqlite/worker/workerNotificationStore', () => ({
+  handleAddNotification: mocks.handleAddNotification,
+  handleBulkAddNotifications: mocks.handleBulkAddNotifications,
+  handleUpdateNotificationStatusAction:
+    mocks.handleUpdateNotificationStatusAction,
+}))
+
+vi.mock('util/db/sqlite/worker/workerCleanup', () => ({
+  handleEnforceMaxLength: mocks.handleEnforceMaxLength,
+}))
+
+vi.mock('util/db/query-ir/executor/flatFetchExecutor', () => ({
+  executeFlatFetch: mocks.executeFlatFetch,
+}))
+
+vi.mock('util/db/query-ir/executor/graphExecutor', () => ({
+  executeGraphPlan: mocks.executeGraphPlan,
+}))
+
+vi.mock('util/db/sqlite/queries/executionEngine', () => ({
+  executeQueryPlan: mocks.executeQueryPlan,
+}))
+
+const rawDb = {
+  exec: mocks.rawExec,
+}
+
+const notify = vi.fn<(table: TableName, hint?: object) => void>()
+
+const timelineRequest: Omit<FetchTimelineRequest, 'id' | 'type'> = {
+  batchSqls: {
+    belongingTags: 'belongingTags {IDS}',
+    customEmojis: 'customEmojis {IDS}',
+    interactions: 'interactions {IDS}',
+    media: 'media {IDS}',
+    mentions: 'mentions {IDS}',
+    polls: 'polls {IDS}',
+    profileEmojis: 'profileEmojis {IDS}',
+    timelineTypes: 'timelineTypes {IDS}',
+  },
+  phase1: {
+    bind: ['https://example.test'],
+    sql: 'phase1',
+  },
+  phase2BaseSql: 'phase2 {IDS}',
+}
+
+async function createFallbackHandle(origin?: string) {
+  vi.stubGlobal('Worker', undefined)
+  if (origin !== undefined) {
+    vi.stubGlobal('location', { origin })
+  }
+  vi.stubGlobal('fetch', mocks.fetch)
+
+  const { getDb } = await import('util/db/sqlite/initSqlite')
+  return getDb(notify)
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.clearAllMocks()
+
+  mocks.rawExec.mockReturnValue([])
+  mocks.wasmArrayBuffer.mockResolvedValue(new ArrayBuffer(8))
+  mocks.fetch.mockResolvedValue({
+    arrayBuffer: mocks.wasmArrayBuffer,
+  })
+  mocks.databaseConstructor.mockImplementation(function Database() {
+    return rawDb
+  })
+  mocks.initSqlite.mockResolvedValue({
+    oo1: {
+      DB: mocks.databaseConstructor,
+    },
+  })
+  mocks.loadSqliteWasmInitializer.mockResolvedValue(mocks.initSqlite)
+  mocks.resolveLocalAccountId.mockReturnValue(7)
+  mocks.resolvePostIdInternal.mockReturnValue(99)
+  mocks.buildTimelineKey.mockReturnValue('home:#vitest')
+  mocks.worker.initWorker.mockResolvedValue('opfs')
+
+  const changed = { changedTables: ['posts'] }
+  mocks.handleAddNotification.mockReturnValue(changed)
+  mocks.handleBulkAddNotifications.mockReturnValue(changed)
+  mocks.handleBulkUpsertCustomEmojis.mockReturnValue(changed)
+  mocks.handleBulkUpsertStatuses.mockReturnValue(changed)
+  mocks.handleDeleteEvent.mockReturnValue(changed)
+  mocks.handleEnsureLocalAccount.mockReturnValue(changed)
+  mocks.handleRemoveFromTimeline.mockReturnValue(changed)
+  mocks.handleToggleReaction.mockReturnValue(changed)
+  mocks.handleUpdateNotificationStatusAction.mockReturnValue(changed)
+  mocks.handleUpdateStatus.mockReturnValue(changed)
+  mocks.handleUpdateStatusAction.mockReturnValue(changed)
+  mocks.handleUpsertStatus.mockReturnValue(changed)
+  mocks.handleEnforceMaxLength.mockReturnValue({
+    changedTables: ['posts'],
+    deletedCounts: {
+      notifications: 2,
+      posts: 3,
+      timeline_entries: 1,
+    },
+    hasMore: true,
+  })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('getDb worker mode', () => {
+  it('returns the worker API and reuses the initialized singleton', async () => {
+    vi.stubGlobal('Worker', class FakeWorker {})
+    const firstNotify = vi.fn()
+    const secondNotify = vi.fn()
+    const { getDb } = await import('util/db/sqlite/initSqlite')
+
+    const first = await getDb(firstNotify)
+    const second = await getDb(secondNotify)
+
+    expect(mocks.worker.initWorker).toHaveBeenCalledOnce()
+    expect(mocks.worker.initWorker).toHaveBeenCalledWith(firstNotify)
+    expect(second).toBe(first)
+    expect(first).toEqual({
+      cancelStaleRequests: mocks.worker.cancelStaleRequests,
+      execAsync: mocks.worker.execAsync,
+      execAsyncTimed: mocks.worker.execAsyncTimed,
+      execBatch: mocks.worker.execBatch,
+      executeFlatFetch: mocks.worker.executeFlatFetch,
+      executeGraphPlan: mocks.worker.executeGraphPlan,
+      executeQueryPlan: mocks.worker.executeQueryPlan,
+      fetchTimeline: mocks.worker.fetchTimeline,
+      persistence: 'opfs',
+      sendCommand: mocks.worker.sendCommand,
+    })
+  })
+
+  it('warns and initializes the memory fallback when worker setup fails', async () => {
+    vi.stubGlobal('Worker', class FakeWorker {})
+    vi.stubGlobal('location', { origin: 'https://client.test' })
+    vi.stubGlobal('fetch', mocks.fetch)
+    const workerError = new Error('worker unavailable')
+    mocks.worker.initWorker.mockRejectedValue(workerError)
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { getDb } = await import('util/db/sqlite/initSqlite')
+
+    const handle = await getDb(notify)
+
+    expect(handle.persistence).toBe('memory')
+    expect(warn).toHaveBeenCalledWith(
+      'SQLite: Worker mode failed, falling back to main thread.',
+      workerError,
+    )
+    expect(mocks.fetch).toHaveBeenCalledWith('https://client.test/sqlite3.wasm')
+  })
+})
+
+describe('main-thread fallback initialization', () => {
+  it('loads WASM, configures SQLite, and exposes all schema exec overloads', async () => {
+    mocks.ensureSchema.mockImplementation(({ db }) => {
+      db.exec('schema rows', {
+        bind: [1],
+        returnValue: 'resultRows',
+      })
+      db.exec('schema bind', { bind: [2] })
+      db.exec('schema plain')
+    })
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const handle = await createFallbackHandle('https://client.test')
+
+    expect(mocks.fetch).toHaveBeenCalledWith('https://client.test/sqlite3.wasm')
+    expect(mocks.wasmArrayBuffer).toHaveBeenCalledOnce()
+    expect(mocks.loadSqliteWasmInitializer).toHaveBeenCalledWith(
+      'https://client.test',
+    )
+    const moduleArg = mocks.initSqlite.mock.calls[0][0]
+    expect(moduleArg.wasmBinary).toBeInstanceOf(ArrayBuffer)
+    expect(moduleArg.locateFile('sqlite3-opfs-async-proxy.js')).toBe(
+      'https://client.test/sqlite3-opfs-async-proxy.js',
+    )
+    expect(mocks.databaseConstructor).toHaveBeenCalledWith(':memory:', 'c')
+    expect(mocks.rawExec.mock.calls.slice(0, 5)).toEqual([
+      ['PRAGMA journal_mode=WAL;'],
+      ['PRAGMA synchronous=NORMAL;'],
+      ['PRAGMA foreign_keys = ON;'],
+      ['PRAGMA cache_size = -8000;'],
+      ['PRAGMA temp_store = MEMORY;'],
+    ])
+    expect(mocks.rawExec).toHaveBeenCalledWith('schema rows', {
+      bind: [1],
+      returnValue: 'resultRows',
+    })
+    expect(mocks.rawExec).toHaveBeenCalledWith('schema bind', { bind: [2] })
+    expect(mocks.rawExec).toHaveBeenCalledWith('schema plain')
+    expect(warn).toHaveBeenCalledWith(
+      'SQLite: using in-memory fallback (no Worker). Data will not persist.',
+    )
+    expect(handle.persistence).toBe('memory')
+    expect(handle.cancelStaleRequests('old-session')).toBe(0)
+  })
+
+  it('uses relative WASM paths when location is unavailable', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await createFallbackHandle()
+
+    expect(mocks.fetch).toHaveBeenCalledWith('/sqlite3.wasm')
+    expect(mocks.loadSqliteWasmInitializer).toHaveBeenCalledWith('')
+    expect(mocks.initSqlite.mock.calls[0][0].locateFile('sqlite3.wasm')).toBe(
+      '/sqlite3.wasm',
+    )
+  })
+})
+
+describe('main-thread SQL API', () => {
+  it('executes row and non-row queries and records timings', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const handle = await createFallbackHandle()
+    mocks.rawExec.mockReset()
+    mocks.logSlowQueryExplain.mockReset()
+    const now = vi
+      .fn()
+      .mockReturnValueOnce(10)
+      .mockReturnValueOnce(14)
+      .mockReturnValueOnce(20)
+      .mockReturnValueOnce(27)
+      .mockReturnValueOnce(30)
+      .mockReturnValueOnce(39)
+      .mockReturnValueOnce(50)
+      .mockReturnValueOnce(61)
+    vi.stubGlobal('performance', { now })
+    mocks.rawExec
+      .mockReturnValueOnce([[1, 'row']])
+      .mockReturnValueOnce(undefined)
+      .mockReturnValueOnce([[2, 'timed']])
+      .mockReturnValueOnce(undefined)
+
+    await expect(
+      handle.execAsync('SELECT rows', {
+        bind: [1],
+        returnValue: 'resultRows',
+      }),
+    ).resolves.toEqual([[1, 'row']])
+    await expect(handle.execAsync('UPDATE rows')).resolves.toBeUndefined()
+    await expect(
+      handle.execAsyncTimed('SELECT timed', {
+        bind: [2],
+        returnValue: 'resultRows',
+      }),
+    ).resolves.toEqual({
+      durationMs: 9,
+      result: [[2, 'timed']],
+    })
+    await expect(
+      handle.execAsyncTimed('DELETE rows', { bind: [3] }),
+    ).resolves.toEqual({
+      durationMs: 11,
+      result: undefined,
+    })
+
+    expect(mocks.rawExec.mock.calls).toEqual([
+      [
+        'SELECT rows',
+        {
+          bind: [1],
+          returnValue: 'resultRows',
+        },
+      ],
+      ['UPDATE rows', { bind: undefined }],
+      [
+        'SELECT timed',
+        {
+          bind: [2],
+          returnValue: 'resultRows',
+        },
+      ],
+      ['DELETE rows', { bind: [3] }],
+    ])
+    expect(mocks.logSlowQueryExplain.mock.calls).toEqual([
+      [rawDb, 'SELECT rows', [1], 4],
+      [rawDb, 'UPDATE rows', undefined, 7],
+      [rawDb, 'SELECT timed', [2], 9],
+      [rawDb, 'DELETE rows', [3], 11],
+    ])
+  })
+
+  it('commits batches and selects requested or all return values', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const handle = await createFallbackHandle()
+    mocks.rawExec.mockReset()
+    mocks.rawExec.mockImplementation((sql) => {
+      if (sql === 'SELECT first') return [['first']]
+      if (sql === 'SELECT second') return [['second']]
+      return undefined
+    })
+
+    await expect(
+      handle.execBatch(
+        [
+          { returnValue: 'resultRows', sql: 'SELECT first' },
+          { bind: [2], returnValue: 'resultRows', sql: 'SELECT second' },
+          { bind: [3], sql: 'UPDATE third' },
+        ],
+        { returnIndices: [1], rollbackOnError: true },
+      ),
+    ).resolves.toEqual({ 1: [['second']] })
+
+    expect(mocks.rawExec.mock.calls).toEqual([
+      ['BEGIN;'],
+      ['SELECT first', { bind: undefined, returnValue: 'resultRows' }],
+      ['SELECT second', { bind: [2], returnValue: 'resultRows' }],
+      ['UPDATE third', { bind: [3] }],
+      ['COMMIT;'],
+    ])
+
+    mocks.rawExec.mockClear()
+    await expect(
+      handle.execBatch([
+        { returnValue: 'resultRows', sql: 'SELECT first' },
+        { sql: 'UPDATE third' },
+      ]),
+    ).resolves.toEqual({ 0: [['first']], 1: undefined })
+    expect(mocks.rawExec).toHaveBeenNthCalledWith(1, 'BEGIN;')
+    expect(mocks.rawExec).toHaveBeenLastCalledWith('COMMIT;')
+
+    mocks.rawExec.mockClear()
+    await expect(
+      handle.execBatch([{ sql: 'UPDATE third' }], {
+        returnIndices: [],
+        rollbackOnError: false,
+      }),
+    ).resolves.toEqual({})
+    expect(mocks.rawExec).toHaveBeenCalledOnce()
+    expect(mocks.rawExec).toHaveBeenCalledWith('UPDATE third', {
+      bind: undefined,
+    })
+  })
+
+  it('rolls back a failed batch and preserves the original error', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const handle = await createFallbackHandle()
+    const failure = new Error('statement failed')
+    mocks.rawExec.mockReset()
+    mocks.rawExec.mockImplementation((sql) => {
+      if (sql === 'BROKEN') throw failure
+      return undefined
+    })
+
+    await expect(
+      handle.execBatch([{ sql: 'BROKEN' }], { rollbackOnError: true }),
+    ).rejects.toBe(failure)
+    expect(mocks.rawExec).toHaveBeenLastCalledWith('ROLLBACK;')
+  })
+
+  it('ignores a rollback failure and still throws the statement error', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const handle = await createFallbackHandle()
+    const failure = new Error('statement failed')
+    mocks.rawExec.mockReset()
+    mocks.rawExec.mockImplementation((sql) => {
+      if (sql === 'BROKEN') throw failure
+      if (sql === 'ROLLBACK;') throw new Error('rollback failed')
+      return undefined
+    })
+
+    await expect(
+      handle.execBatch([{ sql: 'BROKEN' }], { rollbackOnError: true }),
+    ).rejects.toBe(failure)
+    expect(mocks.rawExec).toHaveBeenLastCalledWith('ROLLBACK;')
+  })
+
+  it('delegates all structured query executors to their fallback engines', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const handle = await createFallbackHandle()
+    const flatRequest = { ids: [1], target: 'posts' }
+    const graphPlan = { nodes: [] }
+    const graphOptions = { limit: 20 }
+    const queryPlan = { meta: {}, steps: [] }
+    const flatResult = { entities: [] }
+    const graphResult = { items: [] }
+    const queryResult = { stepResults: [], totalDurationMs: 1 }
+    mocks.executeFlatFetch.mockReturnValue(flatResult)
+    mocks.executeGraphPlan.mockReturnValue(graphResult)
+    mocks.executeQueryPlan.mockReturnValue(queryResult)
+
+    await expect(handle.executeFlatFetch(flatRequest as never)).resolves.toBe(
+      flatResult,
+    )
+    await expect(
+      handle.executeGraphPlan(graphPlan as never, graphOptions as never),
+    ).resolves.toBe(graphResult)
+    await expect(handle.executeQueryPlan(queryPlan as never)).resolves.toBe(
+      queryResult,
+    )
+
+    expect(mocks.executeFlatFetch).toHaveBeenCalledWith(rawDb, flatRequest)
+    expect(mocks.executeQueryPlan).toHaveBeenCalledWith(rawDb, queryPlan)
+    expect(mocks.executeGraphPlan).toHaveBeenCalledWith(
+      rawDb,
+      graphPlan,
+      graphOptions,
+      expect.any(Function),
+    )
+    expect(mocks.executeGraphPlan.mock.calls[0][3]()).toEqual({})
+  })
+})
+
+describe('main-thread timeline fetch', () => {
+  it('returns immediately when phase 1 has no posts', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const handle = await createFallbackHandle()
+    mocks.rawExec.mockReset()
+    mocks.rawExec.mockReturnValue([])
+    const now = vi.fn().mockReturnValueOnce(100).mockReturnValueOnce(106)
+    vi.stubGlobal('performance', { now })
+
+    const result = await handle.fetchTimeline(timelineRequest)
+
+    expect(mocks.rawExec).toHaveBeenCalledOnce()
+    expect(mocks.rawExec).toHaveBeenCalledWith('phase1', {
+      bind: ['https://example.test'],
+      returnValue: 'resultRows',
+    })
+    expect(result).toEqual({
+      batchResults: {
+        belongingTags: [],
+        customEmojis: [],
+        interactions: [],
+        media: [],
+        mentions: [],
+        polls: [],
+        profileEmojis: [],
+        timelineTypes: [],
+      },
+      phase1Rows: [],
+      phase2Rows: [],
+      totalDurationMs: 6,
+    })
+  })
+
+  it('expands reblogs, deduplicates IDs, and runs every enrichment query', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const handle = await createFallbackHandle()
+    mocks.rawExec.mockReset()
+    mocks.rawExec.mockImplementation((sql) => {
+      if (sql === 'phase1') return [[1], [2]]
+      if (sql === 'phase2 ?,?') {
+        return [
+          ['first', null, 3],
+          ['second', null, 2],
+          ['third', null, null],
+        ]
+      }
+      return [[sql]]
+    })
+    const now = vi.fn().mockReturnValueOnce(200).mockReturnValueOnce(215)
+    vi.stubGlobal('performance', { now })
+
+    const result = await handle.fetchTimeline({
+      ...timelineRequest,
+      reblogPostIdColumnIndex: 2,
+    })
+
+    expect(result.phase1Rows).toEqual([[1], [2]])
+    expect(result.phase2Rows).toHaveLength(3)
+    expect(result.totalDurationMs).toBe(15)
+    expect(mocks.rawExec).toHaveBeenCalledTimes(10)
+    for (const key of Object.keys(timelineRequest.batchSqls)) {
+      expect(mocks.rawExec).toHaveBeenCalledWith(`${key} ?,?,?`, {
+        bind: [1, 2, 3],
+        returnValue: 'resultRows',
+      })
+      expect(
+        result.batchResults[key as keyof typeof result.batchResults],
+      ).toEqual([[`${key} ?,?,?`]])
+    }
+  })
+
+  it('uses the legacy reblog column index when none is supplied', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const handle = await createFallbackHandle()
+    mocks.rawExec.mockReset()
+    const phase2Row = Array.from({ length: 26 }, () => null)
+    phase2Row[25] = 8
+    mocks.rawExec.mockImplementation((sql) => {
+      if (sql === 'phase1') return [[4]]
+      if (sql === 'phase2 ?') return [phase2Row]
+      return []
+    })
+
+    await handle.fetchTimeline(timelineRequest)
+
+    expect(mocks.rawExec).toHaveBeenCalledWith('interactions ?,?', {
+      bind: [4, 8],
+      returnValue: 'resultRows',
+    })
+  })
+})
+
+describe('main-thread command API', () => {
+  it('dispatches direct status and notification commands with change hints', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const handle = await createFallbackHandle()
+    const cases: {
+      command: SendCommandPayload
+      expectedArgs: unknown[]
+      handler: ReturnType<typeof vi.fn>
+      hint: object | undefined
+    }[] = [
+      {
+        command: {
+          backendUrl: 'https://example.test',
+          statusJson: '{"id":"1"}',
+          tag: 'news',
+          timelineType: 'tag',
+          type: 'upsertStatus',
+        },
+        expectedArgs: [
+          rawDb,
+          '{"id":"1"}',
+          'https://example.test',
+          'tag',
+          'news',
+        ],
+        handler: mocks.handleUpsertStatus,
+        hint: {
+          backendUrl: 'https://example.test',
+          tag: 'news',
+          timelineType: 'tag',
+        },
+      },
+      {
+        command: {
+          backendUrl: 'https://example.test',
+          statusesJson: ['{"id":"1"}'],
+          timelineType: 'home',
+          type: 'bulkUpsertStatuses',
+        },
+        expectedArgs: [
+          rawDb,
+          ['{"id":"1"}'],
+          'https://example.test',
+          'home',
+          undefined,
+        ],
+        handler: mocks.handleBulkUpsertStatuses,
+        hint: {
+          backendUrl: 'https://example.test',
+          tag: undefined,
+          timelineType: 'home',
+        },
+      },
+      {
+        command: {
+          backendUrl: 'https://example.test',
+          statusJson: '{"id":"2"}',
+          type: 'updateStatus',
+        },
+        expectedArgs: [rawDb, '{"id":"2"}', 'https://example.test'],
+        handler: mocks.handleUpdateStatus,
+        hint: { backendUrl: 'https://example.test' },
+      },
+      {
+        command: {
+          backendUrl: 'https://example.test',
+          notificationJson: '{"id":"n1"}',
+          type: 'addNotification',
+        },
+        expectedArgs: [rawDb, '{"id":"n1"}', 'https://example.test'],
+        handler: mocks.handleAddNotification,
+        hint: { backendUrl: 'https://example.test' },
+      },
+      {
+        command: {
+          backendUrl: 'https://example.test',
+          notificationsJson: ['{"id":"n2"}'],
+          type: 'bulkAddNotifications',
+        },
+        expectedArgs: [rawDb, ['{"id":"n2"}'], 'https://example.test'],
+        handler: mocks.handleBulkAddNotifications,
+        hint: { backendUrl: 'https://example.test' },
+      },
+      {
+        command: {
+          action: 'favourited',
+          backendUrl: 'https://example.test',
+          statusId: '2',
+          type: 'updateNotificationStatusAction',
+          value: true,
+        },
+        expectedArgs: [rawDb, 'https://example.test', '2', 'favourited', true],
+        handler: mocks.handleUpdateNotificationStatusAction,
+        hint: { backendUrl: 'https://example.test' },
+      },
+      {
+        command: {
+          accountJson: '{"id":"me"}',
+          backendUrl: 'https://example.test',
+          type: 'ensureLocalAccount',
+        },
+        expectedArgs: [rawDb, 'https://example.test', '{"id":"me"}'],
+        handler: mocks.handleEnsureLocalAccount,
+        hint: undefined,
+      },
+      {
+        command: {
+          backendUrl: 'https://example.test',
+          emojisJson: '[]',
+          type: 'bulkUpsertCustomEmojis',
+        },
+        expectedArgs: [rawDb, 'https://example.test', '[]'],
+        handler: mocks.handleBulkUpsertCustomEmojis,
+        hint: undefined,
+      },
+    ]
+
+    for (const { command, expectedArgs, handler, hint } of cases) {
+      notify.mockClear()
+      await expect(handle.sendCommand(command)).resolves.toEqual({
+        changedTables: ['posts'],
+      })
+      expect(handler).toHaveBeenLastCalledWith(...expectedArgs)
+      expect(notify).toHaveBeenCalledWith('posts', hint)
+    }
+  })
+
+  it('dispatches account-scoped interaction and deletion commands', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const handle = await createFallbackHandle()
+
+    await handle.sendCommand({
+      action: 'bookmarked',
+      backendUrl: 'https://example.test',
+      statusId: '10',
+      type: 'updateStatusAction',
+      value: false,
+    })
+    expect(mocks.handleUpdateStatusAction).toHaveBeenCalledWith(
+      rawDb,
+      7,
+      '10',
+      'bookmarked',
+      false,
+    )
+
+    await handle.sendCommand({
+      backendUrl: 'https://example.test',
+      sourceTimelineType: 'local',
+      statusId: '11',
+      tag: 'town',
+      type: 'handleDeleteEvent',
+    })
+    expect(mocks.handleDeleteEvent).toHaveBeenCalledWith(rawDb, 7, '11')
+    expect(notify).toHaveBeenLastCalledWith('posts', {
+      backendUrl: 'https://example.test',
+      tag: 'town',
+      timelineType: 'local',
+    })
+
+    await handle.sendCommand({
+      backendUrl: 'https://example.test',
+      emoji: ':party:',
+      statusId: '12',
+      type: 'toggleReaction',
+      value: true,
+    })
+    expect(mocks.handleToggleReaction).toHaveBeenCalledWith(
+      rawDb,
+      7,
+      '12',
+      true,
+      ':party:',
+    )
+    expect(notify).toHaveBeenLastCalledWith('posts', {
+      backendUrl: 'https://example.test',
+    })
+  })
+
+  it('returns no changes when an account-scoped command has no local account', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    mocks.resolveLocalAccountId.mockReturnValue(null)
+    const handle = await createFallbackHandle()
+    notify.mockClear()
+
+    await expect(
+      handle.sendCommand({
+        action: 'reblogged',
+        backendUrl: 'https://unknown.test',
+        statusId: '10',
+        type: 'updateStatusAction',
+        value: true,
+      }),
+    ).resolves.toEqual({ changedTables: [] })
+
+    expect(mocks.handleUpdateStatusAction).not.toHaveBeenCalled()
+    expect(notify).not.toHaveBeenCalled()
+  })
+
+  it('removes a resolved status from the requested timeline', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const handle = await createFallbackHandle()
+
+    await handle.sendCommand({
+      backendUrl: 'https://example.test',
+      statusId: '20',
+      tag: 'typescript',
+      timelineType: 'tag',
+      type: 'removeFromTimeline',
+    })
+
+    expect(mocks.buildTimelineKey).toHaveBeenCalledWith('tag', {
+      tag: 'typescript',
+    })
+    expect(mocks.resolvePostIdInternal).toHaveBeenCalledWith(rawDb, 7, '20')
+    expect(mocks.handleRemoveFromTimeline).toHaveBeenCalledWith(
+      rawDb,
+      7,
+      'home:#vitest',
+      99,
+    )
+    expect(notify).toHaveBeenCalledWith('posts', {
+      backendUrl: 'https://example.test',
+      tag: 'typescript',
+      timelineType: 'tag',
+    })
+  })
+
+  it('returns no changes when removal cannot resolve the backend status', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    mocks.resolvePostIdInternal.mockReturnValue(null)
+    const handle = await createFallbackHandle()
+    notify.mockClear()
+
+    await expect(
+      handle.sendCommand({
+        backendUrl: 'https://example.test',
+        statusId: 'missing',
+        timelineType: 'home',
+        type: 'removeFromTimeline',
+      }),
+    ).resolves.toEqual({ changedTables: [] })
+
+    expect(mocks.handleRemoveFromTimeline).not.toHaveBeenCalled()
+    expect(notify).not.toHaveBeenCalled()
+  })
+
+  it('maps cleanup options and preserves its extended result', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const handle = await createFallbackHandle()
+
+    await expect(
+      handle.sendCommand({
+        batchLimit: 50,
+        mode: 'emergency',
+        targetRatio: 0.25,
+        type: 'enforceMaxLength',
+      }),
+    ).resolves.toEqual({
+      changedTables: ['posts'],
+      deletedCounts: {
+        notifications: 2,
+        posts: 3,
+        timeline_entries: 1,
+      },
+      hasMore: true,
+    })
+    expect(mocks.handleEnforceMaxLength).toHaveBeenCalledWith(
+      rawDb,
+      100000,
+      100000,
+      100000,
+      {
+        batchLimit: 50,
+        mode: 'emergency',
+        targetRatio: 0.25,
+      },
+    )
+    expect(notify).toHaveBeenCalledWith('posts', undefined)
+  })
+
+  it('acknowledges memory exports without dispatch or notification', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const handle = await createFallbackHandle()
+    notify.mockClear()
+
+    await expect(
+      handle.sendCommand({ type: 'exportDatabase' }),
+    ).resolves.toEqual({ ok: true })
+    expect(notify).not.toHaveBeenCalled()
+  })
+
+  it('rejects unknown fallback commands', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const handle = await createFallbackHandle()
+
+    await expect(
+      handle.sendCommand({ type: 'not-supported' } as never),
+    ).rejects.toThrow('Unknown command type: not-supported')
+  })
+})

--- a/src/util/db/sqlite/__tests__/migration-branches.test.ts
+++ b/src/util/db/sqlite/__tests__/migration-branches.test.ts
@@ -1,0 +1,238 @@
+import { v2_0_4_migration } from 'util/db/sqlite/migrations/v2.0.4'
+import { v2_0_5_migration } from 'util/db/sqlite/migrations/v2.0.5'
+import { v28Migration } from 'util/db/sqlite/migrations/v28'
+import { describe, expect, it, vi } from 'vitest'
+
+type MigrationHandle = Parameters<typeof v2_0_4_migration.up>[0]
+
+function makeHandle(
+  implementation: (
+    sql: string,
+    options?: { returnValue?: string },
+  ) => unknown = () => undefined,
+): { exec: ReturnType<typeof vi.fn>; handle: MigrationHandle } {
+  const exec = vi.fn(implementation)
+  return {
+    exec,
+    handle: { db: { exec } } as unknown as MigrationHandle,
+  }
+}
+
+describe('v28Migration', () => {
+  it('adds and backfills all v28 columns and indexes', () => {
+    const { exec, handle } = makeHandle()
+
+    v28Migration.up(handle)
+
+    const sql = exec.mock.calls.map(([statement]) => statement).join('\n')
+    expect(sql).toContain(
+      'ALTER TABLE posts ADD COLUMN reply_to_post_id INTEGER',
+    )
+    expect(sql).toContain(
+      'ALTER TABLE posts ADD COLUMN repost_of_post_id INTEGER',
+    )
+    expect(sql).toContain('UPDATE posts')
+    expect(sql).toContain(
+      'ALTER TABLE posts_mentions ADD COLUMN profile_id INTEGER',
+    )
+    expect(sql).toContain(
+      'ALTER TABLE timelines ADD COLUMN local_account_id INTEGER',
+    )
+    expect(sql).toContain('DROP INDEX IF EXISTS idx_timelines_identity')
+    expect(sql).toContain('CREATE UNIQUE INDEX idx_timelines_identity')
+    expect(sql).toContain(
+      'ALTER TABLE notifications ADD COLUMN local_account_id INTEGER',
+    )
+    expect(sql).toContain('UPDATE notifications')
+    expect(sql).toContain(
+      'ALTER TABLE local_accounts ADD COLUMN is_active INTEGER',
+    )
+    expect(sql).toContain(
+      'ALTER TABLE local_accounts ADD COLUMN last_used_at_ms INTEGER',
+    )
+  })
+
+  it('validates when every expected column exists', () => {
+    const columns: Record<string, string[]> = {
+      local_accounts: ['is_active', 'last_used_at_ms'],
+      notifications: ['local_account_id'],
+      posts: ['reply_to_post_id', 'repost_of_post_id'],
+      posts_mentions: ['profile_id'],
+      timelines: ['local_account_id'],
+    }
+    const { handle } = makeHandle((sql) => {
+      const table = /PRAGMA table_info\(([^)]+)\)/.exec(sql)?.[1] ?? ''
+      return (columns[table] ?? []).map((column) => [0, column])
+    })
+
+    expect(v28Migration.validate(handle)).toBe(true)
+  })
+
+  it('fails validation when any expected column is missing', () => {
+    const { handle } = makeHandle((sql) => {
+      const table = /PRAGMA table_info\(([^)]+)\)/.exec(sql)?.[1] ?? ''
+      if (table === 'posts') return [[0, 'repost_of_post_id']]
+      return []
+    })
+
+    expect(v28Migration.validate(handle)).toBe(false)
+  })
+})
+
+describe('v2.0.4 migration', () => {
+  it('skips reference rewrites when there are no duplicate profiles', () => {
+    const { exec, handle } = makeHandle((sql) =>
+      sql.includes('SELECT COUNT(*) FROM _profile_merge_map') ? [[0]] : [],
+    )
+
+    v2_0_4_migration.up(handle)
+
+    const sql = exec.mock.calls.map(([statement]) => statement).join('\n')
+    expect(sql).not.toContain('UPDATE posts SET author_profile_id')
+    expect(sql).toContain('DROP TABLE _profile_merge_map')
+    expect(sql).toContain('CREATE UNIQUE INDEX idx_profiles_canonical_acct')
+  })
+
+  it('rewrites all profile references before deleting duplicates', () => {
+    const { exec, handle } = makeHandle((sql) =>
+      sql.includes('SELECT COUNT(*) FROM _profile_merge_map') ? [[2]] : [],
+    )
+
+    v2_0_4_migration.up(handle)
+
+    const sql = exec.mock.calls.map(([statement]) => statement).join('\n')
+    expect(sql).toContain('UPDATE posts SET author_profile_id')
+    expect(sql).toContain('UPDATE post_mentions SET profile_id')
+    expect(sql).toContain('UPDATE notifications SET actor_profile_id')
+    expect(sql).toContain('UPDATE local_accounts SET profile_id')
+    expect(sql).toContain('UPDATE profiles SET moved_to_profile_id')
+    expect(sql).toContain('DELETE FROM profiles')
+  })
+
+  it.each([
+    {
+      duplicateCount: 1,
+      expected: false,
+      indexRows: [['CREATE UNIQUE INDEX idx ON profiles(canonical_acct)']],
+      name: 'duplicates remain',
+    },
+    {
+      duplicateCount: 0,
+      expected: false,
+      indexRows: [],
+      name: 'index is missing',
+    },
+    {
+      duplicateCount: 0,
+      expected: false,
+      indexRows: [['CREATE INDEX idx ON profiles(canonical_acct)']],
+      name: 'index is not unique',
+    },
+    {
+      duplicateCount: 0,
+      expected: true,
+      indexRows: [['CREATE UNIQUE INDEX idx ON profiles(canonical_acct)']],
+      name: 'data and index are valid',
+    },
+  ])(
+    'returns $expected when $name',
+    ({ duplicateCount, expected, indexRows }) => {
+      const { handle } = makeHandle((sql) => {
+        if (sql.includes('HAVING COUNT(*) > 1')) return [[duplicateCount]]
+        if (sql.includes("type='index'")) return indexRows
+        return []
+      })
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      expect(v2_0_4_migration.validate(handle)).toBe(expected)
+    },
+  )
+})
+
+describe('v2.0.5 migration', () => {
+  it('is idempotent when the unique index already exists', () => {
+    const { exec, handle } = makeHandle((sql) =>
+      sql.includes("type='index'") ? [['CREATE UNIQUE INDEX existing']] : [],
+    )
+
+    v2_0_5_migration.up(handle)
+
+    expect(exec).toHaveBeenCalledOnce()
+  })
+
+  it('creates the index without rewrites when there are no duplicates', () => {
+    const { exec, handle } = makeHandle((sql) => {
+      if (sql.includes("type='index'")) return []
+      if (sql.includes('SELECT COUNT(*) FROM _profile_merge_map_v205')) {
+        return [[0]]
+      }
+      return []
+    })
+
+    v2_0_5_migration.up(handle)
+
+    const sql = exec.mock.calls.map(([statement]) => statement).join('\n')
+    expect(sql).not.toContain('UPDATE posts SET author_profile_id')
+    expect(sql).toContain('DROP TABLE _profile_merge_map_v205')
+    expect(sql).toContain('CREATE UNIQUE INDEX idx_profiles_username_server')
+  })
+
+  it('rewrites all profile references before deleting duplicates', () => {
+    const { exec, handle } = makeHandle((sql) => {
+      if (sql.includes("type='index'")) return []
+      if (sql.includes('SELECT COUNT(*) FROM _profile_merge_map_v205')) {
+        return [[3]]
+      }
+      return []
+    })
+
+    v2_0_5_migration.up(handle)
+
+    const sql = exec.mock.calls.map(([statement]) => statement).join('\n')
+    expect(sql).toContain('UPDATE posts SET author_profile_id')
+    expect(sql).toContain('UPDATE post_mentions SET profile_id')
+    expect(sql).toContain('UPDATE notifications SET actor_profile_id')
+    expect(sql).toContain('UPDATE local_accounts SET profile_id')
+    expect(sql).toContain('UPDATE profiles SET moved_to_profile_id')
+    expect(sql).toContain('DELETE FROM profiles')
+  })
+
+  it.each([
+    {
+      duplicateCount: 2,
+      expected: false,
+      indexRows: [['CREATE UNIQUE INDEX idx ON profiles(username, server_id)']],
+      name: 'duplicates remain',
+    },
+    {
+      duplicateCount: 0,
+      expected: false,
+      indexRows: [],
+      name: 'index is missing',
+    },
+    {
+      duplicateCount: 0,
+      expected: false,
+      indexRows: [['CREATE INDEX idx ON profiles(username, server_id)']],
+      name: 'index is not unique',
+    },
+    {
+      duplicateCount: 0,
+      expected: true,
+      indexRows: [['CREATE UNIQUE INDEX idx ON profiles(username, server_id)']],
+      name: 'data and index are valid',
+    },
+  ])(
+    'returns $expected when $name',
+    ({ duplicateCount, expected, indexRows }) => {
+      const { handle } = makeHandle((sql) => {
+        if (sql.includes('HAVING COUNT(*) > 1')) return [[duplicateCount]]
+        if (sql.includes("type='index'")) return indexRows
+        return []
+      })
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      expect(v2_0_5_migration.validate(handle)).toBe(expected)
+    },
+  )
+})

--- a/src/util/db/sqlite/__tests__/notificationStore-actions.test.ts
+++ b/src/util/db/sqlite/__tests__/notificationStore-actions.test.ts
@@ -1,0 +1,277 @@
+import type { Entity } from 'megalodon'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { getSqliteDb } = vi.hoisted(() => ({
+  getSqliteDb: vi.fn(),
+}))
+
+vi.mock('util/db/sqlite/connection', () => ({
+  getSqliteDb,
+}))
+
+import {
+  addNotification,
+  bulkAddNotifications,
+  getNotifications,
+  rowToStoredNotification,
+  updateNotificationStatusAction,
+} from 'util/db/sqlite/notificationStore'
+
+function makeNotification(id: string): Entity.Notification {
+  return {
+    account: {
+      acct: 'actor@example.com',
+      avatar: '',
+      avatar_static: '',
+      bot: false,
+      created_at: '',
+      display_name: 'Actor',
+      emojis: [],
+      fields: [],
+      followers_count: 0,
+      following_count: 0,
+      group: null,
+      header: '',
+      header_static: '',
+      id: 'actor',
+      limited: null,
+      locked: false,
+      moved: null,
+      noindex: null,
+      note: '',
+      statuses_count: 0,
+      suspended: null,
+      url: 'https://example.com/@actor',
+      username: 'actor',
+    },
+    created_at: '2024-01-01T00:00:00.000Z',
+    id,
+    type: 'follow',
+  }
+}
+
+function makeRow(id = 1): (string | number | null)[] {
+  const row = new Array<string | number | null>(42).fill(null)
+  row[0] = id
+  row[1] = 'https://example.com'
+  row[2] = 1_700_000_000_000
+  row[3] = 'follow'
+  row[4] = `notification-${id}`
+  row[6] = 'actor@example.com'
+  row[7] = 'actor'
+  return row
+}
+
+describe('notification store commands', () => {
+  const sendCommand = vi.fn()
+
+  beforeEach(() => {
+    getSqliteDb.mockReset()
+    sendCommand.mockReset()
+    getSqliteDb.mockResolvedValue({ sendCommand })
+  })
+
+  it('serializes a notification when adding it', async () => {
+    const notification = makeNotification('notification-1')
+
+    await addNotification(notification, 'https://example.com')
+
+    expect(sendCommand).toHaveBeenCalledWith({
+      backendUrl: 'https://example.com',
+      notificationJson: JSON.stringify(notification),
+      type: 'addNotification',
+    })
+  })
+
+  it('does not initialize SQLite for an empty bulk add', async () => {
+    await bulkAddNotifications([], 'https://example.com')
+
+    expect(getSqliteDb).not.toHaveBeenCalled()
+  })
+
+  it('serializes every notification in a bulk add', async () => {
+    const notifications = [
+      makeNotification('notification-1'),
+      makeNotification('notification-2'),
+    ]
+
+    await bulkAddNotifications(notifications, 'https://example.com')
+
+    expect(sendCommand).toHaveBeenCalledWith({
+      backendUrl: 'https://example.com',
+      notificationsJson: notifications.map((item) => JSON.stringify(item)),
+      type: 'bulkAddNotifications',
+    })
+  })
+
+  it('delegates notification status action updates', async () => {
+    await updateNotificationStatusAction(
+      'https://example.com',
+      'status-1',
+      'bookmarked',
+      true,
+    )
+
+    expect(sendCommand).toHaveBeenCalledWith({
+      action: 'bookmarked',
+      backendUrl: 'https://example.com',
+      statusId: 'status-1',
+      type: 'updateNotificationStatusAction',
+      value: true,
+    })
+  })
+})
+
+describe('getNotifications', () => {
+  const execAsync = vi.fn()
+
+  beforeEach(() => {
+    getSqliteDb.mockReset()
+    execAsync.mockReset()
+    execAsync.mockResolvedValue([makeRow(1), makeRow(2)])
+    getSqliteDb.mockResolvedValue({ execAsync })
+  })
+
+  it('uses the maximum limit when filters are omitted', async () => {
+    const result = await getNotifications()
+
+    expect(result.map((item) => item.notification_id)).toEqual([1, 2])
+    expect(execAsync).toHaveBeenCalledWith(
+      expect.stringContaining('ORDER BY n.created_at_ms DESC'),
+      {
+        bind: [2_147_483_647],
+        kind: 'timeline',
+        returnValue: 'resultRows',
+      },
+    )
+    const sql = execAsync.mock.calls[0][0] as string
+    expect(sql).not.toContain('WHERE la.backend_url IN')
+    expect(sql).not.toContain('n.local_account_id = ?')
+  })
+
+  it('binds backend URLs before the requested limit', async () => {
+    await getNotifications(['https://one.example', 'https://two.example'], 25)
+
+    expect(execAsync).toHaveBeenCalledWith(
+      expect.stringContaining('WHERE la.backend_url IN (?,?)'),
+      {
+        bind: ['https://one.example', 'https://two.example', 25],
+        kind: 'timeline',
+        returnValue: 'resultRows',
+      },
+    )
+  })
+
+  it('uses WHERE for a local account filter without backend URLs', async () => {
+    await getNotifications(undefined, 10, 42)
+
+    const sql = execAsync.mock.calls[0][0] as string
+    expect(sql).toContain('WHERE n.local_account_id = ?')
+    expect(execAsync.mock.calls[0][1].bind).toEqual([42, 10])
+  })
+
+  it('combines backend and local account filters with AND', async () => {
+    await getNotifications(['https://example.com'], 10, 42)
+
+    const sql = execAsync.mock.calls[0][0] as string
+    expect(sql).toContain('WHERE la.backend_url IN (?)')
+    expect(sql).toContain('AND n.local_account_id = ?')
+    expect(execAsync.mock.calls[0][1].bind).toEqual([
+      'https://example.com',
+      42,
+      10,
+    ])
+  })
+})
+
+describe('rowToStoredNotification edge cases', () => {
+  it('falls back to the database id when no local notification id exists', () => {
+    const row = makeRow(7)
+    row[4] = null
+
+    expect(rowToStoredNotification(row).id).toBe('7')
+  })
+
+  it('maps emojis, media, mentions, poll options, and reactions', () => {
+    const row = makeRow()
+    row[11] = 1
+    row[12] = 1
+    row[14] = 99
+    row[19] = 1_700_000_000_000
+    row[20] = 1
+    row[21] = null
+    row[31] = JSON.stringify([
+      null,
+      {
+        shortcode: 'wave',
+        static_url: null,
+        url: 'https://example.com/wave.png',
+        visible_in_picker: 1,
+      },
+    ])
+    row[32] = '[]'
+    row[33] = JSON.stringify({
+      expires_at: null,
+      id: 12,
+      multiple: 1,
+      options: JSON.stringify([{ title: 'A', votes_count: null }]),
+      votes_count: 3,
+    })
+    row[34] = JSON.stringify([
+      {
+        shortcode: 'actor',
+        static_url: 'https://example.com/actor-static.png',
+        url: 'https://example.com/actor.png',
+        visible_in_picker: 0,
+      },
+    ])
+    row[35] = '{invalid'
+    row[36] = JSON.stringify([null, { id: 'media-1', type: 'image' }])
+    row[37] = JSON.stringify([null, { acct: 'alice@example.net' }])
+    row[38] = 1
+    row[39] = '{invalid'
+    row[40] = 'wave'
+    row[41] = 'https://example.com/wave.png'
+
+    const result = rowToStoredNotification(row)
+
+    expect(result.account.locked).toBe(true)
+    expect(result.account.bot).toBe(true)
+    expect(result.account.emojis[0]).toEqual({
+      shortcode: 'actor',
+      static_url: 'https://example.com/actor-static.png',
+      url: 'https://example.com/actor.png',
+      visible_in_picker: false,
+    })
+    expect(result.status?.visibility).toBe('public')
+    expect(result.status?.sensitive).toBe(true)
+    expect(result.status?.emojis[0].static_url).toBe(
+      'https://example.com/wave.png',
+    )
+    expect(result.status?.emoji_reactions).toEqual([])
+    expect(result.status?.media_attachments).toEqual([
+      { id: 'media-1', type: 'image' },
+    ])
+    expect(result.status?.mentions).toEqual([
+      {
+        acct: 'alice@example.net',
+        id: '',
+        url: '',
+        username: 'alice',
+      },
+    ])
+    expect(result.status?.poll).toMatchObject({
+      id: '12',
+      multiple: true,
+      options: [{ title: 'A', votes_count: null }],
+      voted: true,
+      votes_count: 3,
+    })
+    expect(result.status?.poll).not.toHaveProperty('own_votes')
+    expect(result.reaction).toMatchObject({
+      name: 'wave',
+      static_url: 'https://example.com/wave.png',
+      url: 'https://example.com/wave.png',
+    })
+  })
+})

--- a/src/util/db/sqlite/__tests__/queries-statusBatch-execution.test.ts
+++ b/src/util/db/sqlite/__tests__/queries-statusBatch-execution.test.ts
@@ -1,0 +1,166 @@
+import {
+  buildBatchMapsFromResults,
+  executeBatchQueries,
+  replacePlaceholders,
+  type SqliteHandle,
+} from 'util/db/sqlite/queries/statusBatch'
+import { describe, expect, it, vi } from 'vitest'
+
+function createHandle(execAsync: ReturnType<typeof vi.fn>): SqliteHandle {
+  return { execAsync } as unknown as SqliteHandle
+}
+
+describe('replacePlaceholders', () => {
+  it('投稿数と同数のプレースホルダに置換する', () => {
+    expect(replacePlaceholders('WHERE id IN (__PH__)', 3)).toBe(
+      'WHERE id IN (?,?,?)',
+    )
+  })
+
+  it('空入力用には空のプレースホルダ列を生成する', () => {
+    expect(replacePlaceholders('WHERE id IN (__PH__)', 0)).toBe(
+      'WHERE id IN ()',
+    )
+  })
+})
+
+describe('buildBatchMapsFromResults', () => {
+  it('各バッチ結果を post_id キーの Map に変換する', () => {
+    const maps = buildBatchMapsFromResults({
+      belongingTags: [[5, '["testing"]']],
+      customEmojis: [[6, '[{"shortcode":"party"}]']],
+      interactions: [[1, '{"is_favourited":1}']],
+      media: [[2, '[{"id":"media-1"}]']],
+      mentions: [[3, '[{"acct":"alice@example.com"}]']],
+      polls: [[8, '{"id":"poll-1"}']],
+      profileEmojis: [[7, '[{"shortcode":"wave"}]']],
+      timelineTypes: [[4, '["home","local"]']],
+    })
+
+    expect(maps.interactionsMap).toEqual(new Map([[1, '{"is_favourited":1}']]))
+    expect(maps.mediaMap).toEqual(new Map([[2, '[{"id":"media-1"}]']]))
+    expect(maps.mentionsMap).toEqual(
+      new Map([[3, '[{"acct":"alice@example.com"}]']]),
+    )
+    expect(maps.timelineTypesMap).toEqual(new Map([[4, '["home","local"]']]))
+    expect(maps.belongingTagsMap).toEqual(new Map([[5, '["testing"]']]))
+    expect(maps.customEmojisMap).toEqual(
+      new Map([[6, '[{"shortcode":"party"}]']]),
+    )
+    expect(maps.profileEmojisMap).toEqual(
+      new Map([[7, '[{"shortcode":"wave"}]']]),
+    )
+    expect(maps.pollsMap).toEqual(new Map([[8, '{"id":"poll-1"}']]))
+    expect(maps.emojiReactionsMap).toEqual(new Map())
+  })
+
+  it('同じ post_id が複数回現れた場合は最後の値を採用する', () => {
+    const maps = buildBatchMapsFromResults({
+      belongingTags: [],
+      customEmojis: [],
+      interactions: [
+        [1, 'old'],
+        [1, 'new'],
+      ],
+      media: [],
+      mentions: [],
+      polls: [],
+      profileEmojis: [],
+      timelineTypes: [],
+    })
+
+    expect(maps.interactionsMap).toEqual(new Map([[1, 'new']]))
+  })
+})
+
+describe('executeBatchQueries', () => {
+  it('post_id が空なら DB に問い合わせず空の Map 群を返す', async () => {
+    const execAsync = vi.fn()
+
+    const maps = await executeBatchQueries(createHandle(execAsync), [])
+
+    expect(execAsync).not.toHaveBeenCalled()
+    for (const map of Object.values(maps)) {
+      expect(map).toEqual(new Map())
+    }
+  })
+
+  it('8種類のバッチを実行し、bind と結果を正しく組み立てる', async () => {
+    const execAsync = vi
+      .fn()
+      .mockResolvedValueOnce([[1, 'interaction']])
+      .mockResolvedValueOnce([[2, 'media']])
+      .mockResolvedValueOnce([[3, 'mention']])
+      .mockResolvedValueOnce([[4, 'timeline']])
+      .mockResolvedValueOnce([[5, 'tag']])
+      .mockResolvedValueOnce([[6, 'emoji']])
+      .mockResolvedValueOnce([[7, 'profile-emoji']])
+      .mockResolvedValueOnce([[8, 'poll']])
+    const handle = createHandle(execAsync)
+
+    const maps = await executeBatchQueries(handle, [10, 20], {
+      interactionsSql:
+        'SELECT post_id, value FROM custom_interactions WHERE post_id IN (__PH__)',
+      localAccountId: 99,
+    })
+
+    expect(execAsync).toHaveBeenCalledTimes(8)
+    expect(execAsync.mock.calls[0]).toEqual([
+      'SELECT post_id, value FROM custom_interactions WHERE post_id IN (?,?)',
+      {
+        bind: [10, 20],
+        kind: 'timeline',
+        returnValue: 'resultRows',
+      },
+    ])
+    for (const call of execAsync.mock.calls.slice(1, 7)) {
+      expect(call[0]).toContain('IN (?,?)')
+      expect(call[1]).toEqual({
+        bind: [10, 20],
+        kind: 'timeline',
+        returnValue: 'resultRows',
+      })
+      expect(call[1]).not.toHaveProperty('sessionTag')
+    }
+    expect(execAsync.mock.calls[7][1]).toEqual({
+      bind: [99, 10, 20],
+      kind: 'timeline',
+      returnValue: 'resultRows',
+    })
+    expect(maps).toEqual({
+      belongingTagsMap: new Map([[5, 'tag']]),
+      customEmojisMap: new Map([[6, 'emoji']]),
+      emojiReactionsMap: new Map(),
+      interactionsMap: new Map([[1, 'interaction']]),
+      mediaMap: new Map([[2, 'media']]),
+      mentionsMap: new Map([[3, 'mention']]),
+      pollsMap: new Map([[8, 'poll']]),
+      profileEmojisMap: new Map([[7, 'profile-emoji']]),
+      timelineTypesMap: new Map([[4, 'timeline']]),
+    })
+  })
+
+  it('localAccountId 未指定時は poll の先頭 bind に null を渡す', async () => {
+    const execAsync = vi.fn().mockResolvedValue([])
+
+    await executeBatchQueries(createHandle(execAsync), [42])
+
+    expect(execAsync).toHaveBeenCalledTimes(8)
+    expect(execAsync.mock.calls[7][1]).toMatchObject({
+      bind: [null, 42],
+    })
+  })
+
+  it('いずれかのバッチクエリが失敗した場合はエラーを呼び出し元へ返す', async () => {
+    const execAsync = vi
+      .fn()
+      .mockResolvedValueOnce([])
+      .mockRejectedValueOnce(new Error('media query failed'))
+      .mockResolvedValue([])
+
+    await expect(
+      executeBatchQueries(createHandle(execAsync), [1]),
+    ).rejects.toThrow('media query failed')
+    expect(execAsync).toHaveBeenCalledTimes(8)
+  })
+})

--- a/src/util/db/sqlite/__tests__/queries-statusCustomSanitize.test.ts
+++ b/src/util/db/sqlite/__tests__/queries-statusCustomSanitize.test.ts
@@ -1,0 +1,76 @@
+import { sanitizeWhereClause } from 'util/db/sqlite/queries/statusCustomQuery'
+import { describe, expect, it } from 'vitest'
+
+describe('sanitizeWhereClause', () => {
+  it('前後空白、セミコロン、大小文字を問わない LIMIT/OFFSET を除去する', () => {
+    const sanitized = sanitizeWhereClause(
+      "  p.language = 'ja'; limit 20 OfFsEt 5;  ",
+    )
+
+    expect(sanitized).toBe("p.language = 'ja'")
+    expect(sanitized).not.toContain(';')
+  })
+
+  it('複数の LIMIT/OFFSET をすべて除去する', () => {
+    const sanitized = sanitizeWhereClause(
+      'p.is_reblog = 0 LIMIT 10 OFFSET 1 LIMIT 20 OFFSET 2',
+    )
+
+    expect(sanitized).not.toMatch(/\b(?:LIMIT|OFFSET)\b/i)
+    expect(sanitized.trim()).toBe('p.is_reblog = 0')
+  })
+
+  it('空文字列とセミコロンだけの入力を空文字列にする', () => {
+    expect(sanitizeWhereClause('')).toBe('')
+    expect(sanitizeWhereClause(' ;;; ')).toBe('')
+  })
+
+  it.each([
+    'DROP',
+    'DELETE',
+    'INSERT',
+    'UPDATE',
+    'ALTER',
+    'CREATE',
+    'ATTACH',
+    'DETACH',
+    'PRAGMA',
+    'VACUUM',
+    'REINDEX',
+  ])('%s を独立した SQL キーワードとして拒否する', (keyword) => {
+    expect(() =>
+      sanitizeWhereClause(`p.id = 1 OR ${keyword.toLowerCase()} TABLE posts`),
+    ).toThrow(
+      'Custom query contains forbidden SQL statements. Only SELECT-compatible WHERE clauses are allowed.',
+    )
+  })
+
+  it('禁止語を一部に含む通常の識別子は拒否しない', () => {
+    const input =
+      'p.updated_at IS NULL AND p.created_by IS NOT NULL AND p.delete_flag = 0 AND p.pragma_mode = 1'
+
+    expect(sanitizeWhereClause(input)).toBe(input)
+  })
+
+  it.each(["p.language = 'ja' -- bypass", 'p.language = "ja" /* bypass */'])(
+    'SQL コメントを拒否する: %s',
+    (input) => {
+      expect(() => sanitizeWhereClause(input)).toThrow(
+        'Custom query contains SQL comments (-- or /* */). Comments are not allowed.',
+      )
+    },
+  )
+
+  it('LIMIT/OFFSET を一部に含む識別子は変更しない', () => {
+    const input = 'p.limitless = 1 AND p.offset_value = 2'
+
+    expect(sanitizeWhereClause(input)).toBe(input)
+  })
+
+  it('SELECT 互換の複雑な WHERE 句は内容を維持する', () => {
+    const input =
+      "EXISTS (SELECT 1 FROM post_media pm WHERE pm.post_id = p.id) AND vt.name IN ('public', 'unlisted')"
+
+    expect(sanitizeWhereClause(input)).toBe(input)
+  })
+})

--- a/src/util/db/sqlite/__tests__/queries-statusFetchBehavior.test.ts
+++ b/src/util/db/sqlite/__tests__/queries-statusFetchBehavior.test.ts
@@ -1,0 +1,141 @@
+import type { SqliteHandle } from 'util/db/sqlite/queries/statusBatch'
+import { fetchStatusesByIds } from 'util/db/sqlite/queries/statusFetch'
+import { describe, expect, it, vi } from 'vitest'
+
+type SqlValue = string | number | null
+
+function makeBaseRow(postId: number, localId: string): SqlValue[] {
+  const row: SqlValue[] = new Array(52).fill(null)
+  Object.assign(row, {
+    0: postId,
+    1: 'https://example.com',
+    2: localId,
+    3: 1_700_000_000_000 + postId,
+    4: `https://example.com/objects/${postId}`,
+    5: `<p>Status ${postId}</p>`,
+    6: '',
+    7: `https://example.com/@alice/${postId}`,
+    8: 'ja',
+    9: 'public',
+    10: 0,
+    11: 0,
+    14: 'alice@example.com',
+    15: 'alice',
+    16: 'Alice',
+    17: 'https://example.com/avatar.png',
+    18: 'https://example.com/header.png',
+    19: 0,
+    20: 0,
+    21: 'https://example.com/@alice',
+    22: 0,
+    23: 0,
+    24: 0,
+  })
+  return row
+}
+
+describe('fetchStatusesByIds behavior', () => {
+  it('本体行が空なら子テーブルクエリを実行せず空配列を返す', async () => {
+    const execAsync = vi.fn(async () => [])
+    const handle = { execAsync } as unknown as SqliteHandle
+
+    await expect(fetchStatusesByIds(handle, [42])).resolves.toEqual([])
+    expect(execAsync).toHaveBeenCalledOnce()
+  })
+
+  it('リブログと timeline 上書きがない通常投稿も取得する', async () => {
+    const row = makeBaseRow(42, 'status-42')
+    let callIndex = 0
+    const execAsync = vi.fn(
+      async (_sql: string, _options?: Record<string, unknown>) => {
+        callIndex += 1
+        return callIndex === 1 ? [row] : []
+      },
+    )
+    const handle = { execAsync } as unknown as SqliteHandle
+
+    const statuses = await fetchStatusesByIds(handle, [42])
+
+    expect(statuses).toHaveLength(1)
+    expect(statuses[0]).toMatchObject({
+      id: 'status-42',
+      reblog: null,
+      timelineTypes: [],
+    })
+    const interactionsCall = execAsync.mock.calls
+      .slice(1)
+      .find(([sql]) => sql.includes('FROM post_interactions'))
+    expect(interactionsCall?.[1]).toMatchObject({ bind: [42] })
+  })
+
+  it('通常行を組み立て、リブログ ID を重複なくバッチ取得し、timeline map を上書きする', async () => {
+    const first = makeBaseRow(42, 'status-42')
+    first[11] = 1
+    first[25] = 77
+    first[26] = '<p>Reblogged status</p>'
+    // [27] は rb_spoiler_text。リブログ ID と取り違えないことも検証する。
+    first[27] = 'reblog spoiler'
+    first[34] = 1_699_999_000_000
+    first[35] = 'https://remote.example/objects/77'
+    first[36] = 'bob@remote.example'
+    first[37] = 'bob'
+    first[38] = 'Bob'
+    first[47] = 'remote-77'
+
+    const second = makeBaseRow(100, 'status-100')
+    second[11] = 1
+    second[25] = 77
+    second[26] = '<p>Same reblogged status</p>'
+    second[27] = ''
+    second[34] = 1_699_999_000_000
+    second[35] = 'https://remote.example/objects/77'
+    second[36] = 'bob@remote.example'
+    second[37] = 'bob'
+    second[38] = 'Bob'
+    second[47] = 'remote-77'
+
+    let callIndex = 0
+    const execAsync = vi.fn(
+      async (sql: string, _options?: Record<string, unknown>) => {
+        callIndex += 1
+        if (callIndex === 1) return [first, second]
+        if (sql.includes('FROM timeline_entries')) {
+          return [
+            [42, '["public"]'],
+            [100, '["local"]'],
+          ]
+        }
+        return []
+      },
+    )
+    const handle = { execAsync } as unknown as SqliteHandle
+    const timelineTypes = new Map([
+      [42, '["home","tag"]'],
+      [100, '["home"]'],
+    ])
+
+    const statuses = await fetchStatusesByIds(handle, [42, 100], timelineTypes)
+
+    expect(statuses.map((status) => status.id)).toEqual([
+      'status-42',
+      'status-100',
+    ])
+    expect(statuses.map((status) => status.timelineTypes)).toEqual([
+      ['home', 'tag'],
+      ['home'],
+    ])
+    expect(statuses.map((status) => status.reblog?.id)).toEqual([
+      'remote-77',
+      'remote-77',
+    ])
+
+    expect(execAsync).toHaveBeenCalledTimes(9)
+    const calls = execAsync.mock.calls.slice(1)
+    const interactionsCall = calls.find(([sql]) =>
+      sql.includes('FROM post_interactions'),
+    )
+    const pollsCall = calls.find(([sql]) => sql.includes('FROM polls p'))
+    expect(interactionsCall?.[1]).toMatchObject({ bind: [42, 100, 77] })
+    expect(pollsCall?.[1]).toMatchObject({ bind: [null, 42, 100, 77] })
+  })
+})

--- a/src/util/db/sqlite/__tests__/queries-statusFilterBranches.test.ts
+++ b/src/util/db/sqlite/__tests__/queries-statusFilterBranches.test.ts
@@ -1,0 +1,188 @@
+import type { TimelineConfigV2 } from 'types/types'
+import { buildFilterConditions } from 'util/db/sqlite/queries/statusFilter'
+import { describe, expect, it } from 'vitest'
+
+function makeConfig(
+  overrides: Partial<TimelineConfigV2> = {},
+): TimelineConfigV2 {
+  return {
+    applyInstanceBlock: false,
+    applyMuteFilter: false,
+    id: 'branch-test',
+    order: 0,
+    type: 'home',
+    visible: true,
+    ...overrides,
+  }
+}
+
+describe('buildFilterConditions boundaries', () => {
+  it('フィルターが無効なら条件も bind も追加しない', () => {
+    expect(buildFilterConditions(makeConfig(), [])).toEqual({
+      binds: [],
+      conditions: [],
+    })
+  })
+
+  it('minMediaCount=0 は最小枚数条件にせず onlyMedia を適用する', () => {
+    const result = buildFilterConditions(
+      makeConfig({ minMediaCount: 0, onlyMedia: true }),
+      [],
+    )
+
+    expect(result.conditions).toEqual([
+      'EXISTS(SELECT 1 FROM post_media WHERE post_id = p.id)',
+    ])
+    expect(result.binds).toEqual([])
+  })
+
+  it('visibilityFilter は 1〜3 件だけ適用し、4 件なら絞り込まない', () => {
+    const three = buildFilterConditions(
+      makeConfig({
+        visibilityFilter: ['public', 'unlisted', 'private'],
+      }),
+      [],
+    )
+    const four = buildFilterConditions(
+      makeConfig({
+        visibilityFilter: ['public', 'unlisted', 'private', 'direct'],
+      }),
+      [],
+    )
+
+    expect(three.conditions).toEqual([
+      '(SELECT name FROM visibility_types WHERE id = p.visibility_id) IN (?,?,?)',
+    ])
+    expect(three.binds).toEqual(['public', 'unlisted', 'private'])
+    expect(four).toEqual({ binds: [], conditions: [] })
+  })
+
+  it('visibilityFilter と languageFilter の空配列は条件を追加しない', () => {
+    expect(
+      buildFilterConditions(
+        makeConfig({ languageFilter: [], visibilityFilter: [] }),
+        [],
+      ),
+    ).toEqual({ binds: [], conditions: [] })
+  })
+
+  it('languageFilter は NULL 言語を残し、指定順に bind する', () => {
+    const result = buildFilterConditions(
+      makeConfig({ languageFilter: ['ja', 'en'] }),
+      [],
+      'post',
+    )
+
+    expect(result.conditions).toEqual([
+      '(post.language IN (?,?) OR post.language IS NULL)',
+    ])
+    expect(result.binds).toEqual(['ja', 'en'])
+  })
+
+  it('投稿除外オプションをすべて独立した条件にする', () => {
+    const result = buildFilterConditions(
+      makeConfig({
+        excludeReblogs: true,
+        excludeReplies: true,
+        excludeSensitive: true,
+        excludeSpoiler: true,
+      }),
+      [],
+      'x',
+    )
+
+    expect(result.conditions).toEqual([
+      'x.is_reblog = 0',
+      'x.in_reply_to_uri IS NULL',
+      "x.spoiler_text = ''",
+      'x.is_sensitive = 0',
+    ])
+  })
+
+  it('空のアカウント一覧は include/exclude 条件を追加しない', () => {
+    const result = buildFilterConditions(
+      makeConfig({
+        accountFilter: { accts: [], mode: 'include' },
+        applyMuteFilter: true,
+      }),
+      [],
+    )
+
+    // include モードではアカウント一覧が空でも mute 条件を意図的に抑止する。
+    expect(result).toEqual({ binds: [], conditions: [] })
+  })
+
+  it('未指定の mute/block 設定は有効として扱う', () => {
+    const config = makeConfig()
+    config.applyMuteFilter = undefined
+    config.applyInstanceBlock = undefined
+
+    const result = buildFilterConditions(config, [])
+
+    expect(result.conditions[0]).toBe('1=1')
+    expect(result.conditions[1]).toContain('blocked_instances')
+    expect(result.conditions[1]).toContain('p.author_profile_id')
+    expect(result.binds).toEqual([])
+  })
+
+  it('JOIN 済み profile を使う mute/block 条件とホスト bind を生成する', () => {
+    const result = buildFilterConditions(
+      makeConfig({
+        applyInstanceBlock: true,
+        applyMuteFilter: true,
+      }),
+      ['https://social.example/path', 'https://remote.example'],
+      'post',
+      { profileJoined: true },
+    )
+
+    expect(result.conditions).toHaveLength(2)
+    expect(result.conditions[0]).toContain('pr.acct')
+    expect(result.conditions[0]).toContain('muted_accounts')
+    expect(result.conditions[1]).toContain(
+      "substr(pr.acct, instr(pr.acct, '@') + 1)",
+    )
+    expect(result.binds).toEqual(['social.example', 'remote.example'])
+  })
+
+  it('include アカウント指定時は mute だけを抑止する', () => {
+    const result = buildFilterConditions(
+      makeConfig({
+        accountFilter: {
+          accts: ['alice@example.com'],
+          mode: 'include',
+        },
+        applyInstanceBlock: true,
+        applyMuteFilter: true,
+      }),
+      ['https://example.com'],
+    )
+
+    expect(result.conditions).toHaveLength(2)
+    expect(result.conditions[0]).toContain(' IN (?)')
+    expect(result.conditions[1]).toContain('blocked_instances')
+    expect(result.conditions.join(' ')).not.toContain('muted_accounts')
+    expect(result.binds).toEqual(['alice@example.com'])
+  })
+
+  it('空 tableAlias ではカラムにドット接頭辞を付けない', () => {
+    const result = buildFilterConditions(
+      makeConfig({
+        accountFilter: { accts: ['alice@example.com'], mode: 'exclude' },
+        excludeReblogs: true,
+        languageFilter: ['ja'],
+        onlyMedia: true,
+      }),
+      [],
+      '',
+    )
+
+    expect(result.conditions).toEqual([
+      'EXISTS(SELECT 1 FROM post_media WHERE post_id = id)',
+      '(language IN (?) OR language IS NULL)',
+      'is_reblog = 0',
+      '(SELECT acct FROM profiles WHERE id = author_profile_id) NOT IN (?)',
+    ])
+    expect(result.binds).toEqual(['ja', 'alice@example.com'])
+  })
+})

--- a/src/util/db/sqlite/__tests__/queries-statusMapperBranches.test.ts
+++ b/src/util/db/sqlite/__tests__/queries-statusMapperBranches.test.ts
@@ -1,0 +1,625 @@
+import type { Entity } from 'megalodon'
+import type { BatchMaps } from 'util/db/sqlite/queries/statusBatch'
+import {
+  assembleStatusFromBatch,
+  rowToStoredStatus,
+  toStoredStatus,
+} from 'util/db/sqlite/queries/statusMapper'
+import type { InteractionsJson } from 'util/db/sqlite/queries/statusMapperTypes'
+import { describe, expect, it } from 'vitest'
+
+type SqlValue = string | number | null
+
+function makeInteractions(
+  overrides: Partial<InteractionsJson> = {},
+): InteractionsJson {
+  return {
+    is_bookmarked: 0,
+    is_favourited: 0,
+    is_muted: 0,
+    is_pinned: 0,
+    is_reblogged: 0,
+    my_reaction_name: null,
+    my_reaction_url: null,
+    ...overrides,
+  }
+}
+
+function makeInlineRow(): SqlValue[] {
+  const row: SqlValue[] = new Array(66).fill(null)
+  Object.assign(row, {
+    0: 42,
+    1: 'https://example.com',
+    2: 'status-42',
+    3: 1_700_000_000_000,
+    4: 'https://example.com/objects/42',
+    5: '<p>Hello</p>',
+    6: '',
+    7: 'https://example.com/@alice/42',
+    8: 'ja',
+    9: 'public',
+    10: 0,
+    11: 0,
+    14: 'alice@example.com',
+    15: 'alice',
+    16: 'Alice',
+    17: 'https://example.com/alice-avatar.png',
+    18: 'https://example.com/alice-header.png',
+    19: 0,
+    20: 0,
+    21: 'https://example.com/@alice',
+    22: 1,
+    23: 2,
+    24: 3,
+  })
+  return row
+}
+
+function makeBatchRow(): SqlValue[] {
+  const row: SqlValue[] = new Array(52).fill(null)
+  Object.assign(row, {
+    0: 42,
+    1: 'https://example.com',
+    2: 'status-42',
+    3: 1_700_000_000_000,
+    4: 'https://example.com/objects/42',
+    5: '<p>Hello</p>',
+    6: '',
+    7: 'https://example.com/@alice/42',
+    8: 'ja',
+    9: 'public',
+    10: 0,
+    11: 0,
+    14: 'alice@example.com',
+    15: 'alice',
+    16: 'Alice',
+    17: 'https://example.com/alice-avatar.png',
+    18: 'https://example.com/alice-header.png',
+    19: 0,
+    20: 0,
+    21: 'https://example.com/@alice',
+    22: 1,
+    23: 2,
+    24: 3,
+  })
+  return row
+}
+
+function makeMaps(overrides: Partial<BatchMaps> = {}): BatchMaps {
+  return {
+    belongingTagsMap: new Map(),
+    customEmojisMap: new Map(),
+    emojiReactionsMap: new Map(),
+    interactionsMap: new Map(),
+    mediaMap: new Map(),
+    mentionsMap: new Map(),
+    pollsMap: new Map(),
+    profileEmojisMap: new Map(),
+    timelineTypesMap: new Map(),
+    ...overrides,
+  }
+}
+
+const mediaJson = JSON.stringify([
+  null,
+  {
+    id: 'media-1',
+    preview_url: 'https://example.com/preview.png',
+    type: 'image',
+    url: 'https://example.com/image.png',
+  },
+])
+const mentionsJson = JSON.stringify([
+  {
+    acct: 'bob@remote.example',
+    url: 'https://remote.example/@bob',
+    username: 'bob',
+  },
+])
+const customEmojisJson = JSON.stringify([
+  {
+    shortcode: 'wave',
+    static_url: null,
+    url: 'https://example.com/wave.gif',
+    visible_in_picker: 1,
+  },
+])
+const profileEmojisJson = JSON.stringify([
+  {
+    shortcode: 'verified',
+    static_url: 'https://example.com/verified.png',
+    url: 'https://example.com/verified.gif',
+    visible_in_picker: 0,
+  },
+])
+const inlinePollJson = JSON.stringify({
+  expires_at: null,
+  id: 5,
+  multiple: 0,
+  options: [{ title: 'yes', votes_count: 2 }],
+  votes_count: 2,
+})
+const batchPollJson = JSON.stringify({
+  expired: 0,
+  expires_at: null,
+  id: 5,
+  multiple: 0,
+  options: [{ title: 'yes', votes_count: 2 }],
+  own_votes: '[0]',
+  voted: 1,
+  votes_count: 2,
+})
+
+describe('rowToStoredStatus branch behavior', () => {
+  it('関連 JSON、タグ、poll、interaction と真偽値をまとめて復元する', () => {
+    const row = makeInlineRow()
+    row[10] = 1
+    row[19] = 1
+    row[20] = 1
+    row[25] = JSON.stringify(
+      makeInteractions({
+        is_bookmarked: 1,
+        is_favourited: 1,
+        is_reblogged: 1,
+      }),
+    )
+    row[26] = mediaJson
+    row[27] = mentionsJson
+    row[28] = JSON.stringify(['home', null, 'tag'])
+    row[29] = JSON.stringify(['cats', null, 'fediverse'])
+    row[30] = customEmojisJson
+    row[31] = profileEmojisJson
+    row[32] = inlinePollJson
+
+    const status = rowToStoredStatus(row)
+
+    expect(status).toMatchObject({
+      belongingTags: ['cats', 'fediverse'],
+      bookmarked: true,
+      favourited: true,
+      reblogged: true,
+      sensitive: true,
+      timelineTypes: ['home', 'tag'],
+    })
+    expect(status.tags).toEqual([
+      { name: 'cats', url: '' },
+      { name: 'fediverse', url: '' },
+    ])
+    expect(status.account).toMatchObject({
+      bot: true,
+      emojis: [
+        {
+          shortcode: 'verified',
+          static_url: 'https://example.com/verified.png',
+          url: 'https://example.com/verified.gif',
+          visible_in_picker: false,
+        },
+      ],
+      locked: true,
+    })
+    expect(status.emojis).toHaveLength(1)
+    expect(status.media_attachments).toHaveLength(1)
+    expect(status.mentions).toHaveLength(1)
+    expect(status.poll).toMatchObject({
+      id: '5',
+      options: [{ title: 'yes', votes_count: 2 }],
+      voted: false,
+    })
+  })
+
+  it('旧 CSV engagement を後方互換として解釈する', () => {
+    const row = makeInlineRow()
+    row[25] = 'favourite,reblog,bookmark'
+
+    const status = rowToStoredStatus(row)
+
+    expect(status.favourited).toBe(true)
+    expect(status.reblogged).toBe(true)
+    expect(status.bookmarked).toBe(true)
+  })
+
+  it('壊れた interactions は false へフォールバックする', () => {
+    const row = makeInlineRow()
+    row[25] = '{not-json'
+
+    const status = rowToStoredStatus(row)
+
+    expect(status.favourited).toBe(false)
+    expect(status.reblogged).toBe(false)
+    expect(status.bookmarked).toBe(false)
+  })
+
+  it('is_reblog が真でも元投稿 ID がなければ reblog を作らない', () => {
+    const row = makeInlineRow()
+    row[11] = 1
+    row[33] = null
+
+    expect(rowToStoredStatus(row).reblog).toBeNull()
+  })
+
+  it('リブログ元の全関連データと旧 CSV engagement を復元する', () => {
+    const row = makeInlineRow()
+    row[11] = 1
+    Object.assign(row, {
+      33: 77,
+      34: '<p>Boosted</p>',
+      35: 'CW',
+      36: 'https://remote.example/@bob/77',
+      37: 'en',
+      38: 'unlisted',
+      39: 1,
+      40: 'reply-1',
+      41: 1_700_000_100_000,
+      42: 1_699_999_900_000,
+      43: 'https://remote.example/objects/77',
+      44: 'bob@remote.example',
+      45: 'bob',
+      46: 'Bob',
+      47: 'https://remote.example/bob-avatar.png',
+      48: 'https://remote.example/bob-header.png',
+      49: 1,
+      50: 1,
+      51: 'https://remote.example/@bob',
+      52: 4,
+      53: 5,
+      54: 6,
+      55: 'favourite,reblog,bookmark',
+      56: mediaJson,
+      57: mentionsJson,
+      58: customEmojisJson,
+      59: profileEmojisJson,
+      60: inlinePollJson,
+      61: 'remote-77',
+      65: '{not-json',
+    })
+
+    const reblog = rowToStoredStatus(row).reblog
+
+    expect(reblog).toMatchObject({
+      bookmarked: true,
+      content: '<p>Boosted</p>',
+      created_at: new Date(1_699_999_900_000).toISOString(),
+      edited_at: new Date(1_700_000_100_000).toISOString(),
+      emoji_reactions: [],
+      favourited: true,
+      favourites_count: 6,
+      id: 'remote-77',
+      in_reply_to_id: 'reply-1',
+      language: 'en',
+      reblog: null,
+      reblogged: true,
+      reblogs_count: 5,
+      replies_count: 4,
+      sensitive: true,
+      spoiler_text: 'CW',
+      uri: 'https://remote.example/objects/77',
+      url: 'https://remote.example/@bob/77',
+      visibility: 'unlisted',
+    })
+    expect(reblog?.account).toMatchObject({
+      acct: 'bob@remote.example',
+      bot: true,
+      locked: true,
+      username: 'bob',
+    })
+    expect(reblog?.emojis).toHaveLength(1)
+    expect(reblog?.account.emojis).toHaveLength(1)
+    expect(reblog?.media_attachments).toHaveLength(1)
+    expect(reblog?.mentions).toHaveLength(1)
+    expect(reblog?.poll?.id).toBe('5')
+  })
+
+  it('リブログ元の nullable SQL カラムに API 互換の既定値を設定する', () => {
+    const row = makeInlineRow()
+    row[11] = 1
+    row[33] = 77
+
+    const reblog = rowToStoredStatus(row).reblog
+
+    expect(reblog).toMatchObject({
+      content: '',
+      created_at: '',
+      edited_at: null,
+      favourites_count: 0,
+      id: '',
+      poll: null,
+      reblogs_count: 0,
+      replies_count: 0,
+      spoiler_text: '',
+      uri: '',
+      visibility: 'public',
+    })
+    expect(reblog?.url).toBeUndefined()
+    expect(reblog?.account).toMatchObject({
+      acct: '',
+      avatar: '',
+      display_name: '',
+      header: '',
+      url: '',
+      username: '',
+    })
+  })
+
+  it('nullable SQL カラムに API 互換の既定値を設定する', () => {
+    const row = makeInlineRow()
+    for (const index of [
+      1, 2, 4, 5, 6, 7, 8, 9, 14, 15, 16, 17, 18, 21, 22, 23, 24,
+    ]) {
+      row[index] = null
+    }
+
+    const status = rowToStoredStatus(row)
+
+    expect(status).toMatchObject({
+      backendUrl: '',
+      content: '',
+      favourites_count: 0,
+      id: '',
+      language: null,
+      reblogs_count: 0,
+      replies_count: 0,
+      spoiler_text: '',
+      uri: '',
+      visibility: 'public',
+    })
+    expect(status.url).toBeUndefined()
+    expect(status.account).toMatchObject({
+      acct: '',
+      avatar: '',
+      display_name: '',
+      header: '',
+      url: '',
+      username: '',
+    })
+  })
+})
+
+describe('assembleStatusFromBatch branch behavior', () => {
+  it('全バッチ Map を使ってメイン投稿を構築する', () => {
+    const row = makeBatchRow()
+    row[10] = 1
+    row[13] = 1_700_000_100_000
+    row[19] = 1
+    row[20] = 1
+    row[50] = '{not-json'
+    const maps = makeMaps({
+      belongingTagsMap: new Map([
+        [42, JSON.stringify(['cats', null, 'fediverse'])],
+      ]),
+      customEmojisMap: new Map([[42, customEmojisJson]]),
+      interactionsMap: new Map([
+        [
+          42,
+          JSON.stringify(
+            makeInteractions({
+              is_bookmarked: 1,
+              is_favourited: 1,
+              is_reblogged: 1,
+            }),
+          ),
+        ],
+      ]),
+      mediaMap: new Map([[42, mediaJson]]),
+      mentionsMap: new Map([[42, mentionsJson]]),
+      pollsMap: new Map([[42, batchPollJson]]),
+      profileEmojisMap: new Map([[42, profileEmojisJson]]),
+      timelineTypesMap: new Map([
+        [42, JSON.stringify(['home', null, 'local'])],
+      ]),
+    })
+
+    const status = assembleStatusFromBatch(row, maps)
+
+    expect(status).toMatchObject({
+      belongingTags: ['cats', 'fediverse'],
+      bookmarked: true,
+      edited_at: new Date(1_700_000_100_000).toISOString(),
+      emoji_reactions: [],
+      favourited: true,
+      reblogged: true,
+      sensitive: true,
+      timelineTypes: ['home', 'local'],
+    })
+    expect(status.account).toMatchObject({ bot: true, locked: true })
+    expect(status.account.emojis).toHaveLength(1)
+    expect(status.emojis).toHaveLength(1)
+    expect(status.media_attachments).toHaveLength(1)
+    expect(status.mentions).toHaveLength(1)
+    expect(status.poll).toMatchObject({ own_votes: [0], voted: true })
+    expect(status.tags).toEqual([
+      { name: 'cats', url: '' },
+      { name: 'fediverse', url: '' },
+    ])
+  })
+
+  it('is_reblog が真でも元投稿 ID がなければ reblog を作らない', () => {
+    const row = makeBatchRow()
+    row[11] = 1
+    row[25] = null
+
+    expect(assembleStatusFromBatch(row, makeMaps()).reblog).toBeNull()
+  })
+
+  it('リブログ元のバッチ Map、poll、リアクションを復元する', () => {
+    const row = makeBatchRow()
+    row[11] = 1
+    Object.assign(row, {
+      25: 77,
+      26: '<p>Boosted</p>',
+      27: 'CW',
+      28: 'https://remote.example/@bob/77',
+      29: 'en',
+      30: 'private',
+      31: 1,
+      32: 'reply-1',
+      33: 1_700_000_100_000,
+      34: 1_699_999_900_000,
+      35: 'https://remote.example/objects/77',
+      36: 'bob@remote.example',
+      37: 'bob',
+      38: 'Bob',
+      39: 'https://remote.example/bob-avatar.png',
+      40: 'https://remote.example/bob-header.png',
+      41: 1,
+      42: 1,
+      43: 'https://remote.example/@bob',
+      44: 4,
+      45: 5,
+      46: 6,
+      47: 'remote-77',
+      51: JSON.stringify([{ count: 2, me: false, name: '🔥' }]),
+    })
+    const maps = makeMaps({
+      customEmojisMap: new Map([[77, customEmojisJson]]),
+      interactionsMap: new Map([
+        [
+          77,
+          JSON.stringify(
+            makeInteractions({
+              is_bookmarked: 1,
+              is_favourited: 1,
+              is_reblogged: 1,
+              my_reaction_name: '🔥',
+            }),
+          ),
+        ],
+      ]),
+      mediaMap: new Map([[77, mediaJson]]),
+      mentionsMap: new Map([[77, mentionsJson]]),
+      pollsMap: new Map([[77, batchPollJson]]),
+      profileEmojisMap: new Map([[77, profileEmojisJson]]),
+    })
+
+    const reblog = assembleStatusFromBatch(row, maps).reblog
+
+    expect(reblog).toMatchObject({
+      bookmarked: true,
+      content: '<p>Boosted</p>',
+      created_at: new Date(1_699_999_900_000).toISOString(),
+      edited_at: new Date(1_700_000_100_000).toISOString(),
+      emoji_reactions: [{ count: 2, me: true, name: '🔥' }],
+      favourited: true,
+      id: 'remote-77',
+      poll: { own_votes: [0], voted: true },
+      reblogged: true,
+      sensitive: true,
+      visibility: 'private',
+    })
+    expect(reblog?.account).toMatchObject({
+      acct: 'bob@remote.example',
+      bot: true,
+      locked: true,
+    })
+    expect(reblog?.account.emojis).toHaveLength(1)
+    expect(reblog?.emojis).toHaveLength(1)
+    expect(reblog?.media_attachments).toHaveLength(1)
+    expect(reblog?.mentions).toHaveLength(1)
+  })
+
+  it('リブログ元の nullable カラムに既定値を設定する', () => {
+    const row = makeBatchRow()
+    row[11] = 1
+    row[25] = 77
+
+    const reblog = assembleStatusFromBatch(row, makeMaps()).reblog
+
+    expect(reblog).toMatchObject({
+      bookmarked: false,
+      content: '',
+      created_at: '',
+      edited_at: null,
+      favourited: false,
+      favourites_count: 0,
+      id: '',
+      reblogged: false,
+      reblogs_count: 0,
+      replies_count: 0,
+      spoiler_text: '',
+      uri: '',
+      visibility: 'public',
+    })
+    expect(reblog?.url).toBeUndefined()
+    expect(reblog?.account).toMatchObject({
+      acct: '',
+      avatar: '',
+      display_name: '',
+      header: '',
+      url: '',
+      username: '',
+    })
+  })
+
+  it('メイン投稿の nullable カラムに API 互換の既定値を設定する', () => {
+    const row = makeBatchRow()
+    for (const index of [
+      1, 2, 4, 5, 6, 7, 8, 9, 14, 15, 16, 17, 18, 21, 22, 23, 24,
+    ]) {
+      row[index] = null
+    }
+
+    const status = assembleStatusFromBatch(row, makeMaps())
+
+    expect(status).toMatchObject({
+      backendUrl: '',
+      content: '',
+      favourites_count: 0,
+      id: '',
+      language: null,
+      reblogs_count: 0,
+      replies_count: 0,
+      spoiler_text: '',
+      uri: '',
+      visibility: 'public',
+    })
+    expect(status.url).toBeUndefined()
+    expect(status.account).toMatchObject({
+      acct: '',
+      avatar: '',
+      display_name: '',
+      header: '',
+      url: '',
+      username: '',
+    })
+  })
+})
+
+describe('toStoredStatus', () => {
+  it('Entity.Status に DB 用メタデータとタグ名・時刻を追加する', () => {
+    const status = {
+      created_at: '2023-11-14T22:13:20.000Z',
+      edited_at: '2023-11-14T22:15:00.000Z',
+      id: 'remote-id',
+      tags: [
+        { name: 'cats', url: 'https://example.com/tags/cats' },
+        { name: 'fediverse', url: 'https://example.com/tags/fediverse' },
+      ],
+    } as Entity.Status
+
+    const stored = toStoredStatus(status, 'https://example.com', [
+      'home',
+      'tag',
+    ])
+
+    expect(stored).toMatchObject({
+      backendUrl: 'https://example.com',
+      belongingTags: ['cats', 'fediverse'],
+      created_at_ms: 1_700_000_000_000,
+      edited_at_ms: 1_700_000_100_000,
+      id: 'remote-id',
+      post_id: 0,
+      timelineTypes: ['home', 'tag'],
+    })
+  })
+
+  it('編集日時がない status は edited_at_ms を null にする', () => {
+    const status = {
+      created_at: '2023-11-14T22:13:20.000Z',
+      edited_at: null,
+      tags: [],
+    } as unknown as Entity.Status
+
+    expect(toStoredStatus(status, 'https://example.com', []).edited_at_ms).toBe(
+      null,
+    )
+  })
+})

--- a/src/util/db/sqlite/__tests__/queries-statusMapperParsers.test.ts
+++ b/src/util/db/sqlite/__tests__/queries-statusMapperParsers.test.ts
@@ -1,0 +1,439 @@
+import type { Entity } from 'megalodon'
+import {
+  editedAtMsToIso,
+  mergeLocalReaction,
+  parseBatchPoll,
+  parseEmojiReactions,
+  parseEmojis,
+  parseInlinePoll,
+  parseInteractions,
+  parseMediaAttachments,
+  parseMentions,
+} from 'util/db/sqlite/queries/statusMapperParsers'
+import type { InteractionsJson } from 'util/db/sqlite/queries/statusMapperTypes'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+function makeInteractions(
+  overrides: Partial<InteractionsJson> = {},
+): InteractionsJson {
+  return {
+    is_bookmarked: 0,
+    is_favourited: 0,
+    is_muted: 0,
+    is_pinned: 0,
+    is_reblogged: 0,
+    my_reaction_name: null,
+    my_reaction_url: null,
+    ...overrides,
+  }
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('parseEmojiReactions / parseInteractions', () => {
+  it.each([null, ''])('空値 %s は空のリアクション配列にする', (json) => {
+    expect(parseEmojiReactions(json)).toEqual([])
+  })
+
+  it('有効なリアクション JSON はそのまま復元する', () => {
+    const reactions = [{ count: 2, me: false, name: 'blobcat' }]
+
+    expect(parseEmojiReactions(JSON.stringify(reactions))).toEqual(reactions)
+  })
+
+  it('壊れたリアクション JSON は空配列へフォールバックする', () => {
+    expect(parseEmojiReactions('{not-json')).toEqual([])
+  })
+
+  it.each([null, ''])(
+    '空値 %s は interactions がないものとして扱う',
+    (json) => {
+      expect(parseInteractions(json)).toBeNull()
+    },
+  )
+
+  it('有効な interactions JSON を復元する', () => {
+    const interactions = makeInteractions({
+      is_bookmarked: 1,
+      my_reaction_name: '👍',
+    })
+
+    expect(parseInteractions(JSON.stringify(interactions))).toEqual(
+      interactions,
+    )
+  })
+
+  it('壊れた interactions JSON は null へフォールバックする', () => {
+    expect(parseInteractions('not-json')).toBeNull()
+  })
+})
+
+describe('mergeLocalReaction', () => {
+  it('ローカルリアクションがなければ元の配列を変更しない', () => {
+    const reactions = [{ count: 1, me: false, name: '👍' }] as Entity.Reaction[]
+
+    expect(mergeLocalReaction(reactions, null)).toBe(reactions)
+    expect(mergeLocalReaction(reactions, makeInteractions())).toBe(reactions)
+  })
+
+  it('コロンで囲まれた名前を正規化し、URL を補完して me を立てる', () => {
+    const localUrl = 'https://example.com/emoji/blobcat.png'
+    const reactions = [
+      {
+        count: 3,
+        me: false,
+        name: ':blobcat:',
+        static_url: localUrl,
+      },
+    ] as Entity.Reaction[]
+
+    expect(
+      mergeLocalReaction(
+        reactions,
+        makeInteractions({
+          my_reaction_name: 'blobcat',
+          my_reaction_url: localUrl,
+        }),
+      ),
+    ).toEqual([
+      {
+        count: 3,
+        me: true,
+        name: ':blobcat:',
+        static_url: localUrl,
+        url: localUrl,
+      },
+    ])
+  })
+
+  it('URL のない同名カスタム絵文字もローカル URL と同一として扱う', () => {
+    const localUrl = 'https://example.com/emoji/blobcat.png'
+
+    expect(
+      mergeLocalReaction(
+        [{ count: 1, me: false, name: 'blobcat' }] as Entity.Reaction[],
+        makeInteractions({
+          my_reaction_name: ':blobcat:',
+          my_reaction_url: localUrl,
+        }),
+      ),
+    ).toEqual([
+      {
+        count: 1,
+        me: true,
+        name: 'blobcat',
+        static_url: localUrl,
+        url: localUrl,
+      },
+    ])
+  })
+
+  it('同名でも URL が異なるカスタム絵文字は別リアクションとして追加する', () => {
+    const original = {
+      count: 4,
+      me: false,
+      name: 'blobcat',
+      url: 'https://remote.example/blobcat.png',
+    }
+    const localUrl = 'https://local.example/blobcat.png'
+
+    expect(
+      mergeLocalReaction(
+        [original] as Entity.Reaction[],
+        makeInteractions({
+          my_reaction_name: 'blobcat',
+          my_reaction_url: localUrl,
+        }),
+      ),
+    ).toEqual([
+      original,
+      {
+        account_ids: [],
+        count: 1,
+        me: true,
+        name: 'blobcat',
+        static_url: localUrl,
+        url: localUrl,
+      },
+    ])
+  })
+
+  it('Unicode リアクションは URL なしで一致し、不要な URL フィールドを足さない', () => {
+    expect(
+      mergeLocalReaction(
+        [{ count: 5, me: false, name: '🔥' }] as Entity.Reaction[],
+        makeInteractions({ my_reaction_name: '🔥' }),
+      ),
+    ).toEqual([{ count: 5, me: true, name: '🔥' }])
+  })
+
+  it('一致する名前がなければ Unicode リアクションを末尾に追加する', () => {
+    expect(
+      mergeLocalReaction(
+        [{ count: 1, me: false, name: '👍' }] as Entity.Reaction[],
+        makeInteractions({ my_reaction_name: '🔥' }),
+      ),
+    ).toEqual([
+      { count: 1, me: false, name: '👍' },
+      { account_ids: [], count: 1, me: true, name: '🔥' },
+    ])
+  })
+})
+
+describe('parseEmojis / parseMediaAttachments / parseMentions', () => {
+  it('空値は各パーサーで空配列にする', () => {
+    expect(parseEmojis(null)).toEqual([])
+    expect(parseMediaAttachments('')).toEqual([])
+    expect(parseMentions(null)).toEqual([])
+  })
+
+  it('絵文字の null 要素と shortcode 欠損を除外し、static URL を補完する', () => {
+    const json = JSON.stringify([
+      null,
+      {
+        shortcode: null,
+        static_url: null,
+        url: 'https://example.com/ignored.png',
+        visible_in_picker: 1,
+      },
+      {
+        shortcode: 'fallback',
+        static_url: null,
+        url: 'https://example.com/fallback.png',
+        visible_in_picker: 1,
+      },
+      {
+        shortcode: 'static',
+        static_url: 'https://example.com/static.png',
+        url: 'https://example.com/animated.gif',
+        visible_in_picker: 0,
+      },
+    ])
+
+    expect(parseEmojis(json)).toEqual([
+      {
+        shortcode: 'fallback',
+        static_url: 'https://example.com/fallback.png',
+        url: 'https://example.com/fallback.png',
+        visible_in_picker: true,
+      },
+      {
+        shortcode: 'static',
+        static_url: 'https://example.com/static.png',
+        url: 'https://example.com/animated.gif',
+        visible_in_picker: false,
+      },
+    ])
+  })
+
+  it('メディア配列から null 要素だけを除外する', () => {
+    const attachment = {
+      id: 'media-1',
+      preview_url: 'https://example.com/preview.png',
+      type: 'image',
+      url: 'https://example.com/image.png',
+    }
+
+    expect(
+      parseMediaAttachments(JSON.stringify([null, attachment, null])),
+    ).toEqual([attachment])
+  })
+
+  it('メンションの保存値を優先し、欠損値は acct から補う', () => {
+    const json = JSON.stringify([
+      null,
+      {
+        acct: 'alice@remote.example',
+        url: 'https://remote.example/@alice',
+        username: 'stored-alice',
+      },
+      { acct: 'bob@remote.example' },
+      { acct: '' },
+    ])
+
+    expect(parseMentions(json)).toEqual([
+      {
+        acct: 'alice@remote.example',
+        id: '',
+        url: 'https://remote.example/@alice',
+        username: 'stored-alice',
+      },
+      {
+        acct: 'bob@remote.example',
+        id: '',
+        url: '',
+        username: 'bob',
+      },
+      { acct: '', id: '', url: '', username: '' },
+    ])
+  })
+
+  it.each([parseEmojis, parseMediaAttachments, parseMentions])(
+    '%# の構造化 JSON パーサーは壊れた JSON を呼び出し元へ通知する',
+    (parser) => {
+      expect(() => parser('{not-json')).toThrow(SyntaxError)
+    },
+  )
+})
+
+describe('poll parsers', () => {
+  it('インライン poll の文字列 options と過去の期限を復元する', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime('2026-01-15T00:00:00.000Z')
+
+    const poll = parseInlinePoll(
+      JSON.stringify({
+        expires_at: '2026-01-14T23:59:59.000Z',
+        id: 10,
+        multiple: 1,
+        options: JSON.stringify([
+          { title: 'A', votes_count: 2 },
+          { title: 'B', votes_count: null },
+        ]),
+        votes_count: 2,
+      }),
+    )
+
+    expect(poll).toEqual({
+      expired: true,
+      expires_at: '2026-01-14T23:59:59.000Z',
+      id: '10',
+      multiple: true,
+      options: [
+        { title: 'A', votes_count: 2 },
+        { title: 'B', votes_count: null },
+      ],
+      voted: false,
+      votes_count: 2,
+    })
+  })
+
+  it('インライン poll の配列 options と期限なしを復元する', () => {
+    const poll = parseInlinePoll(
+      JSON.stringify({
+        expires_at: null,
+        id: 11,
+        multiple: 0,
+        options: [{ title: 'Only', votes_count: 0 }],
+        votes_count: 0,
+      }),
+    )
+
+    expect(poll.expired).toBe(false)
+    expect(poll.multiple).toBe(false)
+    expect(poll.options).toEqual([{ title: 'Only', votes_count: 0 }])
+    expect(poll).not.toHaveProperty('own_votes')
+  })
+
+  it('batch poll は DB の expired/voted と JSON 文字列の own_votes を優先する', () => {
+    const poll = parseBatchPoll(
+      JSON.stringify({
+        expired: 1,
+        expires_at: '2099-01-01T00:00:00.000Z',
+        id: 20,
+        multiple: 1,
+        options: JSON.stringify([{ title: 'A', votes_count: 4 }]),
+        own_votes: '[0,2]',
+        voted: 1,
+        votes_count: 4,
+      }),
+    )
+
+    expect(poll).toMatchObject({
+      expired: true,
+      id: '20',
+      multiple: true,
+      options: [{ title: 'A', votes_count: 4 }],
+      own_votes: [0, 2],
+      voted: true,
+    })
+  })
+
+  it('batch poll は expired=0 を期限日時より優先し、配列 own_votes を保つ', () => {
+    const poll = parseBatchPoll(
+      JSON.stringify({
+        expired: 0,
+        expires_at: '2000-01-01T00:00:00.000Z',
+        id: 21,
+        multiple: 0,
+        options: [{ title: 'A', votes_count: null }],
+        own_votes: [1],
+        voted: 0,
+        votes_count: 0,
+      }),
+    )
+
+    expect(poll.expired).toBe(false)
+    expect(poll.multiple).toBe(false)
+    expect(poll).toMatchObject({ own_votes: [1] })
+    expect(poll.voted).toBe(false)
+  })
+
+  it('batch poll は expired が null なら日時から期限切れを判定する', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime('2026-01-15T00:00:00.000Z')
+
+    const expired = parseBatchPoll(
+      JSON.stringify({
+        expired: null,
+        expires_at: '2026-01-14T00:00:00.000Z',
+        id: 22,
+        multiple: 0,
+        options: [],
+        own_votes: null,
+        voted: null,
+        votes_count: 0,
+      }),
+    )
+    const openEnded = parseBatchPoll(
+      JSON.stringify({
+        expired: null,
+        expires_at: null,
+        id: 23,
+        multiple: 0,
+        options: [],
+        own_votes: null,
+        voted: null,
+        votes_count: 0,
+      }),
+    )
+
+    expect(expired.expired).toBe(true)
+    expect(openEnded.expired).toBe(false)
+    expect(openEnded).not.toHaveProperty('own_votes')
+  })
+
+  it('壊れた own_votes だけを無視し、poll 本体は復元する', () => {
+    const poll = parseBatchPoll(
+      JSON.stringify({
+        expired: null,
+        expires_at: null,
+        id: 24,
+        multiple: 0,
+        options: [],
+        own_votes: 'not-json',
+        voted: 1,
+        votes_count: 1,
+      }),
+    )
+
+    expect(poll.voted).toBe(true)
+    expect(poll).not.toHaveProperty('own_votes')
+  })
+
+  it.each([parseInlinePoll, parseBatchPoll])(
+    '%# は壊れた poll JSON を呼び出し元へ通知する',
+    (parser) => {
+      expect(() => parser('{not-json')).toThrow(SyntaxError)
+    },
+  )
+})
+
+describe('editedAtMsToIso', () => {
+  it('ミリ秒を ISO 文字列へ変換し、null は維持する', () => {
+    expect(editedAtMsToIso(1_700_001_000_000)).toBe('2023-11-14T22:30:00.000Z')
+    expect(editedAtMsToIso(null)).toBeNull()
+  })
+})

--- a/src/util/db/sqlite/__tests__/stores-statusColumnValues.test.ts
+++ b/src/util/db/sqlite/__tests__/stores-statusColumnValues.test.ts
@@ -1,0 +1,180 @@
+import { getSqliteDb } from 'util/db/sqlite/connection'
+import {
+  getDistinctColumnValues,
+  getDistinctTags,
+  getDistinctTimelineTypes,
+  searchColumnValuesDirect,
+  searchDistinctColumnValues,
+} from 'util/db/sqlite/stores/statusColumnValues'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('util/db/sqlite/connection', () => ({
+  getSqliteDb: vi.fn(),
+}))
+
+function installExecResult(rows: unknown[] = []) {
+  const execAsync = vi.fn().mockResolvedValue(rows)
+  vi.mocked(getSqliteDb).mockResolvedValue({ execAsync } as never)
+  return execAsync
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('固定候補値の取得', () => {
+  it('タグ名をソート済みクエリから取り出す', async () => {
+    const execAsync = installExecResult([['alpha'], ['beta']])
+
+    await expect(getDistinctTags()).resolves.toEqual(['alpha', 'beta'])
+    expect(execAsync).toHaveBeenCalledWith(
+      'SELECT DISTINCT ht.name FROM post_hashtags pht INNER JOIN hashtags ht ON pht.hashtag_id = ht.id ORDER BY ht.name;',
+      { returnValue: 'resultRows' },
+    )
+  })
+
+  it('タイムライン種別をソート済みクエリから取り出す', async () => {
+    const execAsync = installExecResult([['home'], ['local']])
+
+    await expect(getDistinctTimelineTypes()).resolves.toEqual(['home', 'local'])
+    expect(execAsync).toHaveBeenCalledWith(
+      'SELECT DISTINCT te.timeline_key FROM timeline_entries te ORDER BY te.timeline_key;',
+      { returnValue: 'resultRows' },
+    )
+  })
+
+  it('DB の取得または実行に失敗した場合は候補なしとして扱う', async () => {
+    vi.mocked(getSqliteDb).mockRejectedValueOnce(new Error('not ready'))
+    await expect(getDistinctTimelineTypes()).resolves.toEqual([])
+
+    const execAsync = vi.fn().mockRejectedValue(new Error('query failed'))
+    vi.mocked(getSqliteDb).mockResolvedValue({ execAsync } as never)
+    await expect(getDistinctTags()).resolves.toEqual([])
+  })
+})
+
+describe('getDistinctColumnValues', () => {
+  it('ホワイトリスト上のテーブル・カラムだけを bind 付きで取得する', async () => {
+    const execAsync = installExecResult([['ja'], ['en']])
+
+    await expect(
+      getDistinctColumnValues('posts', 'language', 7),
+    ).resolves.toEqual(['ja', 'en'])
+    expect(execAsync).toHaveBeenCalledWith(
+      'SELECT DISTINCT "language" FROM "posts" WHERE "language" IS NOT NULL AND "language" != \'\' ORDER BY "language" LIMIT ?;',
+      { bind: [7], returnValue: 'resultRows' },
+    )
+  })
+
+  it.each([
+    ['unknown_table', 'language'],
+    ['posts', 'content_html'],
+  ])('許可されていない %s.%s は DB に問い合わせない', async (table, column) => {
+    const execAsync = installExecResult([['should-not-be-used']])
+
+    await expect(getDistinctColumnValues(table, column)).resolves.toEqual([])
+    expect(getSqliteDb).not.toHaveBeenCalled()
+    expect(execAsync).not.toHaveBeenCalled()
+  })
+
+  it('DB エラー時は空配列へフォールバックする', async () => {
+    const execAsync = vi.fn().mockRejectedValue(new Error('query failed'))
+    vi.mocked(getSqliteDb).mockResolvedValue({ execAsync } as never)
+
+    await expect(getDistinctColumnValues('profiles', 'acct')).resolves.toEqual(
+      [],
+    )
+  })
+})
+
+describe('searchDistinctColumnValues', () => {
+  it('通常のエイリアスを実テーブル・実カラムに解決する', async () => {
+    const execAsync = installExecResult([['ja-JP']])
+
+    await expect(
+      searchDistinctColumnValues('p', 'language', 'ja', 4),
+    ).resolves.toEqual(['ja-JP'])
+    expect(execAsync).toHaveBeenCalledWith(
+      expect.stringContaining('SELECT DISTINCT "language" FROM "posts"'),
+      { bind: ['ja%', 4], returnValue: 'resultRows' },
+    )
+  })
+
+  it('互換カラムのオーバーライドを優先し LIKE ワイルドカードをエスケープする', async () => {
+    const execAsync = installExecResult([['ja%_\\server']])
+
+    await expect(
+      searchDistinctColumnValues('p', 'origin_backend_url', 'ja%_\\', 3),
+    ).resolves.toEqual(['ja%_\\server'])
+    expect(execAsync).toHaveBeenCalledWith(
+      expect.stringMatching(
+        /SELECT DISTINCT "backend_url" FROM "local_accounts".*LIKE \? ESCAPE '\\'/,
+      ),
+      {
+        bind: ['ja\\%\\_\\\\%', 3],
+        returnValue: 'resultRows',
+      },
+    )
+  })
+
+  it.each([
+    ['unknown', 'language'],
+    ['p', 'unknown_column'],
+    ['pr', 'url'],
+  ])(
+    '解決または許可できない %s.%s は DB に問い合わせない',
+    async (alias, column) => {
+      const execAsync = installExecResult([['should-not-be-used']])
+
+      await expect(
+        searchDistinctColumnValues(alias, column, ''),
+      ).resolves.toEqual([])
+      expect(getSqliteDb).not.toHaveBeenCalled()
+      expect(execAsync).not.toHaveBeenCalled()
+    },
+  )
+
+  it('DB エラー時は空配列へフォールバックする', async () => {
+    const execAsync = vi.fn().mockRejectedValue(new Error('query failed'))
+    vi.mocked(getSqliteDb).mockResolvedValue({ execAsync } as never)
+
+    await expect(
+      searchDistinctColumnValues('p', 'language', 'ja'),
+    ).resolves.toEqual([])
+  })
+})
+
+describe('searchColumnValuesDirect', () => {
+  it('直接指定した許可済みカラムを安全なプレフィクスで検索する', async () => {
+    const execAsync = installExecResult([['alice@example.com']])
+
+    await expect(
+      searchColumnValuesDirect('profiles', 'acct', 'ali_', 2),
+    ).resolves.toEqual(['alice@example.com'])
+    expect(execAsync).toHaveBeenCalledWith(
+      expect.stringMatching(
+        /SELECT DISTINCT "acct" FROM "profiles".*LIKE \? ESCAPE '\\'/,
+      ),
+      { bind: ['ali\\_%', 2], returnValue: 'resultRows' },
+    )
+  })
+
+  it('許可されていない直接指定は DB に問い合わせない', async () => {
+    const execAsync = installExecResult([['should-not-be-used']])
+
+    await expect(
+      searchColumnValuesDirect('profiles', 'url', ''),
+    ).resolves.toEqual([])
+    expect(getSqliteDb).not.toHaveBeenCalled()
+    expect(execAsync).not.toHaveBeenCalled()
+  })
+
+  it('DB エラー時は空配列へフォールバックする', async () => {
+    const execAsync = vi.fn().mockRejectedValue(new Error('query failed'))
+    vi.mocked(getSqliteDb).mockResolvedValue({ execAsync } as never)
+
+    await expect(
+      searchColumnValuesDirect('profiles', 'acct', 'ali'),
+    ).resolves.toEqual([])
+  })
+})

--- a/src/util/db/sqlite/__tests__/stores-statusCustomQueryExec.test.ts
+++ b/src/util/db/sqlite/__tests__/stores-statusCustomQueryExec.test.ts
@@ -1,0 +1,215 @@
+import { getSqliteDb } from 'util/db/sqlite/connection'
+import { fetchStatusesByIds } from 'util/db/sqlite/queries/statusFetch'
+import { MAX_QUERY_LIMIT } from 'util/db/sqlite/queries/statusSelect'
+import {
+  getStatusesByCustomQuery,
+  validateCustomQuery,
+} from 'util/db/sqlite/stores/statusCustomQueryExec'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('util/db/sqlite/connection', () => ({
+  getSqliteDb: vi.fn(),
+}))
+
+vi.mock('util/db/sqlite/queries/statusFetch', () => ({
+  fetchStatusesByIds: vi.fn(),
+}))
+
+function installHandle(rows: unknown[] = []) {
+  const execAsync = vi.fn().mockResolvedValue(rows)
+  const handle = { execAsync }
+  vi.mocked(getSqliteDb).mockResolvedValue(handle as never)
+  vi.mocked(fetchStatusesByIds).mockResolvedValue([
+    { id: 'assembled-status' },
+  ] as never)
+  return { execAsync, handle }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('getStatusesByCustomQuery', () => {
+  it('参照された互換テーブルだけを JOIN し backend filter とページングを bind する', async () => {
+    const { execAsync, handle } = installHandle([[101], [202]])
+    const query =
+      "ptt.timelineType = 'home' AND pbt.tag = 'tech' AND " +
+      "pme.acct = 'alice@example.com' AND prb.original_uri IS NOT NULL AND " +
+      'pe.is_bookmarked = 1 LIMIT 999 OFFSET 888;'
+
+    await expect(
+      getStatusesByCustomQuery(
+        query,
+        ['https://one.example', 'https://two.example'],
+        12,
+        4,
+      ),
+    ).resolves.toEqual([{ id: 'assembled-status' }])
+
+    const [sql, options] = execAsync.mock.calls[0]
+    expect(sql).toContain('LEFT JOIN timeline_entries ptt')
+    expect(sql).toContain('LEFT JOIN post_hashtags pht')
+    expect(sql).toContain('LEFT JOIN hashtags ht')
+    expect(sql).toContain('LEFT JOIN post_mentions pme')
+    expect(sql).toContain('LEFT JOIN (SELECT rb_src.id AS post_id')
+    expect(sql).toContain('LEFT JOIN post_interactions pe')
+    expect(sql).toContain("ht.name = 'tech'")
+    expect(sql).not.toContain('pbt.tag')
+    expect(sql).not.toContain('LIMIT 999')
+    expect(sql).not.toContain('OFFSET 888')
+    expect(sql).toContain('la.backend_url IN (?,?)')
+    expect(options).toEqual({
+      bind: ['https://one.example', 'https://two.example', 12, 4],
+      kind: 'timeline',
+      returnValue: 'resultRows',
+    })
+    expect(fetchStatusesByIds).toHaveBeenCalledWith(handle, [101, 202])
+  })
+
+  it('空の WHERE 句には 1=1 と既定ページングを使い、不要な JOIN を追加しない', async () => {
+    const { execAsync, handle } = installHandle([])
+
+    await getStatusesByCustomQuery(' ; LIMIT 9 OFFSET 2', [])
+
+    const [sql, options] = execAsync.mock.calls[0]
+    expect(sql).toContain('WHERE (1=1)')
+    expect(sql).not.toContain('LEFT JOIN timeline_entries ptt')
+    expect(sql).not.toContain('la.backend_url IN')
+    expect(options.bind).toEqual([MAX_QUERY_LIMIT, 0])
+    expect(fetchStatusesByIds).toHaveBeenCalledWith(handle, [])
+  })
+
+  it('0 の limit と offset を有効な値として保持する', async () => {
+    const { execAsync } = installHandle([])
+
+    await getStatusesByCustomQuery("p.language = 'ja'", undefined, 0, 0)
+
+    expect(execAsync.mock.calls[0][1].bind).toEqual([0, 0])
+  })
+
+  it('禁止 SQL とコメントを詳細取得前に拒否する', async () => {
+    const { execAsync } = installHandle([])
+
+    await expect(
+      getStatusesByCustomQuery("p.language = 'ja'; DELETE FROM posts"),
+    ).rejects.toThrow('forbidden SQL statements')
+    await expect(
+      getStatusesByCustomQuery("p.language = 'ja' -- ignore filter"),
+    ).rejects.toThrow('SQL comments')
+    expect(execAsync).not.toHaveBeenCalled()
+    expect(fetchStatusesByIds).not.toHaveBeenCalled()
+  })
+
+  it('詳細フェッチのエラーを呼び出し元へ返す', async () => {
+    installHandle([[1]])
+    vi.mocked(fetchStatusesByIds).mockRejectedValue(new Error('phase 2 failed'))
+
+    await expect(getStatusesByCustomQuery("p.language = 'ja'")).rejects.toThrow(
+      'phase 2 failed',
+    )
+  })
+})
+
+describe('validateCustomQuery', () => {
+  it.each(['', '   ', ' ; LIMIT 10 OFFSET 5 ;;'])(
+    '実質的に空のクエリ %j は DB を使わず有効とする',
+    async (query) => {
+      await expect(validateCustomQuery(query)).resolves.toBeNull()
+      expect(getSqliteDb).not.toHaveBeenCalled()
+    },
+  )
+
+  it.each([
+    'DROP',
+    'DELETE',
+    'INSERT',
+    'UPDATE',
+    'ALTER',
+    'CREATE',
+    'ATTACH',
+    'DETACH',
+    'PRAGMA',
+    'VACUUM',
+    'REINDEX',
+  ])('%s を含むクエリを EXPLAIN 前に拒否する', async (keyword) => {
+    const result = await validateCustomQuery(
+      `p.language = 'ja' OR ${keyword} = 1`,
+    )
+
+    expect(result).toBe(
+      'クエリに禁止されたSQL文が含まれています。WHERE句のみ使用可能です。',
+    )
+    expect(getSqliteDb).not.toHaveBeenCalled()
+  })
+
+  it('Status クエリを v2 互換 JOIN 付きで EXPLAIN する', async () => {
+    const { execAsync } = installHandle([])
+
+    await expect(
+      validateCustomQuery("ptt.timelineType = 'home' LIMIT 100;"),
+    ).resolves.toBeNull()
+
+    const sql = execAsync.mock.calls[0][0]
+    expect(sql).toContain('EXPLAIN')
+    expect(sql).toContain('SELECT DISTINCT p.id')
+    expect(sql).toContain(
+      'SELECT te2.post_id, te2.timeline_key AS timelineType',
+    )
+    expect(sql).toContain("WHERE (ptt.timelineType = 'home')")
+    expect(sql).not.toContain('LIMIT 100')
+  })
+
+  it('Notification クエリを通知専用の SELECT で EXPLAIN する', async () => {
+    const { execAsync } = installHandle([])
+
+    await expect(
+      validateCustomQuery("n.notification_type = 'follow'"),
+    ).resolves.toBeNull()
+
+    const sql = execAsync.mock.calls[0][0]
+    expect(sql).toContain('SELECT DISTINCT n.id')
+    expect(sql).toContain("WHERE (nt.name = 'follow')")
+    expect(sql).not.toContain('UNION ALL')
+  })
+
+  it('Status と Notification の混合クエリを UNION ALL で EXPLAIN する', async () => {
+    const { execAsync } = installHandle([])
+
+    await expect(
+      validateCustomQuery(
+        "p.language = 'ja' OR n.notification_type = 'mention'",
+      ),
+    ).resolves.toBeNull()
+
+    const sql = execAsync.mock.calls[0][0]
+    expect(sql).toContain('SELECT post_id FROM (')
+    expect(sql).toContain('UNION ALL')
+    expect(sql).toContain("p.language = 'ja' OR nt.name = 'mention'")
+  })
+
+  it('SQLite の Error を読みやすい検証メッセージに変換する', async () => {
+    const execAsync = vi.fn().mockRejectedValue(new Error('no such column: x'))
+    vi.mocked(getSqliteDb).mockResolvedValue({ execAsync } as never)
+
+    await expect(validateCustomQuery('p.x = 1')).resolves.toBe(
+      'クエリエラー: no such column: x',
+    )
+  })
+
+  it('Error 以外の throw も文字列化して検証メッセージに変換する', async () => {
+    const execAsync = vi.fn().mockRejectedValue('sqlite unavailable')
+    vi.mocked(getSqliteDb).mockResolvedValue({ execAsync } as never)
+
+    await expect(validateCustomQuery('p.id > 0')).resolves.toBe(
+      'クエリエラー: sqlite unavailable',
+    )
+  })
+
+  it('DB handle の取得失敗も検証エラーとして返す', async () => {
+    vi.mocked(getSqliteDb).mockRejectedValue(new Error('database not ready'))
+
+    await expect(validateCustomQuery('p.id > 0')).resolves.toBe(
+      'クエリエラー: database not ready',
+    )
+  })
+})

--- a/src/util/db/sqlite/__tests__/stores-statusStore.test.ts
+++ b/src/util/db/sqlite/__tests__/stores-statusStore.test.ts
@@ -1,0 +1,268 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('util/db/sqlite/connection', () => ({
+  getSqliteDb: vi.fn(),
+}))
+
+async function loadStatusStore() {
+  vi.resetModules()
+  const { getSqliteDb } = await import('util/db/sqlite/connection')
+  const sendCommand = vi.fn().mockResolvedValue({ ok: true })
+  vi.mocked(getSqliteDb).mockResolvedValue({ sendCommand } as never)
+  const store = await import('util/db/sqlite/stores/statusStore')
+  return { getSqliteDb, sendCommand, store }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.clearAllTimers()
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+describe('upsertStatus のマイクロバッチ', () => {
+  it('同じキーの投稿を 100ms 後に1コマンドへまとめる', async () => {
+    const { getSqliteDb, sendCommand, store } = await loadStatusStore()
+    const first = { content: 'first', id: 'status-1' }
+    const second = { content: 'second', id: 'status-2' }
+
+    await store.upsertStatus(first as never, 'https://social.example', 'home')
+    await store.upsertStatus(second as never, 'https://social.example', 'home')
+
+    expect(getSqliteDb).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(99)
+    expect(sendCommand).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1)
+    await Promise.resolve()
+
+    expect(sendCommand).toHaveBeenCalledTimes(1)
+    expect(sendCommand).toHaveBeenCalledWith({
+      backendUrl: 'https://social.example',
+      statusesJson: [JSON.stringify(first), JSON.stringify(second)],
+      tag: undefined,
+      timelineType: 'home',
+      type: 'bulkUpsertStatuses',
+    })
+  })
+
+  it('backend、timelineType、tag が異なる投稿を別々のコマンドに分ける', async () => {
+    const { sendCommand, store } = await loadStatusStore()
+
+    await store.upsertStatus(
+      { id: 'home' } as never,
+      'https://one.example',
+      'home',
+    )
+    await store.upsertStatus(
+      { id: 'tagged' } as never,
+      'https://one.example',
+      'tag',
+      'testing',
+    )
+    await store.upsertStatus(
+      { id: 'other-backend' } as never,
+      'https://two.example',
+      'home',
+    )
+
+    await vi.advanceTimersByTimeAsync(100)
+    await Promise.resolve()
+
+    expect(sendCommand).toHaveBeenCalledTimes(3)
+    expect(sendCommand.mock.calls.map(([command]) => command)).toEqual([
+      {
+        backendUrl: 'https://one.example',
+        statusesJson: [JSON.stringify({ id: 'home' })],
+        tag: undefined,
+        timelineType: 'home',
+        type: 'bulkUpsertStatuses',
+      },
+      {
+        backendUrl: 'https://one.example',
+        statusesJson: [JSON.stringify({ id: 'tagged' })],
+        tag: 'testing',
+        timelineType: 'tag',
+        type: 'bulkUpsertStatuses',
+      },
+      {
+        backendUrl: 'https://two.example',
+        statusesJson: [JSON.stringify({ id: 'other-backend' })],
+        tag: undefined,
+        timelineType: 'home',
+        type: 'bulkUpsertStatuses',
+      },
+    ])
+  })
+
+  it('全バッファ合計が20件に達したらタイマーを待たず即座に全キーを flush する', async () => {
+    const { sendCommand, store } = await loadStatusStore()
+
+    for (let index = 0; index < 10; index++) {
+      await store.upsertStatus(
+        { id: `home-${index}` } as never,
+        'https://social.example',
+        'home',
+      )
+    }
+    for (let index = 0; index < 10; index++) {
+      await store.upsertStatus(
+        { id: `local-${index}` } as never,
+        'https://social.example',
+        'local',
+      )
+    }
+
+    expect(sendCommand).toHaveBeenCalledTimes(2)
+    expect(sendCommand.mock.calls[0][0].statusesJson).toHaveLength(10)
+    expect(sendCommand.mock.calls[1][0].statusesJson).toHaveLength(10)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('flush 中の DB エラーを記録し、タイマー callback から漏らさない', async () => {
+    const { getSqliteDb, sendCommand, store } = await loadStatusStore()
+    vi.mocked(getSqliteDb).mockRejectedValue(new Error('database not ready'))
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await store.upsertStatus(
+      { id: 'status-1' } as never,
+      'https://social.example',
+      'home',
+    )
+    await vi.advanceTimersByTimeAsync(100)
+    await Promise.resolve()
+
+    expect(sendCommand).not.toHaveBeenCalled()
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Failed to flush upsert buffer:',
+      expect.objectContaining({ message: 'database not ready' }),
+    )
+  })
+})
+
+describe('直接書き込み API', () => {
+  it('空の Status 配列と絵文字配列では DB を取得しない', async () => {
+    const { getSqliteDb, sendCommand, store } = await loadStatusStore()
+
+    await store.bulkUpsertStatuses([], 'https://social.example', 'home')
+    await store.bulkUpsertCustomEmojis('https://social.example', [])
+
+    expect(getSqliteDb).not.toHaveBeenCalled()
+    expect(sendCommand).not.toHaveBeenCalled()
+  })
+
+  it('各操作を対応する Worker コマンドへ正確に変換する', async () => {
+    const { getSqliteDb, sendCommand, store } = await loadStatusStore()
+    const statuses = [
+      { content: 'first', id: 'status-1' },
+      { content: 'second', id: 'status-2' },
+    ]
+    const editedStatus = { content: 'edited', id: 'status-3' }
+    const account = { acct: 'alice', id: 'account-1' }
+    const emojis = [
+      {
+        shortcode: 'party',
+        static_url: 'https://cdn.example/party-static.png',
+        url: 'https://cdn.example/party.png',
+      },
+    ]
+
+    await store.bulkUpsertStatuses(
+      statuses as never,
+      'https://social.example',
+      'tag',
+      'testing',
+      true,
+    )
+    await store.removeFromTimeline(
+      'https://social.example',
+      'status-1',
+      'tag',
+      'testing',
+    )
+    await store.handleDeleteEvent('https://social.example', 'status-2', 'local')
+    await store.updateStatusAction(
+      'https://social.example',
+      'status-3',
+      'bookmarked',
+      true,
+    )
+    await store.updateStatus(editedStatus as never, 'https://social.example')
+    await store.ensureLocalAccount(account as never, 'https://social.example')
+    await store.toggleReactionInDb(
+      'https://social.example',
+      'status-4',
+      false,
+      ':party:',
+    )
+    await store.bulkUpsertCustomEmojis('https://social.example', emojis)
+
+    expect(getSqliteDb).toHaveBeenCalledTimes(8)
+    expect(sendCommand.mock.calls.map(([command]) => command)).toEqual([
+      {
+        backendUrl: 'https://social.example',
+        skipProfileUpdate: true,
+        statusesJson: statuses.map((status) => JSON.stringify(status)),
+        tag: 'testing',
+        timelineType: 'tag',
+        type: 'bulkUpsertStatuses',
+      },
+      {
+        backendUrl: 'https://social.example',
+        statusId: 'status-1',
+        tag: 'testing',
+        timelineType: 'tag',
+        type: 'removeFromTimeline',
+      },
+      {
+        backendUrl: 'https://social.example',
+        sourceTimelineType: 'local',
+        statusId: 'status-2',
+        tag: undefined,
+        type: 'handleDeleteEvent',
+      },
+      {
+        action: 'bookmarked',
+        backendUrl: 'https://social.example',
+        statusId: 'status-3',
+        type: 'updateStatusAction',
+        value: true,
+      },
+      {
+        backendUrl: 'https://social.example',
+        statusJson: JSON.stringify(editedStatus),
+        type: 'updateStatus',
+      },
+      {
+        accountJson: JSON.stringify(account),
+        backendUrl: 'https://social.example',
+        type: 'ensureLocalAccount',
+      },
+      {
+        backendUrl: 'https://social.example',
+        emoji: ':party:',
+        statusId: 'status-4',
+        type: 'toggleReaction',
+        value: false,
+      },
+      {
+        backendUrl: 'https://social.example',
+        emojisJson: JSON.stringify(emojis),
+        type: 'bulkUpsertCustomEmojis',
+      },
+    ])
+  })
+
+  it('Worker コマンドのエラーを呼び出し元へ返す', async () => {
+    const { sendCommand, store } = await loadStatusStore()
+    sendCommand.mockRejectedValue(new Error('worker failed'))
+
+    await expect(
+      store.removeFromTimeline('https://social.example', 'status-1', 'home'),
+    ).rejects.toThrow('worker failed')
+  })
+})

--- a/src/util/db/sqlite/__tests__/stores-statusTimelineQueries.test.ts
+++ b/src/util/db/sqlite/__tests__/stores-statusTimelineQueries.test.ts
@@ -1,0 +1,159 @@
+import { getSqliteDb } from 'util/db/sqlite/connection'
+import { fetchStatusesByIds } from 'util/db/sqlite/queries/statusFetch'
+import { MAX_QUERY_LIMIT } from 'util/db/sqlite/queries/statusSelect'
+import {
+  getBookmarkedStatuses,
+  getStatusesByTag,
+  getStatusesByTimelineType,
+} from 'util/db/sqlite/stores/statusTimelineQueries'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('util/db/sqlite/connection', () => ({
+  getSqliteDb: vi.fn(),
+}))
+
+vi.mock('util/db/sqlite/queries/statusFetch', () => ({
+  fetchStatusesByIds: vi.fn(),
+}))
+
+function installHandle(rows: unknown[] = []) {
+  const execAsync = vi.fn().mockResolvedValue(rows)
+  const handle = { execAsync }
+  vi.mocked(getSqliteDb).mockResolvedValue(handle as never)
+  vi.mocked(fetchStatusesByIds).mockResolvedValue([
+    { id: 'assembled-status' },
+  ] as never)
+  return { execAsync, handle }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('getStatusesByTimelineType', () => {
+  it('post_id と timelineTypes を取得して詳細フェッチへ引き渡す', async () => {
+    const { execAsync, handle } = installHandle([
+      [11, '["home","local"]'],
+      [22, null],
+    ])
+
+    await expect(getStatusesByTimelineType('home')).resolves.toEqual([
+      { id: 'assembled-status' },
+    ])
+
+    expect(execAsync).toHaveBeenCalledWith(
+      expect.stringMatching(
+        /INNER JOIN timeline_entries te.*WHERE te\.timeline_key = \?/s,
+      ),
+      {
+        bind: ['home', MAX_QUERY_LIMIT],
+        kind: 'timeline',
+        returnValue: 'resultRows',
+      },
+    )
+    expect(fetchStatusesByIds).toHaveBeenCalledWith(
+      handle,
+      [11, 22],
+      new Map([[11, '["home","local"]']]),
+    )
+  })
+
+  it('timelineType、backend URL、limit を SQL の placeholder 順で bind する', async () => {
+    const { execAsync } = installHandle([])
+
+    await getStatusesByTimelineType(
+      'local',
+      ['https://one.example', 'https://two.example'],
+      7,
+    )
+
+    const [sql, options] = execAsync.mock.calls[0]
+    expect(sql).toContain('la.backend_url IN (?,?)')
+    expect(options.bind).toEqual([
+      'local',
+      'https://one.example',
+      'https://two.example',
+      7,
+    ])
+  })
+})
+
+describe('getStatusesByTag', () => {
+  it('タグ、backend URL、limit を SQL の placeholder 順で bind する', async () => {
+    const { execAsync, handle } = installHandle([[31], [32]])
+
+    await getStatusesByTag(
+      'TypeScript',
+      ['https://one.example', 'https://two.example'],
+      5,
+    )
+
+    const [sql, options] = execAsync.mock.calls[0]
+    expect(sql).toMatch(/INNER JOIN hashtags ht.*WHERE ht\.name = LOWER\(\?\)/s)
+    expect(sql).toContain('la.backend_url IN (?,?)')
+    expect(options).toEqual({
+      bind: ['TypeScript', 'https://one.example', 'https://two.example', 5],
+      kind: 'timeline',
+      returnValue: 'resultRows',
+    })
+    expect(fetchStatusesByIds).toHaveBeenCalledWith(handle, [31, 32])
+  })
+
+  it('空の backend URL 配列では filter を追加せず、空 ID も詳細フェッチへ渡す', async () => {
+    const { execAsync, handle } = installHandle([])
+
+    await getStatusesByTag('testing', [])
+
+    const [sql, options] = execAsync.mock.calls[0]
+    expect(sql).not.toContain('la.backend_url IN')
+    expect(options.bind).toEqual(['testing', MAX_QUERY_LIMIT])
+    expect(fetchStatusesByIds).toHaveBeenCalledWith(handle, [])
+  })
+})
+
+describe('getBookmarkedStatuses', () => {
+  it('ブックマーク条件と既定 limit で取得する', async () => {
+    const { execAsync, handle } = installHandle([[41]])
+
+    await getBookmarkedStatuses()
+
+    expect(execAsync).toHaveBeenCalledWith(
+      expect.stringMatching(
+        /INNER JOIN post_interactions pi.*WHERE pi\.is_bookmarked = 1/s,
+      ),
+      {
+        bind: [MAX_QUERY_LIMIT],
+        kind: 'timeline',
+        returnValue: 'resultRows',
+      },
+    )
+    expect(fetchStatusesByIds).toHaveBeenCalledWith(handle, [41])
+  })
+
+  it('backend filter の bind を limit より前に渡す', async () => {
+    const { execAsync } = installHandle([])
+
+    await getBookmarkedStatuses(['https://social.example'], 9)
+
+    const [sql, options] = execAsync.mock.calls[0]
+    expect(sql).toContain('la.backend_url IN (?)')
+    expect(options.bind).toEqual(['https://social.example', 9])
+  })
+})
+
+describe('問い合わせ失敗', () => {
+  it('ID 取得が失敗した場合は詳細フェッチを呼ばずエラーを返す', async () => {
+    const execAsync = vi.fn().mockRejectedValue(new Error('phase 1 failed'))
+    vi.mocked(getSqliteDb).mockResolvedValue({ execAsync } as never)
+
+    await expect(getStatusesByTag('testing')).rejects.toThrow('phase 1 failed')
+    expect(fetchStatusesByIds).not.toHaveBeenCalled()
+  })
+
+  it('詳細フェッチのエラーを呼び出し元へ返す', async () => {
+    installHandle([[1]])
+    vi.mocked(fetchStatusesByIds).mockRejectedValue(new Error('phase 2 failed'))
+
+    await expect(getBookmarkedStatuses()).rejects.toThrow('phase 2 failed')
+  })
+})

--- a/src/util/db/sqlite/queries/statusFetch.ts
+++ b/src/util/db/sqlite/queries/statusFetch.ts
@@ -49,7 +49,7 @@ export async function fetchStatusesByIds(
   // リブログ元の post_id を収集し、全 post_id のリストを作成
   const reblogPostIds: number[] = []
   for (const row of baseRows) {
-    const rbPostId = row[27] as number | null // rb_post_id
+    const rbPostId = row[25] as number | null // rb_post_id
     if (rbPostId !== null) {
       reblogPostIds.push(rbPostId)
     }

--- a/src/util/db/sqlite/stores/statusTimelineQueries.ts
+++ b/src/util/db/sqlite/stores/statusTimelineQueries.ts
@@ -19,7 +19,7 @@ export async function getStatusesByTimelineType(
 ): Promise<SqliteStoredStatus[]> {
   const handle = await getSqliteDb()
 
-  const phase1Binds: (string | number)[] = []
+  const phase1Binds: (string | number)[] = [timelineType]
   let backendFilter = ''
   if (backendUrls && backendUrls.length > 0) {
     const placeholders = backendUrls.map(() => '?').join(',')
@@ -39,7 +39,7 @@ export async function getStatusesByTimelineType(
     ORDER BY p.created_at_ms DESC
     LIMIT ?;
   `
-  phase1Binds.push(timelineType, limit ?? MAX_QUERY_LIMIT)
+  phase1Binds.push(limit ?? MAX_QUERY_LIMIT)
 
   const idRows = (await handle.execAsync(phase1Sql, {
     bind: phase1Binds,
@@ -69,7 +69,7 @@ export async function getStatusesByTag(
 ): Promise<SqliteStoredStatus[]> {
   const handle = await getSqliteDb()
 
-  const phase1Binds: (string | number)[] = []
+  const phase1Binds: (string | number)[] = [tag]
   let backendFilter = ''
   if (backendUrls && backendUrls.length > 0) {
     const placeholders = backendUrls.map(() => '?').join(',')
@@ -89,7 +89,7 @@ export async function getStatusesByTag(
     ORDER BY p.created_at_ms DESC
     LIMIT ?;
   `
-  phase1Binds.push(tag, limit ?? MAX_QUERY_LIMIT)
+  phase1Binds.push(limit ?? MAX_QUERY_LIMIT)
 
   const idRows = (await handle.execAsync(phase1Sql, {
     bind: phase1Binds,

--- a/src/util/db/sqlite/worker/__tests__/sqliteWorkerEntrypoint.test.ts
+++ b/src/util/db/sqlite/worker/__tests__/sqliteWorkerEntrypoint.test.ts
@@ -1,0 +1,1005 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  buildTimelineKey: vi.fn(),
+  bumpTableVersions: vi.fn(),
+  captureTableVersions: vi.fn(),
+  getDb: vi.fn(),
+  getSqlite3Module: vi.fn(),
+  getTableVersionsMap: vi.fn(),
+  handleAddNotification: vi.fn(),
+  handleBulkAddNotifications: vi.fn(),
+  handleBulkUpsertCustomEmojis: vi.fn(),
+  handleBulkUpsertStatuses: vi.fn(),
+  handleDeleteEvent: vi.fn(),
+  handleEnforceMaxLength: vi.fn(),
+  handleEnsureLocalAccount: vi.fn(),
+  handleExec: vi.fn(),
+  handleExecBatch: vi.fn(),
+  handleExportDatabase: vi.fn(),
+  handleFetchTimeline: vi.fn(),
+  handleRemoveFromTimeline: vi.fn(),
+  handleToggleReaction: vi.fn(),
+  handleUpdateNotificationStatusAction: vi.fn(),
+  handleUpdateStatus: vi.fn(),
+  handleUpdateStatusAction: vi.fn(),
+  handleUpsertStatus: vi.fn(),
+  init: vi.fn(),
+  isDatabaseHealthy: vi.fn(),
+  isSqliteCorruptError: vi.fn(),
+  recoverFromCorruption: vi.fn(),
+  resolveLocalAccountId: vi.fn(),
+  resolvePostIdInternal: vi.fn(),
+  runFlatFetch: vi.fn(),
+  runGraphPlan: vi.fn(),
+  runQueryPlan: vi.fn(),
+  sendError: vi.fn(),
+  sendResponse: vi.fn(),
+  syncGraphCacheVersions: vi.fn(),
+}))
+
+vi.mock('util/db/query-ir/executor/flatFetchExecutor', () => ({
+  executeFlatFetch: mocks.runFlatFetch,
+}))
+
+vi.mock('util/db/query-ir/executor/graphExecutor', () => ({
+  executeGraphPlan: mocks.runGraphPlan,
+  syncGraphCacheVersions: mocks.syncGraphCacheVersions,
+}))
+
+vi.mock('util/db/sqlite/helpers', () => ({
+  buildTimelineKey: mocks.buildTimelineKey,
+  resolveLocalAccountId: mocks.resolveLocalAccountId,
+}))
+
+vi.mock('util/db/sqlite/queries/executionEngine', () => ({
+  executeQueryPlan: mocks.runQueryPlan,
+}))
+
+vi.mock('util/db/sqlite/worker/handlers/statusHelpers', () => ({
+  resolvePostIdInternal: mocks.resolvePostIdInternal,
+}))
+
+vi.mock('util/db/sqlite/worker/workerCleanup', () => ({
+  DEFAULT_MAX_NOTIFICATIONS: 200,
+  DEFAULT_MAX_POSTS: 300,
+  DEFAULT_MAX_TIMELINE_ENTRIES: 100,
+  handleEnforceMaxLength: mocks.handleEnforceMaxLength,
+}))
+
+vi.mock('util/db/sqlite/worker/workerExecHandlers', () => ({
+  handleExec: mocks.handleExec,
+  handleExecBatch: mocks.handleExecBatch,
+}))
+
+vi.mock('util/db/sqlite/worker/workerExportHandler', () => ({
+  handleExportDatabase: mocks.handleExportDatabase,
+}))
+
+vi.mock('util/db/sqlite/worker/workerFetchTimelineHandler', () => ({
+  handleFetchTimeline: mocks.handleFetchTimeline,
+}))
+
+vi.mock('util/db/sqlite/worker/workerInit', () => ({
+  init: mocks.init,
+}))
+
+vi.mock('util/db/sqlite/worker/workerMessageHelpers', () => ({
+  sendError: mocks.sendError,
+  sendResponse: mocks.sendResponse,
+}))
+
+vi.mock('util/db/sqlite/worker/workerNotificationStore', () => ({
+  handleAddNotification: mocks.handleAddNotification,
+  handleBulkAddNotifications: mocks.handleBulkAddNotifications,
+  handleUpdateNotificationStatusAction:
+    mocks.handleUpdateNotificationStatusAction,
+}))
+
+vi.mock('util/db/sqlite/worker/workerRecovery', () => ({
+  isDatabaseHealthy: mocks.isDatabaseHealthy,
+  isSqliteCorruptError: mocks.isSqliteCorruptError,
+  recoverFromCorruption: mocks.recoverFromCorruption,
+}))
+
+vi.mock('util/db/sqlite/worker/workerState', () => ({
+  bumpTableVersions: mocks.bumpTableVersions,
+  captureTableVersions: mocks.captureTableVersions,
+  getDb: mocks.getDb,
+  getSqlite3Module: mocks.getSqlite3Module,
+  getTableVersionsMap: mocks.getTableVersionsMap,
+}))
+
+vi.mock('util/db/sqlite/worker/workerStatusStore', () => ({
+  handleBulkUpsertCustomEmojis: mocks.handleBulkUpsertCustomEmojis,
+  handleBulkUpsertStatuses: mocks.handleBulkUpsertStatuses,
+  handleDeleteEvent: mocks.handleDeleteEvent,
+  handleEnsureLocalAccount: mocks.handleEnsureLocalAccount,
+  handleRemoveFromTimeline: mocks.handleRemoveFromTimeline,
+  handleToggleReaction: mocks.handleToggleReaction,
+  handleUpdateStatus: mocks.handleUpdateStatus,
+  handleUpdateStatusAction: mocks.handleUpdateStatusAction,
+  handleUpsertStatus: mocks.handleUpsertStatus,
+}))
+
+await import('util/db/sqlite/worker/sqlite.worker')
+
+const db = { exec: vi.fn() }
+const sqlite3 = { capi: {} }
+const postMessage = vi.fn()
+
+function dispatch(data: Record<string, unknown>): void {
+  const listener = globalThis.onmessage
+  if (listener == null) {
+    throw new Error('SQLite worker did not register an onmessage listener')
+  }
+  ;(listener as (event: MessageEvent) => void)({ data } as MessageEvent)
+}
+
+function expectOkResponse(
+  id: number,
+  changedTables?: string[],
+  changeHint?: {
+    backendUrl?: string
+    tag?: string
+    timelineType?: string
+  },
+): void {
+  expect(mocks.sendResponse).toHaveBeenLastCalledWith(
+    id,
+    { ok: true },
+    changedTables,
+    undefined,
+    changeHint,
+  )
+}
+
+describe('SQLite worker entrypoint', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.stubGlobal('self', { postMessage })
+
+    mocks.getDb.mockReturnValue(db)
+    mocks.getSqlite3Module.mockReturnValue(sqlite3)
+    mocks.getTableVersionsMap.mockReturnValue(new Map([['posts', 4]]))
+    mocks.captureTableVersions.mockReturnValue({
+      posts: 4,
+      timeline_entries: 2,
+    })
+    mocks.resolveLocalAccountId.mockReturnValue(11)
+    mocks.resolvePostIdInternal.mockReturnValue(22)
+    mocks.buildTimelineKey.mockReturnValue('tag:vitest')
+    mocks.isSqliteCorruptError.mockReturnValue(false)
+    mocks.isDatabaseHealthy.mockReturnValue(true)
+    mocks.recoverFromCorruption.mockResolvedValue('restored')
+
+    mocks.init.mockResolvedValue({ persistence: 'opfs' })
+    mocks.handleExportDatabase.mockResolvedValue(undefined)
+    mocks.handleExec.mockReturnValue({
+      durationMs: 2.5,
+      result: [['row']],
+    })
+    mocks.handleExecBatch.mockReturnValue({ 1: [['batch']] })
+
+    for (const handler of [
+      mocks.handleAddNotification,
+      mocks.handleBulkAddNotifications,
+      mocks.handleBulkUpsertCustomEmojis,
+      mocks.handleBulkUpsertStatuses,
+      mocks.handleDeleteEvent,
+      mocks.handleEnsureLocalAccount,
+      mocks.handleRemoveFromTimeline,
+      mocks.handleToggleReaction,
+      mocks.handleUpdateNotificationStatusAction,
+      mocks.handleUpdateStatus,
+      mocks.handleUpdateStatusAction,
+      mocks.handleUpsertStatus,
+    ]) {
+      handler.mockReturnValue({ changedTables: ['posts'] })
+    }
+
+    mocks.handleEnforceMaxLength.mockReturnValue({
+      changedTables: ['timeline_entries', 'posts'],
+      deletedCounts: {
+        notifications: 2,
+        posts: 3,
+        timeline_entries: 1,
+      },
+      hasMore: true,
+      phaseTimings: {
+        notifications: 2,
+        phase1Total: 3,
+        phase2Total: 4,
+        postsCount: 1,
+        postsDelete: 3,
+        timeline: 1,
+        total: 7,
+      },
+    })
+    mocks.runQueryPlan.mockReturnValue({
+      stepResults: [],
+      totalDurationMs: 8,
+    })
+    mocks.runGraphPlan.mockReturnValue({
+      meta: { totalDurationMs: 9 },
+      rows: [],
+    })
+    mocks.runFlatFetch.mockReturnValue({
+      meta: { totalDurationMs: 10 },
+      rows: [],
+    })
+    mocks.handleFetchTimeline.mockReturnValue({ phase1Rows: [] })
+
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(async () => {
+    await vi.waitFor(() => {
+      expect(
+        mocks.recoverFromCorruption.mock.settledResults,
+      ).not.toContainEqual(expect.objectContaining({ state: 'pending' }))
+    })
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  describe('initialization and export messages', () => {
+    it('initializes from the supplied origin and publishes persistence details', async () => {
+      mocks.init.mockResolvedValue({
+        persistence: 'opfs',
+        recovered: 'reset',
+      })
+
+      dispatch({ origin: 'https://app.example', type: '__init' })
+
+      await vi.waitFor(() => {
+        expect(postMessage).toHaveBeenCalledWith({
+          persistence: 'opfs',
+          recovered: 'reset',
+          type: 'init',
+        })
+      })
+      expect(mocks.init).toHaveBeenCalledWith('https://app.example')
+      expect(mocks.getDb).not.toHaveBeenCalled()
+    })
+
+    it.each([
+      [new Error('WASM unavailable'), 'WASM unavailable'],
+      ['initialization rejected', 'initialization rejected'],
+    ])('reports initialization failures', async (error, message) => {
+      mocks.init.mockRejectedValue(error)
+
+      dispatch({ origin: 'https://app.example', type: '__init' })
+
+      await vi.waitFor(() => {
+        expect(postMessage).toHaveBeenCalledWith({
+          error: message,
+          id: -1,
+          type: 'error',
+        })
+      })
+      expect(console.error).toHaveBeenCalledWith(
+        'SQLite Worker: initialization failed:',
+        error,
+      )
+    })
+
+    it('exports the database and acknowledges completion', async () => {
+      dispatch({ id: 31, type: 'exportDatabase' })
+
+      await vi.waitFor(() => {
+        expect(mocks.sendResponse).toHaveBeenCalledWith(31, { ok: true })
+      })
+      expect(mocks.handleExportDatabase).toHaveBeenCalledOnce()
+      expect(mocks.getDb).not.toHaveBeenCalled()
+    })
+
+    it('reports export errors through the common error channel', async () => {
+      const error = new Error('export failed')
+      mocks.handleExportDatabase.mockRejectedValue(error)
+
+      dispatch({ id: 32, type: 'exportDatabase' })
+
+      await vi.waitFor(() => {
+        expect(mocks.sendError).toHaveBeenCalledWith(32, error)
+      })
+    })
+  })
+
+  describe('generic execution requests', () => {
+    it('dispatches exec with bind and return options and preserves duration', () => {
+      dispatch({
+        bind: [7, 'value'],
+        id: 1,
+        returnValue: 'resultRows',
+        sql: 'SELECT * FROM posts WHERE id = ?',
+        type: 'exec',
+      })
+
+      expect(mocks.handleExec).toHaveBeenCalledWith(
+        'SELECT * FROM posts WHERE id = ?',
+        [7, 'value'],
+        'resultRows',
+      )
+      expect(mocks.sendResponse).toHaveBeenCalledWith(
+        1,
+        [['row']],
+        undefined,
+        2.5,
+      )
+    })
+
+    it('dispatches transaction batches with all execution options', () => {
+      const statements = [{ bind: [1], sql: 'DELETE FROM posts WHERE id = ?' }]
+
+      dispatch({
+        id: 2,
+        returnIndices: [0],
+        rollbackOnError: true,
+        statements,
+        type: 'execBatch',
+      })
+
+      expect(mocks.handleExecBatch).toHaveBeenCalledWith(statements, true, [0])
+      expect(mocks.sendResponse).toHaveBeenCalledWith(2, {
+        1: [['batch']],
+      })
+    })
+
+    it('answers readiness probes without invoking a database handler', () => {
+      dispatch({ id: 3, type: 'ready' })
+
+      expect(mocks.sendResponse).toHaveBeenCalledWith(3, true)
+      expect(mocks.handleExec).not.toHaveBeenCalled()
+      expect(mocks.handleExecBatch).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('status mutation requests', () => {
+    it('upserts one status with a scoped change hint', () => {
+      dispatch({
+        backendUrl: 'https://social.example',
+        id: 10,
+        statusJson: '{"id":"one"}',
+        tag: 'vitest',
+        timelineType: 'tag',
+        type: 'upsertStatus',
+      })
+
+      expect(mocks.handleUpsertStatus).toHaveBeenCalledWith(
+        db,
+        '{"id":"one"}',
+        'https://social.example',
+        'tag',
+        'vitest',
+      )
+      expectOkResponse(10, ['posts'], {
+        backendUrl: 'https://social.example',
+        tag: 'vitest',
+        timelineType: 'tag',
+      })
+    })
+
+    it('bulk-upserts statuses and forwards the profile update policy', () => {
+      dispatch({
+        backendUrl: 'https://social.example',
+        id: 11,
+        skipProfileUpdate: true,
+        statusesJson: ['{"id":"one"}', '{"id":"two"}'],
+        timelineType: 'home',
+        type: 'bulkUpsertStatuses',
+      })
+
+      expect(mocks.handleBulkUpsertStatuses).toHaveBeenCalledWith(
+        db,
+        ['{"id":"one"}', '{"id":"two"}'],
+        'https://social.example',
+        'home',
+        undefined,
+        true,
+      )
+      expectOkResponse(11, ['posts'], {
+        backendUrl: 'https://social.example',
+        tag: undefined,
+        timelineType: 'home',
+      })
+    })
+
+    it('updates an interaction for the resolved local account', () => {
+      dispatch({
+        action: 'favourited',
+        backendUrl: 'https://social.example',
+        id: 12,
+        statusId: 'remote-12',
+        type: 'updateStatusAction',
+        value: true,
+      })
+
+      expect(mocks.handleUpdateStatusAction).toHaveBeenCalledWith(
+        db,
+        11,
+        'remote-12',
+        'favourited',
+        true,
+      )
+      expectOkResponse(12, ['posts'], {
+        backendUrl: 'https://social.example',
+      })
+    })
+
+    it('treats an interaction update without a local account as a no-op', () => {
+      mocks.resolveLocalAccountId.mockReturnValue(null)
+
+      dispatch({
+        action: 'bookmarked',
+        backendUrl: 'https://missing.example',
+        id: 13,
+        statusId: 'remote-13',
+        type: 'updateStatusAction',
+        value: false,
+      })
+
+      expect(mocks.handleUpdateStatusAction).not.toHaveBeenCalled()
+      expect(mocks.sendResponse).toHaveBeenCalledWith(13, { ok: true }, [])
+    })
+
+    it('updates a complete status document', () => {
+      dispatch({
+        backendUrl: 'https://social.example',
+        id: 14,
+        statusJson: '{"id":"edited"}',
+        type: 'updateStatus',
+      })
+
+      expect(mocks.handleUpdateStatus).toHaveBeenCalledWith(
+        db,
+        '{"id":"edited"}',
+        'https://social.example',
+      )
+      expectOkResponse(14, ['posts'], {
+        backendUrl: 'https://social.example',
+      })
+    })
+
+    it('deletes a status for the resolved account with source context', () => {
+      dispatch({
+        backendUrl: 'https://social.example',
+        id: 15,
+        sourceTimelineType: 'local',
+        statusId: 'remote-15',
+        tag: 'news',
+        type: 'handleDeleteEvent',
+      })
+
+      expect(mocks.handleDeleteEvent).toHaveBeenCalledWith(db, 11, 'remote-15')
+      expectOkResponse(15, ['posts'], {
+        backendUrl: 'https://social.example',
+        tag: 'news',
+        timelineType: 'local',
+      })
+    })
+
+    it('treats delete without a local account as a no-op', () => {
+      mocks.resolveLocalAccountId.mockReturnValue(undefined)
+
+      dispatch({
+        backendUrl: 'https://missing.example',
+        id: 16,
+        sourceTimelineType: 'home',
+        statusId: 'remote-16',
+        type: 'handleDeleteEvent',
+      })
+
+      expect(mocks.handleDeleteEvent).not.toHaveBeenCalled()
+      expect(mocks.sendResponse).toHaveBeenCalledWith(16, { ok: true }, [])
+    })
+
+    it('resolves account, timeline key, and post before removing an entry', () => {
+      dispatch({
+        backendUrl: 'https://social.example',
+        id: 17,
+        statusId: 'remote-17',
+        tag: 'vitest',
+        timelineType: 'tag',
+        type: 'removeFromTimeline',
+      })
+
+      expect(mocks.buildTimelineKey).toHaveBeenCalledWith('tag', {
+        tag: 'vitest',
+      })
+      expect(mocks.resolvePostIdInternal).toHaveBeenCalledWith(
+        db,
+        11,
+        'remote-17',
+      )
+      expect(mocks.handleRemoveFromTimeline).toHaveBeenCalledWith(
+        db,
+        11,
+        'tag:vitest',
+        22,
+      )
+      expectOkResponse(17, ['posts'], {
+        backendUrl: 'https://social.example',
+        tag: 'vitest',
+        timelineType: 'tag',
+      })
+    })
+
+    it('does not resolve a post when timeline removal has no local account', () => {
+      mocks.resolveLocalAccountId.mockReturnValue(null)
+
+      dispatch({
+        backendUrl: 'https://missing.example',
+        id: 18,
+        statusId: 'remote-18',
+        timelineType: 'home',
+        type: 'removeFromTimeline',
+      })
+
+      expect(mocks.buildTimelineKey).not.toHaveBeenCalled()
+      expect(mocks.resolvePostIdInternal).not.toHaveBeenCalled()
+      expect(mocks.handleRemoveFromTimeline).not.toHaveBeenCalled()
+      expect(mocks.sendResponse).toHaveBeenCalledWith(18, { ok: true }, [])
+    })
+
+    it('does not remove a timeline entry when the remote post is unknown', () => {
+      mocks.resolvePostIdInternal.mockReturnValue(null)
+
+      dispatch({
+        backendUrl: 'https://social.example',
+        id: 19,
+        statusId: 'missing-post',
+        timelineType: 'home',
+        type: 'removeFromTimeline',
+      })
+
+      expect(mocks.buildTimelineKey).toHaveBeenCalledWith('home', {
+        tag: undefined,
+      })
+      expect(mocks.handleRemoveFromTimeline).not.toHaveBeenCalled()
+      expect(mocks.sendResponse).toHaveBeenCalledWith(19, { ok: true }, [])
+    })
+  })
+
+  describe('notification, cleanup, account, and emoji requests', () => {
+    it('adds a notification and forwards its backend change hint', () => {
+      dispatch({
+        backendUrl: 'https://social.example',
+        id: 20,
+        notificationJson: '{"id":"notification"}',
+        type: 'addNotification',
+      })
+
+      expect(mocks.handleAddNotification).toHaveBeenCalledWith(
+        db,
+        '{"id":"notification"}',
+        'https://social.example',
+      )
+      expectOkResponse(20, ['posts'], {
+        backendUrl: 'https://social.example',
+      })
+    })
+
+    it('adds a batch of notifications', () => {
+      dispatch({
+        backendUrl: 'https://social.example',
+        id: 21,
+        notificationsJson: ['{"id":"one"}', '{"id":"two"}'],
+        type: 'bulkAddNotifications',
+      })
+
+      expect(mocks.handleBulkAddNotifications).toHaveBeenCalledWith(
+        db,
+        ['{"id":"one"}', '{"id":"two"}'],
+        'https://social.example',
+      )
+      expectOkResponse(21, ['posts'], {
+        backendUrl: 'https://social.example',
+      })
+    })
+
+    it('updates status actions embedded in notifications', () => {
+      dispatch({
+        action: 'reblogged',
+        backendUrl: 'https://social.example',
+        id: 22,
+        statusId: 'remote-22',
+        type: 'updateNotificationStatusAction',
+        value: true,
+      })
+
+      expect(mocks.handleUpdateNotificationStatusAction).toHaveBeenCalledWith(
+        db,
+        'https://social.example',
+        'remote-22',
+        'reblogged',
+        true,
+      )
+      expectOkResponse(22, ['posts'], {
+        backendUrl: 'https://social.example',
+      })
+    })
+
+    it('enforces cleanup limits and returns progress details', () => {
+      dispatch({
+        batchLimit: 25,
+        id: 23,
+        mode: 'emergency',
+        targetRatio: 0.4,
+        type: 'enforceMaxLength',
+      })
+
+      expect(mocks.handleEnforceMaxLength).toHaveBeenCalledWith(
+        db,
+        100,
+        200,
+        300,
+        {
+          batchLimit: 25,
+          mode: 'emergency',
+          targetRatio: 0.4,
+        },
+      )
+      expect(mocks.sendResponse).toHaveBeenCalledWith(
+        23,
+        {
+          deletedCounts: {
+            notifications: 2,
+            posts: 3,
+            timeline_entries: 1,
+          },
+          hasMore: true,
+          ok: true,
+          phaseTimings: {
+            notifications: 2,
+            phase1Total: 3,
+            phase2Total: 4,
+            postsCount: 1,
+            postsDelete: 3,
+            timeline: 1,
+            total: 7,
+          },
+        },
+        ['timeline_entries', 'posts'],
+      )
+    })
+
+    it('ensures the active local account exists', () => {
+      dispatch({
+        accountJson: '{"id":"me"}',
+        backendUrl: 'https://social.example',
+        id: 24,
+        type: 'ensureLocalAccount',
+      })
+
+      expect(mocks.handleEnsureLocalAccount).toHaveBeenCalledWith(
+        db,
+        'https://social.example',
+        '{"id":"me"}',
+      )
+      expect(mocks.sendResponse).toHaveBeenCalledWith(24, { ok: true }, [
+        'posts',
+      ])
+    })
+
+    it('toggles a reaction for the resolved local account', () => {
+      dispatch({
+        backendUrl: 'https://social.example',
+        emoji: ':blobcat:',
+        id: 25,
+        statusId: 'remote-25',
+        type: 'toggleReaction',
+        value: true,
+      })
+
+      expect(mocks.handleToggleReaction).toHaveBeenCalledWith(
+        db,
+        11,
+        'remote-25',
+        true,
+        ':blobcat:',
+      )
+      expectOkResponse(25, ['posts'], {
+        backendUrl: 'https://social.example',
+      })
+    })
+
+    it('treats a reaction without a local account as a no-op', () => {
+      mocks.resolveLocalAccountId.mockReturnValue(null)
+
+      dispatch({
+        backendUrl: 'https://missing.example',
+        emoji: '👍',
+        id: 26,
+        statusId: 'remote-26',
+        type: 'toggleReaction',
+        value: false,
+      })
+
+      expect(mocks.handleToggleReaction).not.toHaveBeenCalled()
+      expect(mocks.sendResponse).toHaveBeenCalledWith(26, { ok: true }, [])
+    })
+
+    it('upserts a backend custom emoji catalog', () => {
+      dispatch({
+        backendUrl: 'https://social.example',
+        emojisJson: '[{"shortcode":"blobcat"}]',
+        id: 27,
+        type: 'bulkUpsertCustomEmojis',
+      })
+
+      expect(mocks.handleBulkUpsertCustomEmojis).toHaveBeenCalledWith(
+        db,
+        'https://social.example',
+        '[{"shortcode":"blobcat"}]',
+      )
+      expect(mocks.sendResponse).toHaveBeenCalledWith(27, { ok: true }, [
+        'posts',
+      ])
+    })
+  })
+
+  describe('query and timeline requests', () => {
+    it('adds captured versions to legacy query-plan results', () => {
+      const plan = { meta: {}, steps: [] }
+
+      dispatch({ id: 40, plan, type: 'executeQueryPlan' })
+
+      expect(mocks.runQueryPlan).toHaveBeenCalledWith(db, plan)
+      expect(mocks.captureTableVersions).toHaveBeenCalledOnce()
+      expect(mocks.sendResponse).toHaveBeenCalledWith(
+        40,
+        {
+          capturedVersions: {
+            posts: 4,
+            timeline_entries: 2,
+          },
+          stepResults: [],
+          totalDurationMs: 8,
+        },
+        undefined,
+        8,
+      )
+    })
+
+    it('synchronizes cache versions before executing a graph plan', () => {
+      const options = { limit: 30 }
+      const plan = { nodes: [] }
+
+      dispatch({ id: 41, options, plan, type: 'executeGraphPlan' })
+
+      expect(mocks.syncGraphCacheVersions).toHaveBeenCalledWith(
+        mocks.getTableVersionsMap.mock.results[0].value,
+      )
+      expect(mocks.runGraphPlan).toHaveBeenCalledWith(
+        db,
+        plan,
+        options,
+        mocks.captureTableVersions,
+      )
+      expect(mocks.sendResponse).toHaveBeenCalledWith(
+        41,
+        {
+          meta: { totalDurationMs: 9 },
+          rows: [],
+        },
+        undefined,
+        9,
+      )
+    })
+
+    it('executes a flat entity fetch and reports its duration', () => {
+      const request = { ids: [1, 2], sourceType: 'post' }
+
+      dispatch({ id: 42, request, type: 'executeFlatFetch' })
+
+      expect(mocks.runFlatFetch).toHaveBeenCalledWith(db, request)
+      expect(mocks.sendResponse).toHaveBeenCalledWith(
+        42,
+        {
+          meta: { totalDurationMs: 10 },
+          rows: [],
+        },
+        undefined,
+        10,
+      )
+    })
+
+    it('delegates complete timeline fetching to its specialized handler', () => {
+      const message = {
+        batchSqls: {},
+        id: 43,
+        phase1: { bind: [], sql: 'SELECT id FROM posts' },
+        phase2BaseSql: 'SELECT * FROM posts WHERE id IN ({IDS})',
+        type: 'fetchTimeline',
+      }
+
+      dispatch(message)
+
+      expect(mocks.handleFetchTimeline).toHaveBeenCalledWith(message)
+      expect(mocks.sendResponse).toHaveBeenCalledWith(43, {
+        phase1Rows: [],
+      })
+    })
+  })
+
+  describe('dispatch and runtime recovery failures', () => {
+    it('reports unknown request types with the original request id', () => {
+      dispatch({ id: 50, type: 'futureRequest' })
+
+      expect(mocks.sendError).toHaveBeenCalledWith(
+        50,
+        'Unknown message type: futureRequest',
+      )
+    })
+
+    it('reports ordinary handler errors without attempting recovery', () => {
+      const error = new Error('query syntax error')
+      mocks.handleExec.mockImplementation(() => {
+        throw error
+      })
+
+      dispatch({ id: 51, sql: 'invalid SQL', type: 'exec' })
+
+      expect(mocks.sendError).toHaveBeenCalledWith(51, error)
+      expect(mocks.isSqliteCorruptError).toHaveBeenCalledWith(error)
+      expect(mocks.recoverFromCorruption).not.toHaveBeenCalled()
+    })
+
+    it.each([
+      ['restored', 'Restored from backup'],
+      ['reset', 'Reset to empty database'],
+      ['failed', 'Recovery failed'],
+    ])(
+      'publishes the %s runtime recovery outcome and invalidates all tables',
+      async (method, reason) => {
+        const corruption = new Error('database disk image is malformed')
+        mocks.handleExec.mockImplementation(() => {
+          throw corruption
+        })
+        mocks.isSqliteCorruptError.mockReturnValue(true)
+        mocks.recoverFromCorruption.mockResolvedValue(method)
+
+        dispatch({ id: 52, sql: 'SELECT * FROM posts', type: 'exec' })
+
+        await vi.waitFor(() => {
+          expect(postMessage).toHaveBeenCalledWith({
+            method,
+            reason,
+            type: 'db-recovered',
+          })
+        })
+        expect(mocks.sendError).toHaveBeenCalledWith(52, corruption)
+        expect(mocks.recoverFromCorruption).toHaveBeenCalledWith(db, sqlite3)
+        expect(mocks.isDatabaseHealthy).toHaveBeenCalledWith(db)
+        expect(mocks.bumpTableVersions).toHaveBeenCalledWith([
+          'cards',
+          'hashtags',
+          'local_accounts',
+          'notifications',
+          'poll_options',
+          'polls',
+          'post_backend_ids',
+          'post_custom_emojis',
+          'post_hashtags',
+          'post_interactions',
+          'post_media',
+          'post_mentions',
+          'post_stats',
+          'posts',
+          'profile_custom_emojis',
+          'profiles',
+          'servers',
+          'timeline_entries',
+        ])
+      },
+    )
+
+    it('warns when recovery finishes but the database is still unhealthy', async () => {
+      mocks.handleExec.mockImplementation(() => {
+        throw new Error('SQLITE_CORRUPT')
+      })
+      mocks.isSqliteCorruptError.mockReturnValue(true)
+      mocks.isDatabaseHealthy.mockReturnValue(false)
+      mocks.recoverFromCorruption.mockResolvedValue('reset')
+
+      dispatch({ id: 53, sql: 'SELECT 1', type: 'exec' })
+
+      await vi.waitFor(() => {
+        expect(console.error).toHaveBeenCalledWith(
+          'SQLite Worker: runtime recovery completed but DB still corrupt',
+        )
+      })
+      expect(postMessage).toHaveBeenCalledWith({
+        method: 'reset',
+        reason: 'Reset to empty database',
+        type: 'db-recovered',
+      })
+    })
+
+    it.each([
+      [new Error('backup restore exploded'), 'backup restore exploded'],
+      ['non-error rejection', 'non-error rejection'],
+    ])('publishes failures thrown by recovery', async (error, message) => {
+      mocks.handleExec.mockImplementation(() => {
+        throw new Error('SQLITE_CORRUPT')
+      })
+      mocks.isSqliteCorruptError.mockReturnValue(true)
+      mocks.recoverFromCorruption.mockRejectedValue(error)
+
+      dispatch({ id: 54, sql: 'SELECT 1', type: 'exec' })
+
+      await vi.waitFor(() => {
+        expect(postMessage).toHaveBeenCalledWith({
+          method: 'failed',
+          reason: `Recovery error: ${message}`,
+          type: 'db-recovered',
+        })
+      })
+      expect(console.error).toHaveBeenCalledWith(
+        'SQLite Worker: runtime recovery failed:',
+        error,
+      )
+    })
+
+    it.each([
+      ['database', null, sqlite3],
+      ['SQLite module', db, null],
+    ])(
+      'abandons runtime recovery safely when the %s is unavailable',
+      (_dependency, activeDb, activeSqlite3) => {
+        mocks.getDb.mockReturnValue(activeDb)
+        mocks.getSqlite3Module.mockReturnValue(activeSqlite3)
+        mocks.handleExec.mockImplementation(() => {
+          throw new Error('SQLITE_CORRUPT')
+        })
+        mocks.isSqliteCorruptError.mockReturnValue(true)
+
+        dispatch({ id: 55, sql: 'SELECT 1', type: 'exec' })
+
+        expect(mocks.recoverFromCorruption).not.toHaveBeenCalled()
+        expect(postMessage).not.toHaveBeenCalled()
+
+        dispatch({ id: 56, type: 'ready' })
+        expect(mocks.sendResponse).toHaveBeenCalledWith(56, true)
+      },
+    )
+
+    it('rejects messages received while asynchronous recovery is active', async () => {
+      let finishRecovery: (result: 'restored') => void = () => {
+        throw new Error('Recovery promise was not initialized')
+      }
+      const pendingRecovery = new Promise<'restored'>((resolve) => {
+        finishRecovery = resolve
+      })
+      mocks.handleExec.mockImplementation(() => {
+        throw new Error('SQLITE_CORRUPT')
+      })
+      mocks.isSqliteCorruptError.mockReturnValue(true)
+      mocks.recoverFromCorruption.mockReturnValue(pendingRecovery)
+
+      dispatch({ id: 57, sql: 'SELECT 1', type: 'exec' })
+      dispatch({ id: 58, type: 'ready' })
+
+      expect(mocks.sendError).toHaveBeenLastCalledWith(
+        58,
+        'Database recovery in progress',
+      )
+      expect(mocks.sendResponse).not.toHaveBeenCalledWith(58, true)
+      expect(mocks.getDb).toHaveBeenCalledTimes(2)
+
+      finishRecovery('restored')
+      await vi.waitFor(() => {
+        expect(postMessage).toHaveBeenCalledWith({
+          method: 'restored',
+          reason: 'Restored from backup',
+          type: 'db-recovered',
+        })
+      })
+
+      dispatch({ id: 59, type: 'ready' })
+      expect(mocks.sendResponse).toHaveBeenCalledWith(59, true)
+    })
+  })
+})

--- a/src/util/db/sqlite/worker/__tests__/workerExportHandler.test.ts
+++ b/src/util/db/sqlite/worker/__tests__/workerExportHandler.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { isDatabaseHealthy } = vi.hoisted(() => ({
+  isDatabaseHealthy: vi.fn(),
+}))
+
+vi.mock('util/db/sqlite/worker/workerRecovery', () => ({
+  isDatabaseHealthy,
+}))
+
+import { handleExportDatabase } from 'util/db/sqlite/worker/workerExportHandler'
+import { setDb, setSqlite3Module } from 'util/db/sqlite/worker/workerState'
+
+describe('handleExportDatabase', () => {
+  beforeEach(() => {
+    isDatabaseHealthy.mockReset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+    setDb(null)
+    setSqlite3Module(null)
+  })
+
+  it('rejects when the database or sqlite module is unavailable', async () => {
+    setDb(null)
+    setSqlite3Module({ capi: {} })
+    await expect(handleExportDatabase()).rejects.toThrow(
+      'Database or sqlite3 module not initialized',
+    )
+
+    setDb({ exec: vi.fn() })
+    setSqlite3Module(null)
+    await expect(handleExportDatabase()).rejects.toThrow(
+      'Database or sqlite3 module not initialized',
+    )
+  })
+
+  it('preserves the existing backup when the database is unhealthy', async () => {
+    const db = { exec: vi.fn() }
+    setDb(db)
+    setSqlite3Module({ capi: {} })
+    isDatabaseHealthy.mockReturnValue(false)
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await handleExportDatabase()
+
+    expect(db.exec).not.toHaveBeenCalled()
+    expect(warn).toHaveBeenCalledWith(
+      'SQLite Worker: skipping export — database is corrupt, preserving existing backup',
+    )
+  })
+
+  it('checkpoints, copies, and writes a healthy database to OPFS', async () => {
+    const db = { exec: vi.fn() }
+    const bytes = new Uint8Array([1, 2, 3, 4])
+    const sqlite3Module = {
+      capi: { sqlite3_js_db_export: vi.fn().mockReturnValue(bytes) },
+    }
+    const write = vi.fn().mockResolvedValue(undefined)
+    const close = vi.fn().mockResolvedValue(undefined)
+    const createWritable = vi.fn().mockResolvedValue({ close, write })
+    const getFileHandle = vi.fn().mockResolvedValue({ createWritable })
+    const getDirectory = vi.fn().mockResolvedValue({ getFileHandle })
+    vi.stubGlobal('navigator', { storage: { getDirectory } })
+    const info = vi.spyOn(console, 'info').mockImplementation(() => {})
+    setDb(db)
+    setSqlite3Module(sqlite3Module)
+    isDatabaseHealthy.mockReturnValue(true)
+
+    await handleExportDatabase()
+
+    expect(db.exec).toHaveBeenCalledWith('PRAGMA wal_checkpoint(PASSIVE);')
+    expect(sqlite3Module.capi.sqlite3_js_db_export).toHaveBeenCalledWith(db)
+    expect(getFileHandle).toHaveBeenCalledWith('miyulab-fe-backup.sqlite3', {
+      create: true,
+    })
+    expect(write).toHaveBeenCalledOnce()
+    const copiedBytes = write.mock.calls[0][0] as Uint8Array
+    expect(copiedBytes).toEqual(bytes)
+    expect(copiedBytes).not.toBe(bytes)
+    expect(close).toHaveBeenCalledOnce()
+    expect(info).toHaveBeenCalledWith(
+      'SQLite Worker: exported database (0.0 KB) to OPFS',
+    )
+  })
+})

--- a/src/util/db/sqlite/worker/__tests__/workerInit.test.ts
+++ b/src/util/db/sqlite/worker/__tests__/workerInit.test.ts
@@ -1,0 +1,266 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  ensureSchema: vi.fn(),
+  isDatabaseHealthy: vi.fn(),
+  loadSqliteWasmInitializer: vi.fn(),
+  recoverFromCorruption: vi.fn(),
+  setDb: vi.fn(),
+  setSqlite3Module: vi.fn(),
+}))
+
+vi.mock('util/db/sqlite/sqliteWasmLoader', () => ({
+  loadSqliteWasmInitializer: mocks.loadSqliteWasmInitializer,
+}))
+
+vi.mock('util/db/sqlite/schema', () => ({
+  ensureSchema: mocks.ensureSchema,
+}))
+
+vi.mock('util/db/sqlite/worker/workerRecovery', () => ({
+  isDatabaseHealthy: mocks.isDatabaseHealthy,
+  recoverFromCorruption: mocks.recoverFromCorruption,
+}))
+
+vi.mock('util/db/sqlite/worker/workerState', () => ({
+  setDb: mocks.setDb,
+  setSqlite3Module: mocks.setSqlite3Module,
+}))
+
+import { init } from 'util/db/sqlite/worker/workerInit'
+
+function mockDbConstructor(db: object) {
+  return vi.fn(function MockDb() {
+    return db
+  })
+}
+
+function createDb() {
+  return {
+    close: vi.fn(),
+    exec: vi.fn(),
+  }
+}
+
+function createSqlite3({
+  memoryDb = createDb(),
+  opfsDb = createDb(),
+  opfsError,
+  sahDb = createDb(),
+  sahError,
+}: {
+  memoryDb?: ReturnType<typeof createDb>
+  opfsDb?: ReturnType<typeof createDb>
+  opfsError?: Error
+  sahDb?: ReturnType<typeof createDb>
+  sahError?: Error
+} = {}) {
+  const OpfsSAHPoolDb = mockDbConstructor(sahDb)
+  const installOpfsSAHPoolVfs = sahError
+    ? vi.fn().mockRejectedValue(sahError)
+    : vi.fn().mockResolvedValue({ OpfsSAHPoolDb })
+  const OpfsDb = opfsError
+    ? vi.fn(function OpfsDb() {
+        throw opfsError
+      })
+    : mockDbConstructor(opfsDb)
+
+  return {
+    DB: mockDbConstructor(memoryDb),
+    installOpfsSAHPoolVfs,
+    memoryDb,
+    OpfsDb,
+    OpfsSAHPoolDb,
+    opfsDb,
+    sahDb,
+    sqlite3: {
+      installOpfsSAHPoolVfs,
+      oo1: {
+        DB: mockDbConstructor(memoryDb),
+        OpfsDb,
+      },
+    },
+  }
+}
+
+function expectPragmas(db: ReturnType<typeof createDb>) {
+  expect(db.exec.mock.calls.map(([sql]) => sql)).toEqual([
+    'PRAGMA journal_mode=WAL;',
+    'PRAGMA synchronous=NORMAL;',
+    'PRAGMA foreign_keys = ON;',
+    'PRAGMA cache_size = -8000;',
+    'PRAGMA temp_store = MEMORY;',
+  ])
+}
+
+describe('workerInit', () => {
+  const origin = 'https://app.example'
+  let wasmBinary: ArrayBuffer
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+    wasmBinary = new ArrayBuffer(16)
+    fetchMock = vi.fn().mockResolvedValue({
+      arrayBuffer: vi.fn().mockResolvedValue(wasmBinary),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    mocks.isDatabaseHealthy.mockReturnValue(true)
+    vi.spyOn(console, 'info').mockImplementation(() => {})
+    vi.spyOn(console, 'debug').mockImplementation(() => {})
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('loads WASM and opens an OPFS SAH Pool database', async () => {
+    const setup = createSqlite3()
+    const sqliteInitializer = vi.fn().mockResolvedValue(setup.sqlite3)
+    mocks.loadSqliteWasmInitializer.mockResolvedValue(sqliteInitializer)
+
+    await expect(init(origin)).resolves.toEqual({ persistence: 'opfs' })
+
+    expect(fetchMock).toHaveBeenCalledWith(`${origin}/sqlite3.wasm`)
+    expect(mocks.loadSqliteWasmInitializer).toHaveBeenCalledWith(origin)
+    const moduleOptions = sqliteInitializer.mock.calls[0][0]
+    expect(moduleOptions.wasmBinary).toBe(wasmBinary)
+    expect(moduleOptions.locateFile('sqlite3.wasm')).toBe(
+      `${origin}/sqlite3.wasm`,
+    )
+    expect(setup.installOpfsSAHPoolVfs).toHaveBeenCalledWith({
+      directory: '/miyulab-fe',
+      name: 'opfs-sahpool',
+    })
+    expect(setup.OpfsSAHPoolDb).toHaveBeenCalledWith('/miyulab-fe.sqlite3')
+    expectPragmas(setup.sahDb)
+    expect(mocks.ensureSchema).toHaveBeenCalledWith({ db: setup.sahDb })
+    expect(mocks.isDatabaseHealthy).toHaveBeenCalledWith(setup.sahDb)
+    expect(mocks.setSqlite3Module).toHaveBeenCalledWith(setup.sqlite3)
+    expect(mocks.setDb).toHaveBeenCalledWith(setup.sahDb)
+  })
+
+  it('falls back to standard OPFS when the SAH Pool is unavailable', async () => {
+    const setup = createSqlite3({
+      sahError: new Error('SAH unavailable'),
+    })
+    const sqliteInitializer = vi.fn().mockResolvedValue(setup.sqlite3)
+    mocks.loadSqliteWasmInitializer.mockResolvedValue(sqliteInitializer)
+
+    await expect(init(origin)).resolves.toEqual({ persistence: 'opfs' })
+
+    expect(setup.OpfsDb).toHaveBeenCalledWith('/miyulab-fe.sqlite3', 'c')
+    expectPragmas(setup.opfsDb)
+    expect(mocks.setDb).toHaveBeenCalledWith(setup.opfsDb)
+  })
+
+  it('falls back to memory when neither OPFS implementation is available', async () => {
+    const setup = createSqlite3({
+      opfsError: new Error('OPFS unavailable'),
+      sahError: new Error('SAH unavailable'),
+    })
+    const sqliteInitializer = vi.fn().mockResolvedValue(setup.sqlite3)
+    mocks.loadSqliteWasmInitializer.mockResolvedValue(sqliteInitializer)
+
+    await expect(init(origin)).resolves.toEqual({ persistence: 'memory' })
+
+    expect(setup.sqlite3.oo1.DB).toHaveBeenCalledWith(':memory:', 'c')
+    expectPragmas(setup.memoryDb)
+    expect(mocks.ensureSchema).toHaveBeenCalledWith({ db: setup.memoryDb })
+    expect(mocks.isDatabaseHealthy).not.toHaveBeenCalled()
+    expect(mocks.recoverFromCorruption).not.toHaveBeenCalled()
+    expect(mocks.setDb).toHaveBeenCalledWith(setup.memoryDb)
+  })
+
+  it.each(['restored', 'reset'] as const)(
+    'keeps OPFS after a successful %s recovery',
+    async (recoveryResult) => {
+      const setup = createSqlite3()
+      const sqliteInitializer = vi.fn().mockResolvedValue(setup.sqlite3)
+      mocks.loadSqliteWasmInitializer.mockResolvedValue(sqliteInitializer)
+      mocks.isDatabaseHealthy
+        .mockReturnValueOnce(false)
+        .mockReturnValueOnce(true)
+      mocks.recoverFromCorruption.mockResolvedValue(recoveryResult)
+
+      await expect(init(origin)).resolves.toEqual({
+        persistence: 'opfs',
+        recovered: recoveryResult,
+      })
+
+      expect(mocks.recoverFromCorruption).toHaveBeenCalledWith(
+        setup.sahDb,
+        setup.sqlite3,
+      )
+      expect(mocks.isDatabaseHealthy).toHaveBeenCalledTimes(2)
+      expect(setup.sahDb.close).not.toHaveBeenCalled()
+      expect(mocks.setDb).toHaveBeenCalledWith(setup.sahDb)
+    },
+  )
+
+  it('uses a fresh memory database when recovery fails', async () => {
+    const memoryDb = createDb()
+    const setup = createSqlite3({ memoryDb })
+    const sqliteInitializer = vi.fn().mockResolvedValue(setup.sqlite3)
+    mocks.loadSqliteWasmInitializer.mockResolvedValue(sqliteInitializer)
+    mocks.isDatabaseHealthy.mockReturnValue(false)
+    mocks.recoverFromCorruption.mockResolvedValue('failed')
+
+    await expect(init(origin)).resolves.toEqual({
+      persistence: 'memory',
+      recovered: 'reset',
+    })
+
+    expect(setup.sahDb.close).toHaveBeenCalledOnce()
+    expect(setup.sqlite3.oo1.DB).toHaveBeenCalledWith(':memory:', 'c')
+    expectPragmas(memoryDb)
+    expect(mocks.ensureSchema).toHaveBeenNthCalledWith(1, { db: setup.sahDb })
+    expect(mocks.ensureSchema).toHaveBeenNthCalledWith(2, { db: memoryDb })
+    expect(mocks.setDb).toHaveBeenCalledWith(memoryDb)
+  })
+
+  it('uses memory when recovery reports success but health remains bad', async () => {
+    const memoryDb = createDb()
+    const setup = createSqlite3({ memoryDb })
+    const sqliteInitializer = vi.fn().mockResolvedValue(setup.sqlite3)
+    mocks.loadSqliteWasmInitializer.mockResolvedValue(sqliteInitializer)
+    mocks.isDatabaseHealthy.mockReturnValue(false)
+    mocks.recoverFromCorruption.mockResolvedValue('restored')
+
+    await expect(init(origin)).resolves.toEqual({
+      persistence: 'memory',
+      recovered: 'reset',
+    })
+
+    expect(mocks.isDatabaseHealthy).toHaveBeenCalledTimes(2)
+    expect(setup.sahDb.close).toHaveBeenCalledOnce()
+    expect(mocks.setDb).toHaveBeenCalledWith(memoryDb)
+  })
+
+  it('continues with memory fallback when closing corrupt OPFS throws', async () => {
+    const memoryDb = createDb()
+    const sahDb = createDb()
+    sahDb.close.mockImplementation(() => {
+      throw new Error('close failed')
+    })
+    const setup = createSqlite3({ memoryDb, sahDb })
+    const sqliteInitializer = vi.fn().mockResolvedValue(setup.sqlite3)
+    mocks.loadSqliteWasmInitializer.mockResolvedValue(sqliteInitializer)
+    mocks.isDatabaseHealthy.mockReturnValue(false)
+    mocks.recoverFromCorruption.mockResolvedValue('failed')
+
+    await expect(init(origin)).resolves.toEqual({
+      persistence: 'memory',
+      recovered: 'reset',
+    })
+
+    expect(console.debug).toHaveBeenCalledWith(
+      'SQLite Worker: ignore error closing database before fallback',
+      expect.any(Error),
+    )
+    expect(mocks.setDb).toHaveBeenCalledWith(memoryDb)
+  })
+})

--- a/src/util/db/sqlite/worker/__tests__/workerRecovery.test.ts
+++ b/src/util/db/sqlite/worker/__tests__/workerRecovery.test.ts
@@ -1,0 +1,422 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const schemaMocks = vi.hoisted(() => ({
+  createFreshSchema: vi.fn(),
+  dropAllTables: vi.fn(),
+  ensureSchema: vi.fn(),
+}))
+
+vi.mock('util/db/sqlite/schema', () => schemaMocks)
+
+import {
+  isDatabaseHealthy,
+  isSqliteCorruptError,
+  recoverFromCorruption,
+} from 'util/db/sqlite/worker/workerRecovery'
+
+function mockDbHealth(healthy: boolean) {
+  return {
+    close: vi.fn(),
+    exec: vi.fn((sql: string) => {
+      if (sql === 'PRAGMA quick_check(1);') {
+        return [[healthy ? 'ok' : 'corrupt']]
+      }
+      return undefined
+    }),
+  }
+}
+
+function mockDbConstructor(db: object) {
+  return vi.fn(function MockDb() {
+    return db
+  })
+}
+
+function createSqlite3({
+  backupDb = mockDbHealth(true),
+  backupInit = { id: 'backup' },
+  backupStepResult = 101,
+  deserializeResult = 0,
+  supportsDeserialize = true,
+}: {
+  backupDb?: ReturnType<typeof mockDbHealth>
+  backupInit?: object | null
+  backupStepResult?: number
+  deserializeResult?: number
+  supportsDeserialize?: boolean
+} = {}) {
+  const heap = new Uint8Array(64)
+  const capi = {
+    sqlite3_backup_finish: vi.fn(),
+    sqlite3_backup_init: vi.fn().mockReturnValue(backupInit),
+    sqlite3_backup_step: vi.fn().mockReturnValue(backupStepResult),
+    sqlite3_deserialize: supportsDeserialize
+      ? vi.fn().mockReturnValue(deserializeResult)
+      : undefined,
+  }
+
+  return {
+    capi,
+    heap,
+    oo1: { DB: mockDbConstructor(backupDb) },
+    wasm: {
+      alloc: vi.fn().mockReturnValue(7),
+      heap8u: vi.fn().mockReturnValue(heap),
+    },
+  }
+}
+
+function stubBackupFile(bytes: number[]) {
+  const arrayBuffer = Uint8Array.from(bytes).buffer
+  const getFile = vi.fn().mockResolvedValue({
+    arrayBuffer: vi.fn().mockResolvedValue(arrayBuffer),
+  })
+  const getFileHandle = vi.fn().mockResolvedValue({ getFile })
+  const getDirectory = vi.fn().mockResolvedValue({ getFileHandle })
+  vi.stubGlobal('navigator', { storage: { getDirectory } })
+
+  return { getDirectory, getFile, getFileHandle }
+}
+
+describe('workerRecovery health and error detection', () => {
+  it('accepts only an ok quick_check result', () => {
+    const healthyDb = mockDbHealth(true)
+    const unhealthyDb = mockDbHealth(false)
+
+    expect(isDatabaseHealthy(healthyDb)).toBe(true)
+    expect(isDatabaseHealthy(unhealthyDb)).toBe(false)
+    expect(
+      isDatabaseHealthy({ exec: vi.fn().mockReturnValue(undefined) }),
+    ).toBe(false)
+  })
+
+  it('treats a quick_check exception as an unhealthy database', () => {
+    const db = {
+      exec: vi.fn(() => {
+        throw new Error('cannot read page')
+      }),
+    }
+
+    expect(isDatabaseHealthy(db)).toBe(false)
+  })
+
+  it.each([
+    new Error('SQLITE_CORRUPT: damaged'),
+    'database disk image is malformed',
+    new Error('sqlite result code 11'),
+  ])('recognizes SQLite corruption errors: %s', (error) => {
+    expect(isSqliteCorruptError(error)).toBe(true)
+  })
+
+  it.each([
+    new Error('SQLITE_BUSY'),
+    'constraint failed',
+    { message: 'SQLITE_CORRUPT' },
+    null,
+  ])('does not misclassify other values: %s', (error) => {
+    expect(isSqliteCorruptError(error)).toBe(false)
+  })
+})
+
+describe('recoverFromCorruption backup restore', () => {
+  beforeEach(() => {
+    schemaMocks.createFreshSchema.mockReset()
+    schemaMocks.dropAllTables.mockReset()
+    schemaMocks.ensureSchema.mockReset()
+    vi.spyOn(console, 'info').mockImplementation(() => {})
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('restores a healthy OPFS backup and upgrades its schema', async () => {
+    const backupDb = mockDbHealth(true)
+    const db = mockDbHealth(true)
+    const sqlite3 = createSqlite3({ backupDb })
+    const backup = stubBackupFile([1, 2, 3, 4])
+
+    await expect(recoverFromCorruption(db, sqlite3)).resolves.toBe('restored')
+
+    expect(backup.getFileHandle).toHaveBeenCalledWith(
+      'miyulab-fe-backup.sqlite3',
+    )
+    expect(sqlite3.oo1.DB).toHaveBeenCalledWith(':memory:', 'c')
+    expect(sqlite3.wasm.alloc).toHaveBeenCalledWith(4)
+    expect([...sqlite3.heap.slice(7, 11)]).toEqual([1, 2, 3, 4])
+    expect(sqlite3.capi.sqlite3_deserialize).toHaveBeenCalledWith(
+      backupDb,
+      'main',
+      7,
+      4,
+      4,
+      3,
+    )
+    expect(sqlite3.capi.sqlite3_backup_init).toHaveBeenCalledWith(
+      db,
+      'main',
+      backupDb,
+      'main',
+    )
+    expect(sqlite3.capi.sqlite3_backup_step).toHaveBeenCalledWith(
+      { id: 'backup' },
+      -1,
+    )
+    expect(sqlite3.capi.sqlite3_backup_finish).toHaveBeenCalledWith({
+      id: 'backup',
+    })
+    expect(backupDb.close).toHaveBeenCalledOnce()
+    expect(schemaMocks.ensureSchema).toHaveBeenCalledWith({ db })
+    expect(schemaMocks.dropAllTables).not.toHaveBeenCalled()
+  })
+
+  it('skips backup restore when deserialize is unavailable', async () => {
+    const db = mockDbHealth(true)
+    const sqlite3 = createSqlite3({ supportsDeserialize: false })
+
+    await expect(recoverFromCorruption(db, sqlite3)).resolves.toBe('reset')
+
+    expect(schemaMocks.dropAllTables).toHaveBeenCalledWith({ db })
+    expect(schemaMocks.createFreshSchema).toHaveBeenCalledWith({ db })
+    expect(db.exec.mock.calls.map(([sql]) => sql)).toEqual([
+      'PRAGMA user_version = 0;',
+      'BEGIN;',
+      'PRAGMA user_version = 20007;',
+      'COMMIT;',
+      'VACUUM;',
+    ])
+  })
+
+  it('resets when no OPFS backup file exists', async () => {
+    const getFileHandle = vi.fn().mockRejectedValue(new Error('not found'))
+    vi.stubGlobal('navigator', {
+      storage: {
+        getDirectory: vi.fn().mockResolvedValue({ getFileHandle }),
+      },
+    })
+    const db = mockDbHealth(true)
+    const sqlite3 = createSqlite3()
+
+    await expect(recoverFromCorruption(db, sqlite3)).resolves.toBe('reset')
+
+    expect(getFileHandle).toHaveBeenCalledWith('miyulab-fe-backup.sqlite3')
+    expect(sqlite3.wasm.alloc).not.toHaveBeenCalled()
+  })
+
+  it('resets when the OPFS backup file is empty', async () => {
+    stubBackupFile([])
+    const db = mockDbHealth(true)
+    const sqlite3 = createSqlite3()
+
+    await expect(recoverFromCorruption(db, sqlite3)).resolves.toBe('reset')
+
+    expect(sqlite3.wasm.alloc).not.toHaveBeenCalled()
+    expect(sqlite3.oo1.DB).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    {
+      name: 'deserialize fails',
+      options: { deserializeResult: 1 },
+    },
+    {
+      name: 'the backup is corrupt',
+      options: { backupDb: mockDbHealth(false) },
+    },
+    {
+      name: 'backup initialization fails',
+      options: { backupInit: null },
+    },
+    {
+      name: 'backup copying fails',
+      options: { backupStepResult: 5 },
+    },
+  ])('resets when $name', async ({ options }) => {
+    stubBackupFile([9, 8, 7])
+    const db = mockDbHealth(true)
+    const sqlite3 = createSqlite3(options)
+
+    await expect(recoverFromCorruption(db, sqlite3)).resolves.toBe('reset')
+
+    expect(schemaMocks.dropAllTables).toHaveBeenCalledWith({ db })
+    expect(schemaMocks.ensureSchema).not.toHaveBeenCalled()
+  })
+
+  it('resets when the copied backup does not repair the destination', async () => {
+    stubBackupFile([9, 8, 7])
+    const db = mockDbHealth(false)
+    const sqlite3 = createSqlite3()
+
+    await expect(recoverFromCorruption(db, sqlite3)).resolves.toBe('reset')
+
+    expect(sqlite3.capi.sqlite3_backup_finish).toHaveBeenCalledOnce()
+    expect(schemaMocks.dropAllTables).toHaveBeenCalledWith({ db })
+  })
+
+  it('falls back to reset when reading the backup throws', async () => {
+    const getDirectory = vi.fn().mockRejectedValue(new Error('OPFS failed'))
+    vi.stubGlobal('navigator', { storage: { getDirectory } })
+    const db = mockDbHealth(true)
+    const sqlite3 = createSqlite3()
+
+    await expect(recoverFromCorruption(db, sqlite3)).resolves.toBe('reset')
+
+    expect(console.warn).toHaveBeenCalledWith(
+      'SQLite Worker: backup restoration failed:',
+      expect.any(Error),
+    )
+  })
+
+  it('closes the temporary database when restore setup throws', async () => {
+    stubBackupFile([1])
+    const backupDb = mockDbHealth(true)
+    const sqlite3 = createSqlite3({ backupDb })
+    sqlite3.wasm.alloc.mockImplementation(() => {
+      throw new Error('allocation failed')
+    })
+    const db = mockDbHealth(true)
+
+    await expect(recoverFromCorruption(db, sqlite3)).resolves.toBe('reset')
+
+    expect(backupDb.close).toHaveBeenCalledOnce()
+  })
+})
+
+describe('recoverFromCorruption reset fallbacks', () => {
+  beforeEach(() => {
+    schemaMocks.createFreshSchema.mockReset()
+    schemaMocks.dropAllTables.mockReset()
+    schemaMocks.ensureSchema.mockReset()
+    vi.spyOn(console, 'info').mockImplementation(() => {})
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('overwrites the database from a fresh memory database when VACUUM fails', async () => {
+    const db = mockDbHealth(true)
+    db.exec.mockImplementation((sql: string) => {
+      if (sql === 'VACUUM;') {
+        throw new Error('vacuum failed')
+      }
+      return undefined
+    })
+    const memoryDb = mockDbHealth(true)
+    const sqlite3 = createSqlite3({
+      backupDb: memoryDb,
+      supportsDeserialize: false,
+    })
+
+    await expect(recoverFromCorruption(db, sqlite3)).resolves.toBe('reset')
+
+    expect(memoryDb.exec.mock.calls.map(([sql]) => sql)).toEqual([
+      'PRAGMA foreign_keys = ON;',
+      'BEGIN;',
+      'PRAGMA user_version = 20007;',
+      'COMMIT;',
+    ])
+    expect(schemaMocks.createFreshSchema).toHaveBeenNthCalledWith(1, { db })
+    expect(schemaMocks.createFreshSchema).toHaveBeenNthCalledWith(2, {
+      db: memoryDb,
+    })
+    expect(sqlite3.capi.sqlite3_backup_init).toHaveBeenCalledWith(
+      db,
+      'main',
+      memoryDb,
+      'main',
+    )
+    expect(memoryDb.close).toHaveBeenCalledOnce()
+  })
+
+  it('reports failure when memory backup initialization fails', async () => {
+    const db = mockDbHealth(true)
+    db.exec.mockImplementation((sql: string) => {
+      if (sql === 'VACUUM;') throw new Error('vacuum failed')
+      return undefined
+    })
+    const memoryDb = mockDbHealth(true)
+    const sqlite3 = createSqlite3({
+      backupDb: memoryDb,
+      backupInit: null,
+      supportsDeserialize: false,
+    })
+
+    await expect(recoverFromCorruption(db, sqlite3)).resolves.toBe('failed')
+
+    expect(memoryDb.close).toHaveBeenCalledOnce()
+    expect(sqlite3.capi.sqlite3_backup_step).not.toHaveBeenCalled()
+  })
+
+  it('reports failure when memory backup copying fails', async () => {
+    const db = mockDbHealth(true)
+    db.exec.mockImplementation((sql: string) => {
+      if (sql === 'VACUUM;') throw new Error('vacuum failed')
+      return undefined
+    })
+    const memoryDb = mockDbHealth(true)
+    const sqlite3 = createSqlite3({
+      backupDb: memoryDb,
+      backupStepResult: 10,
+      supportsDeserialize: false,
+    })
+
+    await expect(recoverFromCorruption(db, sqlite3)).resolves.toBe('failed')
+
+    expect(sqlite3.capi.sqlite3_backup_finish).toHaveBeenCalledOnce()
+    expect(memoryDb.close).toHaveBeenCalledOnce()
+  })
+
+  it('rolls back a failed DROP/CREATE and uses the memory backup fallback', async () => {
+    const db = mockDbHealth(true)
+    schemaMocks.dropAllTables.mockImplementationOnce(() => {
+      throw new Error('drop failed')
+    })
+    const memoryDb = mockDbHealth(true)
+    const sqlite3 = createSqlite3({
+      backupDb: memoryDb,
+      supportsDeserialize: false,
+    })
+
+    await expect(recoverFromCorruption(db, sqlite3)).resolves.toBe('reset')
+
+    expect(db.exec).toHaveBeenCalledWith('ROLLBACK;')
+    expect(sqlite3.capi.sqlite3_backup_step).toHaveBeenCalledOnce()
+  })
+
+  it('reports failure when both schema reset paths throw', async () => {
+    const db = mockDbHealth(true)
+    db.exec.mockImplementation((sql: string) => {
+      if (sql === 'ROLLBACK;') throw new Error('rollback failed')
+      return undefined
+    })
+    schemaMocks.dropAllTables.mockImplementationOnce(() => {
+      throw new Error('drop failed')
+    })
+    schemaMocks.createFreshSchema.mockImplementationOnce(() => {
+      throw new Error('memory schema failed')
+    })
+    const memoryDb = mockDbHealth(true)
+    memoryDb.close.mockImplementation(() => {
+      throw new Error('close failed')
+    })
+    const sqlite3 = createSqlite3({
+      backupDb: memoryDb,
+      supportsDeserialize: false,
+    })
+
+    await expect(recoverFromCorruption(db, sqlite3)).resolves.toBe('failed')
+
+    expect(db.exec).toHaveBeenCalledWith('ROLLBACK;')
+    expect(console.error).toHaveBeenCalledWith(
+      'SQLite Worker: backup-based reset failed:',
+      expect.any(Error),
+    )
+  })
+})

--- a/src/util/db/sqlite/worker/__tests__/workerUtilities.test.ts
+++ b/src/util/db/sqlite/worker/__tests__/workerUtilities.test.ts
@@ -1,0 +1,373 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { logSlowQueryExplain } = vi.hoisted(() => ({
+  logSlowQueryExplain: vi.fn(),
+}))
+
+vi.mock('util/db/sqlite/explainLogger', () => ({
+  logSlowQueryExplain,
+}))
+
+import {
+  handleExec,
+  handleExecBatch,
+} from 'util/db/sqlite/worker/workerExecHandlers'
+import { handleFetchTimeline } from 'util/db/sqlite/worker/workerFetchTimelineHandler'
+import {
+  sendError,
+  sendResponse,
+} from 'util/db/sqlite/worker/workerMessageHelpers'
+import {
+  bumpTableVersions,
+  captureTableVersions,
+  getDb,
+  getSqlite3Module,
+  getTableVersionsMap,
+  setDb,
+  setSqlite3Module,
+} from 'util/db/sqlite/worker/workerState'
+
+describe('worker state and message helpers', () => {
+  const postMessage = vi.fn()
+
+  beforeEach(() => {
+    postMessage.mockReset()
+    vi.stubGlobal('self', { postMessage })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    setDb(null)
+    setSqlite3Module(null)
+  })
+
+  it('stores the active database and sqlite module', () => {
+    const db = { exec: vi.fn() }
+    const sqlite3Module = { capi: {} }
+
+    setDb(db)
+    setSqlite3Module(sqlite3Module)
+
+    expect(getDb()).toBe(db)
+    expect(getSqlite3Module()).toBe(sqlite3Module)
+  })
+
+  it('increments and captures table versions', () => {
+    const before = captureTableVersions().posts ?? 0
+
+    bumpTableVersions(undefined)
+    bumpTableVersions(['posts'])
+    bumpTableVersions(['posts'])
+
+    expect(captureTableVersions().posts).toBe(before + 2)
+    expect(getTableVersionsMap().get('posts')).toBe(before + 2)
+  })
+
+  it('posts a response and increments versions for changed tables', () => {
+    const before = captureTableVersions().timeline_entries ?? 0
+
+    sendResponse(42, { ok: true }, ['timeline_entries'], 12.5, {
+      backendUrl: 'https://example.com',
+      timelineType: 'home',
+    })
+
+    expect(captureTableVersions().timeline_entries).toBe(before + 1)
+    expect(postMessage).toHaveBeenCalledWith({
+      changedTables: ['timeline_entries'],
+      changeHint: {
+        backendUrl: 'https://example.com',
+        timelineType: 'home',
+      },
+      durationMs: 12.5,
+      id: 42,
+      result: { ok: true },
+      type: 'response',
+    })
+  })
+
+  it.each([
+    [new Error('broken'), 'broken'],
+    ['plain failure', 'plain failure'],
+  ])('normalizes worker errors before posting', (error, expected) => {
+    sendError(7, error)
+
+    expect(postMessage).toHaveBeenCalledWith({
+      error: expected,
+      id: 7,
+      type: 'error',
+    })
+  })
+})
+
+describe('worker exec handlers', () => {
+  beforeEach(() => {
+    logSlowQueryExplain.mockReset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    setDb(null)
+  })
+
+  it('returns result rows and records the worker execution duration', () => {
+    const rows = [[1, 'hello']]
+    const exec = vi.fn().mockReturnValue(rows)
+    setDb({ exec })
+    vi.spyOn(performance, 'now')
+      .mockReturnValueOnce(100)
+      .mockReturnValueOnce(125)
+
+    expect(handleExec('SELECT value FROM items', [1], 'resultRows')).toEqual({
+      durationMs: 25,
+      result: rows,
+    })
+    expect(exec).toHaveBeenCalledWith('SELECT value FROM items', {
+      bind: [1],
+      returnValue: 'resultRows',
+    })
+    expect(logSlowQueryExplain).toHaveBeenCalledWith(
+      { exec },
+      'SELECT value FROM items',
+      [1],
+      25,
+    )
+  })
+
+  it('executes statements without requesting rows', () => {
+    const exec = vi.fn()
+    setDb({ exec })
+    vi.spyOn(performance, 'now').mockReturnValue(10)
+
+    expect(handleExec('DELETE FROM items')).toEqual({
+      durationMs: 0,
+      result: undefined,
+    })
+    expect(exec).toHaveBeenCalledWith('DELETE FROM items', {
+      bind: undefined,
+    })
+  })
+
+  it('commits a batch and returns only requested statement results', () => {
+    const exec = vi
+      .fn()
+      .mockReturnValueOnce(undefined)
+      .mockReturnValueOnce([['first']])
+      .mockReturnValueOnce([['second']])
+      .mockReturnValueOnce(undefined)
+    setDb({ exec })
+    vi.spyOn(performance, 'now').mockReturnValue(0)
+
+    const result = handleExecBatch(
+      [
+        { returnValue: 'resultRows', sql: 'SELECT 1' },
+        { returnValue: 'resultRows', sql: 'SELECT 2' },
+      ],
+      true,
+      [1],
+    )
+
+    expect(result).toEqual({ 1: [['second']] })
+    expect(exec.mock.calls.map(([sql]) => sql)).toEqual([
+      'BEGIN;',
+      'SELECT 1',
+      'SELECT 2',
+      'COMMIT;',
+    ])
+  })
+
+  it('returns all statement entries when returnIndices is omitted', () => {
+    const exec = vi
+      .fn()
+      .mockReturnValueOnce([['first']])
+      .mockReturnValueOnce(undefined)
+    setDb({ exec })
+    vi.spyOn(performance, 'now').mockReturnValue(0)
+
+    expect(
+      handleExecBatch(
+        [
+          { returnValue: 'resultRows', sql: 'SELECT 1' },
+          { sql: 'UPDATE items SET value = 1' },
+        ],
+        false,
+      ),
+    ).toEqual({ 0: [['first']], 1: undefined })
+  })
+
+  it('rolls back and rethrows when a statement fails', () => {
+    const failure = new Error('constraint failed')
+    const exec = vi
+      .fn()
+      .mockReturnValueOnce(undefined)
+      .mockImplementationOnce(() => {
+        throw failure
+      })
+      .mockReturnValueOnce(undefined)
+    setDb({ exec })
+    vi.spyOn(performance, 'now').mockReturnValue(0)
+
+    expect(() =>
+      handleExecBatch([{ sql: 'INSERT INTO items VALUES (1)' }], true),
+    ).toThrow(failure)
+    expect(exec.mock.calls.map(([sql]) => sql)).toEqual([
+      'BEGIN;',
+      'INSERT INTO items VALUES (1)',
+      'ROLLBACK;',
+    ])
+  })
+
+  it('preserves the original error when rollback also fails', () => {
+    const failure = new Error('insert failed')
+    const exec = vi
+      .fn()
+      .mockReturnValueOnce(undefined)
+      .mockImplementationOnce(() => {
+        throw failure
+      })
+      .mockImplementationOnce(() => {
+        throw new Error('rollback failed')
+      })
+    setDb({ exec })
+    vi.spyOn(performance, 'now').mockReturnValue(0)
+
+    expect(() =>
+      handleExecBatch([{ sql: 'INSERT INTO items VALUES (1)' }], true),
+    ).toThrow(failure)
+  })
+})
+
+describe('handleFetchTimeline', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    setDb(null)
+  })
+
+  it('returns empty detail and batch results when phase 1 finds no posts', () => {
+    const exec = vi.fn().mockReturnValue([])
+    setDb({ exec })
+    vi.spyOn(performance, 'now').mockReturnValueOnce(50).mockReturnValueOnce(53)
+
+    const result = handleFetchTimeline({
+      batchSqls: {
+        belongingTags: 'tags {IDS}',
+        customEmojis: 'emojis {IDS}',
+        interactions: 'interactions {IDS}',
+        media: 'media {IDS}',
+        mentions: 'mentions {IDS}',
+        polls: 'polls {IDS}',
+        profileEmojis: 'profile-emojis {IDS}',
+        timelineTypes: 'timelines {IDS}',
+      },
+      phase1: { bind: ['home'], sql: 'phase 1' },
+      phase2BaseSql: 'phase 2 {IDS}',
+    })
+
+    expect(result).toEqual({
+      batchResults: {
+        belongingTags: [],
+        customEmojis: [],
+        interactions: [],
+        media: [],
+        mentions: [],
+        polls: [],
+        profileEmojis: [],
+        timelineTypes: [],
+      },
+      phase1Rows: [],
+      phase2Rows: [],
+      totalDurationMs: 3,
+    })
+    expect(exec).toHaveBeenCalledOnce()
+  })
+
+  it('fetches details and batches for posts and unique reblogs', () => {
+    const phase1Rows = [[10], [20]]
+    const firstPhase2Row = new Array(26).fill(null)
+    const secondPhase2Row = new Array(26).fill(null)
+    firstPhase2Row[25] = 30
+    secondPhase2Row[25] = 10
+    const phase2Rows = [firstPhase2Row, secondPhase2Row]
+    const batchRows = [[10, 'batch']]
+    const exec = vi
+      .fn()
+      .mockReturnValueOnce(phase1Rows)
+      .mockReturnValueOnce(phase2Rows)
+      .mockReturnValue(batchRows)
+    setDb({ exec })
+    vi.spyOn(performance, 'now')
+      .mockReturnValueOnce(100)
+      .mockReturnValueOnce(115)
+
+    const result = handleFetchTimeline({
+      batchSqls: {
+        belongingTags: 'tags IN ({IDS})',
+        customEmojis: 'emojis IN ({IDS})',
+        interactions: 'interactions IN ({IDS})',
+        media: 'media IN ({IDS})',
+        mentions: 'mentions IN ({IDS})',
+        polls: 'polls IN ({IDS})',
+        profileEmojis: 'profile-emojis IN ({IDS})',
+        timelineTypes: 'timelines IN ({IDS})',
+      },
+      phase1: { bind: ['home'], sql: 'phase 1' },
+      phase2BaseSql: 'phase 2 IN ({IDS})',
+    })
+
+    expect(result.phase1Rows).toBe(phase1Rows)
+    expect(result.phase2Rows).toBe(phase2Rows)
+    expect(result.totalDurationMs).toBe(15)
+    expect(result.batchResults.interactions).toBe(batchRows)
+    expect(exec).toHaveBeenNthCalledWith(2, 'phase 2 IN (?,?)', {
+      bind: [10, 20],
+      returnValue: 'resultRows',
+    })
+    for (const [, options] of exec.mock.calls.slice(2)) {
+      expect(options).toEqual({
+        bind: [10, 20, 30],
+        returnValue: 'resultRows',
+      })
+    }
+    expect(exec.mock.calls.slice(2).map(([sql]) => sql)).toEqual([
+      'tags IN (?,?,?)',
+      'emojis IN (?,?,?)',
+      'interactions IN (?,?,?)',
+      'media IN (?,?,?)',
+      'mentions IN (?,?,?)',
+      'polls IN (?,?,?)',
+      'profile-emojis IN (?,?,?)',
+      'timelines IN (?,?,?)',
+    ])
+  })
+
+  it('uses a custom reblog column index', () => {
+    const phase2Row = [1, 99]
+    const exec = vi
+      .fn()
+      .mockReturnValueOnce([[1]])
+      .mockReturnValueOnce([phase2Row])
+      .mockReturnValue([])
+    setDb({ exec })
+    vi.spyOn(performance, 'now').mockReturnValue(0)
+
+    handleFetchTimeline({
+      batchSqls: {
+        belongingTags: '{IDS}',
+        customEmojis: '{IDS}',
+        interactions: '{IDS}',
+        media: '{IDS}',
+        mentions: '{IDS}',
+        polls: '{IDS}',
+        profileEmojis: '{IDS}',
+        timelineTypes: '{IDS}',
+      },
+      phase1: { sql: 'phase 1' },
+      phase2BaseSql: '{IDS}',
+      reblogPostIdColumnIndex: 1,
+    })
+
+    expect(exec).toHaveBeenNthCalledWith(3, '?,?', {
+      bind: [1, 99],
+      returnValue: 'resultRows',
+    })
+  })
+})

--- a/src/util/db/sqlite/workerClient/messageHandler.test.ts
+++ b/src/util/db/sqlite/workerClient/messageHandler.test.ts
@@ -1,0 +1,268 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ALL_TABLE_NAMES, type WorkerMessage } from '../protocol'
+import { handleMessage, onSlowQueryLogs } from './messageHandler'
+import {
+  durationForId,
+  getInitReject,
+  getInitResolve,
+  getInitTimer,
+  pending,
+  setInitReject,
+  setInitResolve,
+  setInitTimer,
+  setNotifyChangeCallback,
+  setSlowQueryLogCallback,
+} from './state'
+
+const dbQueueMocks = vi.hoisted(() => ({
+  startSnapshotRecording: vi.fn(),
+}))
+
+vi.mock('../../dbQueue', () => dbQueueMocks)
+
+function dispatch(message: WorkerMessage): void {
+  handleMessage({ data: message } as MessageEvent<WorkerMessage>)
+}
+
+function resetMessageHandlerState(): void {
+  for (const request of pending.values()) {
+    clearTimeout(request.timer)
+  }
+  pending.clear()
+  durationForId.clear()
+  const initTimer = getInitTimer()
+  if (initTimer != null) {
+    clearTimeout(initTimer)
+  }
+  setInitTimer(null)
+  setInitResolve(null)
+  setInitReject(null)
+  setNotifyChangeCallback(null)
+  setSlowQueryLogCallback(null)
+}
+
+describe('workerClient messageHandler', () => {
+  beforeEach(() => {
+    resetMessageHandlerState()
+    dbQueueMocks.startSnapshotRecording.mockReset()
+  })
+
+  afterEach(() => {
+    resetMessageHandlerState()
+    vi.restoreAllMocks()
+  })
+
+  it('初期化待ちでない init メッセージは無視する', () => {
+    dispatch({ persistence: 'memory', type: 'init' })
+
+    expect(dbQueueMocks.startSnapshotRecording).not.toHaveBeenCalled()
+  })
+
+  it('init を解決し、初期化タイマーとコールバックをクリアする', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    let resolveInit!: (persistence: 'opfs' | 'memory') => void
+    let rejectInit!: (error: Error) => void
+    const init = new Promise<'opfs' | 'memory'>((resolve, reject) => {
+      resolveInit = resolve
+      rejectInit = reject
+    })
+    setInitResolve(resolveInit)
+    setInitReject(rejectInit)
+    setInitTimer(setTimeout(() => undefined, 60_000))
+
+    dispatch({
+      persistence: 'opfs',
+      recovered: 'restored',
+      type: 'init',
+    })
+
+    await expect(init).resolves.toBe('opfs')
+    expect(dbQueueMocks.startSnapshotRecording).toHaveBeenCalledOnce()
+    expect(warn).toHaveBeenCalledWith(
+      'SQLite: database was recovered at startup (restored)',
+    )
+    expect(getInitResolve()).toBeNull()
+    expect(getInitReject()).toBeNull()
+    expect(getInitTimer()).toBeNull()
+  })
+
+  it('通常の init ではリカバリ警告を出さない', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    let resolveInit!: (persistence: 'opfs' | 'memory') => void
+    const init = new Promise<'opfs' | 'memory'>((resolve) => {
+      resolveInit = resolve
+    })
+    setInitResolve(resolveInit)
+
+    dispatch({ persistence: 'memory', type: 'init' })
+
+    await expect(init).resolves.toBe('memory')
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('response を pending へ dispatch し、変更テーブルごとに同じ enriched hint を通知する', () => {
+    const resolve = vi.fn()
+    const reject = vi.fn()
+    const timer = setTimeout(() => undefined, 60_000)
+    pending.set(7, { kind: 'other', reject, resolve, timer })
+    const notify = vi.fn()
+    setNotifyChangeCallback(notify)
+
+    dispatch({
+      changedTables: ['posts', 'post_interactions'],
+      changeHint: { backendUrl: 'https://example.test', timelineType: 'home' },
+      durationMs: 12.5,
+      id: 7,
+      result: { ok: true },
+      type: 'response',
+    })
+
+    expect(pending.has(7)).toBe(false)
+    expect(resolve).toHaveBeenCalledWith({ ok: true })
+    expect(reject).not.toHaveBeenCalled()
+    expect(notify).toHaveBeenCalledTimes(2)
+    expect(notify.mock.calls).toEqual([
+      [
+        'posts',
+        {
+          backendUrl: 'https://example.test',
+          changedTables: ['posts', 'post_interactions'],
+          timelineType: 'home',
+        },
+      ],
+      [
+        'post_interactions',
+        {
+          backendUrl: 'https://example.test',
+          changedTables: ['posts', 'post_interactions'],
+          timelineType: 'home',
+        },
+      ],
+    ])
+    expect(durationForId.get(7)).toBe(12.5)
+    clearTimeout(timer)
+  })
+
+  it('変更情報のない response も解決し、不明な id の response は無視する', () => {
+    const resolve = vi.fn()
+    const timer = setTimeout(() => undefined, 60_000)
+    pending.set(8, {
+      kind: 'timeline',
+      reject: vi.fn(),
+      resolve,
+      timer,
+    })
+    const notify = vi.fn()
+    setNotifyChangeCallback(notify)
+
+    dispatch({ id: 8, result: 'done', type: 'response' })
+    dispatch({
+      changedTables: ['posts'],
+      durationMs: 4,
+      id: 999,
+      result: 'late',
+      type: 'response',
+    })
+
+    expect(resolve).toHaveBeenCalledWith('done')
+    expect(notify).not.toHaveBeenCalled()
+    expect(durationForId.has(8)).toBe(false)
+    expect(durationForId.has(999)).toBe(false)
+    clearTimeout(timer)
+  })
+
+  it('id=-1 の初期化エラーを初期化 Promise へ転送してタイマーを解除する', async () => {
+    let rejectInit!: (error: Error) => void
+    const init = new Promise<never>((_, reject) => {
+      rejectInit = reject
+    })
+    const rejection = expect(init).rejects.toThrowError('OPFS unavailable')
+    setInitReject(rejectInit)
+    setInitResolve(vi.fn())
+    setInitTimer(setTimeout(() => undefined, 60_000))
+
+    dispatch({ error: 'OPFS unavailable', id: -1, type: 'error' })
+
+    await rejection
+    expect(getInitReject()).toBeNull()
+    expect(getInitResolve()).toBeNull()
+    expect(getInitTimer()).toBeNull()
+  })
+
+  it('通常の error は対応する pending だけを reject する', () => {
+    const reject = vi.fn()
+    const timer = setTimeout(() => undefined, 60_000)
+    pending.set(9, {
+      kind: 'priority',
+      reject,
+      resolve: vi.fn(),
+      timer,
+    })
+
+    dispatch({ error: 'query failed', id: 9, type: 'error' })
+    dispatch({ error: 'late error', id: 999, type: 'error' })
+
+    expect(pending.has(9)).toBe(false)
+    expect(reject).toHaveBeenCalledOnce()
+    expect(reject.mock.calls[0][0]).toEqual(new Error('query failed'))
+    clearTimeout(timer)
+  })
+
+  it('初期化 reject がなければ id=-1 も通常の pending error として扱う', () => {
+    const reject = vi.fn()
+    const timer = setTimeout(() => undefined, 60_000)
+    pending.set(-1, {
+      kind: 'other',
+      reject,
+      resolve: vi.fn(),
+      timer,
+    })
+
+    dispatch({ error: 'late init error', id: -1, type: 'error' })
+
+    expect(reject).toHaveBeenCalledOnce()
+    expect(pending.has(-1)).toBe(false)
+    clearTimeout(timer)
+  })
+
+  it('slowQueryLogs の購読と解除を行う', () => {
+    const callback = vi.fn()
+    const unsubscribe = onSlowQueryLogs(callback)
+    const logs = [
+      {
+        bind: '[]',
+        durationMs: 250,
+        explainPlan: 'SCAN posts',
+        sql: 'SELECT * FROM posts',
+        timestamp: '2026-07-30T00:00:00.000Z',
+        userAgent: 'vitest',
+      },
+    ]
+
+    dispatch({ logs, type: 'slowQueryLogs' })
+    expect(callback).toHaveBeenCalledWith(logs)
+
+    unsubscribe()
+    dispatch({ logs, type: 'slowQueryLogs' })
+    expect(callback).toHaveBeenCalledOnce()
+  })
+
+  it('実行時 DB リカバリでは全テーブルの再読込を通知する', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const notify = vi.fn()
+    setNotifyChangeCallback(notify)
+
+    dispatch({
+      method: 'reset',
+      reason: 'integrity check failed',
+      type: 'db-recovered',
+    })
+
+    expect(warn).toHaveBeenCalledWith(
+      'SQLite: database recovered at runtime (reset): integrity check failed',
+    )
+    expect(notify).toHaveBeenCalledTimes(ALL_TABLE_NAMES.length)
+    expect(notify.mock.calls.map(([table]) => table)).toEqual(ALL_TABLE_NAMES)
+    expect(notify.mock.calls.every(([, hint]) => hint === undefined)).toBe(true)
+  })
+})

--- a/src/util/db/sqlite/workerClient/publicApi.test.ts
+++ b/src/util/db/sqlite/workerClient/publicApi.test.ts
@@ -1,0 +1,658 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { setQueuePriority, stopSnapshotRecording } from '../../dbQueue'
+import type { FlatFetchRequest } from '../../query-ir/executor/flatFetchTypes'
+import type {
+  GraphExecuteOptions,
+  SerializedGraphPlan,
+} from '../../query-ir/executor/types'
+import {
+  clearIdCollectCache,
+  getCachedIdCollect,
+} from '../../query-ir/idCollectCache'
+import type {
+  FetchTimelineRequest,
+  QueryPlanResult,
+  SerializedExecutionPlan,
+} from '../protocol'
+import {
+  execAsync,
+  execAsyncTimed,
+  execBatch,
+  executeFlatFetch,
+  executeGraphPlan,
+  executeQueryPlan,
+  fetchTimeline,
+  initWorker,
+  sendCommand,
+  terminateWorker,
+} from './publicApi'
+import {
+  durationForId,
+  getActiveRequest,
+  getConsecutiveOther,
+  getInitPromise,
+  getInitReject,
+  getInitResolve,
+  getInitTimer,
+  getNotifyChangeCallback,
+  getSlowQueryLogCallback,
+  getWorker,
+  INIT_TIMEOUT_MS,
+  incrementNextId,
+  otherQueue,
+  pending,
+  priorityQueue,
+  setActiveRequest,
+  setConsecutiveOther,
+  setInitPromise,
+  setInitReject,
+  setInitResolve,
+  setInitTimer,
+  setNextId,
+  setNotifyChangeCallback,
+  setSlowQueryLogCallback,
+  setWorker,
+  timelineDedup,
+  timelineQueue,
+} from './state'
+
+class FakeBrowserWorker {
+  static instances: FakeBrowserWorker[] = []
+
+  readonly postMessage = vi.fn()
+  readonly terminate = vi.fn()
+  onerror: ((event: ErrorEvent) => void) | null = null
+  onmessage: ((event: MessageEvent) => void) | null = null
+
+  constructor(
+    readonly scriptUrl?: URL | string,
+    readonly options?: WorkerOptions,
+  ) {
+    FakeBrowserWorker.instances.push(this)
+  }
+}
+
+function resetPublicApiState(): void {
+  const initTimer = getInitTimer()
+  if (initTimer != null) {
+    clearTimeout(initTimer)
+  }
+  for (const request of pending.values()) {
+    clearTimeout(request.timer)
+  }
+  pending.clear()
+  priorityQueue.length = 0
+  otherQueue.length = 0
+  timelineQueue.length = 0
+  timelineDedup.clear()
+  durationForId.clear()
+  setWorker(null)
+  setNextId(0)
+  setActiveRequest(false)
+  setConsecutiveOther(0)
+  setInitPromise(null)
+  setInitResolve(null)
+  setInitReject(null)
+  setInitTimer(null)
+  setNotifyChangeCallback(null)
+  setSlowQueryLogCallback(null)
+  clearIdCollectCache()
+  stopSnapshotRecording()
+  setQueuePriority('auto')
+  FakeBrowserWorker.instances.length = 0
+}
+
+function connectFakeWorker(): FakeBrowserWorker {
+  const worker = new FakeBrowserWorker()
+  setWorker(worker as unknown as Worker)
+  return worker
+}
+
+function lastPostedMessage(worker: FakeBrowserWorker): {
+  id: number
+  type: string
+  [key: string]: unknown
+} {
+  const call = worker.postMessage.mock.calls.at(-1)
+  if (!call) {
+    throw new Error('Worker did not receive a message')
+  }
+  return call[0] as {
+    id: number
+    type: string
+    [key: string]: unknown
+  }
+}
+
+function resolveMessage(
+  message: { id: number },
+  result: unknown,
+  durationMs?: number,
+): void {
+  if (durationMs != null) {
+    durationForId.set(message.id, durationMs)
+  }
+  const request = pending.get(message.id)
+  if (!request) {
+    throw new Error(`No pending request for id=${message.id}`)
+  }
+  pending.delete(message.id)
+  request.resolve(result)
+}
+
+const flatFetchRequest = {
+  ids: [1, 2],
+  target: 'posts',
+} as unknown as FlatFetchRequest
+
+const graphPlan = {
+  nodes: [],
+} as unknown as SerializedGraphPlan
+
+const graphOptions = {
+  limit: 40,
+} as unknown as GraphExecuteOptions
+
+const timelineRequest: Omit<FetchTimelineRequest, 'type' | 'id'> = {
+  batchSqls: {
+    belongingTags: 'SELECT belonging tags',
+    customEmojis: 'SELECT custom emojis',
+    interactions: 'SELECT interactions',
+    media: 'SELECT media',
+    mentions: 'SELECT mentions',
+    polls: 'SELECT polls',
+    profileEmojis: 'SELECT profile emojis',
+    timelineTypes: 'SELECT timeline types',
+  },
+  phase1: {
+    bind: ['https://example.test'],
+    sql: 'SELECT id FROM posts WHERE backend_url = ?',
+  },
+  phase2BaseSql: 'SELECT * FROM posts WHERE id IN ({IDS})',
+  reblogPostIdColumnIndex: 4,
+}
+
+describe('workerClient publicApi RPC', () => {
+  beforeEach(() => {
+    resetPublicApiState()
+  })
+
+  afterEach(() => {
+    resetPublicApiState()
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  it('execAsync と execBatch が採番済み payload と queue kind を送る', async () => {
+    const worker = connectFakeWorker()
+
+    const exec = execAsync('SELECT * FROM posts WHERE id = ?', {
+      bind: [10],
+      kind: 'timeline',
+      returnValue: 'resultRows',
+      sessionTag: 'home-tab',
+    })
+    const execMessage = lastPostedMessage(worker)
+    expect(execMessage).toEqual({
+      bind: [10],
+      id: 0,
+      returnValue: 'resultRows',
+      sql: 'SELECT * FROM posts WHERE id = ?',
+      type: 'exec',
+    })
+    expect(pending.get(execMessage.id)?.kind).toBe('timeline')
+    resolveMessage(execMessage, [[10]])
+    await expect(exec).resolves.toEqual([[10]])
+
+    const defaultBatch = execBatch([{ sql: 'DELETE FROM posts' }])
+    const defaultBatchMessage = lastPostedMessage(worker)
+    expect(defaultBatchMessage).toEqual({
+      id: 1,
+      returnIndices: undefined,
+      rollbackOnError: true,
+      statements: [{ sql: 'DELETE FROM posts' }],
+      type: 'execBatch',
+    })
+    expect(pending.get(defaultBatchMessage.id)?.kind).toBe('other')
+    resolveMessage(defaultBatchMessage, {})
+    await expect(defaultBatch).resolves.toEqual({})
+
+    const configuredBatch = execBatch(
+      [
+        { bind: [1], sql: 'UPDATE posts SET hidden = ?' },
+        { returnValue: 'resultRows', sql: 'SELECT changes()' },
+      ],
+      { returnIndices: [1], rollbackOnError: false },
+    )
+    const configuredBatchMessage = lastPostedMessage(worker)
+    expect(configuredBatchMessage).toMatchObject({
+      id: 2,
+      returnIndices: [1],
+      rollbackOnError: false,
+      type: 'execBatch',
+    })
+    resolveMessage(configuredBatchMessage, { 1: [[1]] })
+    await expect(configuredBatch).resolves.toEqual({ 1: [[1]] })
+  })
+
+  it('GraphPlan、FlatFetch、fetchTimeline を timeline RPC として送る', async () => {
+    const worker = connectFakeWorker()
+
+    const graph = executeGraphPlan(graphPlan, graphOptions, 'graph-session')
+    const graphMessage = lastPostedMessage(worker)
+    expect(graphMessage).toEqual({
+      id: 0,
+      options: graphOptions,
+      plan: graphPlan,
+      type: 'executeGraphPlan',
+    })
+    expect(pending.get(graphMessage.id)?.kind).toBe('timeline')
+    resolveMessage(graphMessage, { output: [] })
+    await expect(graph).resolves.toEqual({ output: [] })
+
+    const flat = executeFlatFetch(flatFetchRequest, 'flat-session')
+    const flatMessage = lastPostedMessage(worker)
+    expect(flatMessage).toEqual({
+      id: 1,
+      request: flatFetchRequest,
+      type: 'executeFlatFetch',
+    })
+    expect(pending.get(flatMessage.id)?.kind).toBe('timeline')
+    resolveMessage(flatMessage, { rows: [] })
+    await expect(flat).resolves.toEqual({ rows: [] })
+
+    const timeline = fetchTimeline(timelineRequest, 'timeline-session')
+    const timelineMessage = lastPostedMessage(worker)
+    expect(timelineMessage).toEqual({
+      ...timelineRequest,
+      id: 2,
+      type: 'fetchTimeline',
+    })
+    expect(pending.get(timelineMessage.id)?.kind).toBe('timeline')
+    resolveMessage(timelineMessage, { phase1Rows: [] })
+    await expect(timeline).resolves.toEqual({ phase1Rows: [] })
+  })
+
+  it('sendCommand は command を保持して既定 other または指定 priority に送る', async () => {
+    const worker = connectFakeWorker()
+    const command = {
+      action: 'favourited' as const,
+      backendUrl: 'https://example.test',
+      statusId: 'status-1',
+      type: 'updateStatusAction' as const,
+      value: true,
+    }
+
+    const other = sendCommand(command)
+    const otherMessage = lastPostedMessage(worker)
+    expect(otherMessage).toEqual({ ...command, id: 0 })
+    expect(pending.get(otherMessage.id)?.kind).toBe('other')
+    resolveMessage(otherMessage, { ok: true })
+    await expect(other).resolves.toEqual({ ok: true })
+
+    const priority = sendCommand(command, { kind: 'priority' })
+    const priorityMessage = lastPostedMessage(worker)
+    expect(priorityMessage).toEqual({ ...command, id: 1 })
+    expect(pending.get(priorityMessage.id)?.kind).toBe('priority')
+    resolveMessage(priorityMessage, { ok: true })
+    await expect(priority).resolves.toEqual({ ok: true })
+  })
+
+  it('execAsyncTimed は Worker duration を返して消費し、未通知時は 0 を返す', async () => {
+    const worker = connectFakeWorker()
+
+    const timed = execAsyncTimed('SELECT timed', {
+      kind: 'timeline',
+      sessionTag: 'timed-session',
+    })
+    const timedMessage = lastPostedMessage(worker)
+    resolveMessage(timedMessage, ['row'], 8.25)
+    await expect(timed).resolves.toEqual({
+      durationMs: 8.25,
+      result: ['row'],
+    })
+    expect(durationForId.has(timedMessage.id)).toBe(false)
+
+    const withoutDuration = execAsyncTimed('SELECT without_duration')
+    const withoutDurationMessage = lastPostedMessage(worker)
+    resolveMessage(withoutDurationMessage, 'ok')
+    await expect(withoutDuration).resolves.toEqual({
+      durationMs: 0,
+      result: 'ok',
+    })
+  })
+
+  it('executeQueryPlan は実行結果をキャッシュし、次回 payload に precomputedResults を付与する', async () => {
+    const worker = connectFakeWorker()
+    const plan: SerializedExecutionPlan = {
+      meta: { requiresReblogExpansion: false, sourceType: 'post' },
+      steps: [
+        {
+          binds: ['https://cache.example'],
+          source: 'worker_client_cache_posts',
+          sql: 'SELECT id, created_at_ms FROM cache_posts WHERE backend = ?',
+          type: 'id-collect',
+        },
+        {
+          limit: 20,
+          sourceStepIndices: [0],
+          strategy: 'interleave-by-time',
+          type: 'merge',
+        },
+      ],
+    }
+    const firstResult: QueryPlanResult = {
+      capturedVersions: { worker_client_cache_posts: 3 },
+      stepResults: [
+        {
+          rows: [{ createdAtMs: 1_000, id: 10 }],
+          type: 'id-collect',
+        },
+        { mergedIds: [], type: 'merge' },
+      ],
+      totalDurationMs: 5,
+    }
+
+    const first = executeQueryPlan(plan, 'cache-session')
+    const firstMessage = lastPostedMessage(worker)
+    expect(firstMessage.plan).toBe(plan)
+    resolveMessage(firstMessage, firstResult)
+    await expect(first).resolves.toBe(firstResult)
+    expect(
+      getCachedIdCollect({
+        binds: ['https://cache.example'],
+        sql: 'SELECT id, created_at_ms FROM cache_posts WHERE backend = ?',
+      }),
+    ).toEqual([
+      {
+        createdAtMs: 1_000,
+        id: 10,
+        table: 'worker_client_cache_posts',
+      },
+    ])
+
+    const secondResult: QueryPlanResult = {
+      capturedVersions: { worker_client_cache_posts: 3 },
+      stepResults: [
+        {
+          rows: [{ createdAtMs: 1_000, id: 10 }],
+          type: 'id-collect',
+        },
+        { mergedIds: [], type: 'merge' },
+      ],
+      totalDurationMs: 1,
+    }
+    const second = executeQueryPlan(plan, 'cache-session')
+    const secondMessage = lastPostedMessage(worker)
+    expect(secondMessage.plan).toEqual({
+      ...plan,
+      precomputedResults: {
+        0: {
+          rows: [
+            {
+              createdAtMs: 1_000,
+              id: 10,
+              table: 'worker_client_cache_posts',
+            },
+          ],
+          type: 'id-collect',
+        },
+      },
+    })
+    expect(plan.precomputedResults).toBeUndefined()
+    resolveMessage(secondMessage, secondResult)
+    await expect(second).resolves.toBe(secondResult)
+  })
+
+  it('capturedVersions がない executeQueryPlan 結果はキャッシュしない', async () => {
+    const worker = connectFakeWorker()
+    const plan: SerializedExecutionPlan = {
+      meta: { requiresReblogExpansion: false, sourceType: 'post' },
+      steps: [
+        {
+          binds: [],
+          source: 'uncached_posts',
+          sql: 'SELECT id, created_at_ms FROM uncached_posts',
+          type: 'id-collect',
+        },
+      ],
+    }
+    const result: QueryPlanResult = {
+      stepResults: [
+        {
+          rows: [{ createdAtMs: 500, id: 5 }],
+          type: 'id-collect',
+        },
+      ],
+      totalDurationMs: 2,
+    }
+
+    const execution = executeQueryPlan(plan)
+    const message = lastPostedMessage(worker)
+    resolveMessage(message, result)
+    await execution
+
+    expect(
+      getCachedIdCollect({
+        binds: [],
+        sql: 'SELECT id, created_at_ms FROM uncached_posts',
+      }),
+    ).toBeNull()
+  })
+
+  it('id-collect の結果が欠けている場合は capturedVersions があってもキャッシュしない', async () => {
+    const worker = connectFakeWorker()
+    const plan: SerializedExecutionPlan = {
+      meta: { requiresReblogExpansion: false, sourceType: 'post' },
+      steps: [
+        {
+          binds: [],
+          source: 'missing_result_posts',
+          sql: 'SELECT id, created_at_ms FROM missing_result_posts',
+          type: 'id-collect',
+        },
+      ],
+    }
+    const result: QueryPlanResult = {
+      capturedVersions: { missing_result_posts: 1 },
+      stepResults: [],
+      totalDurationMs: 0,
+    }
+
+    const execution = executeQueryPlan(plan)
+    const message = lastPostedMessage(worker)
+    resolveMessage(message, result)
+    await execution
+
+    expect(
+      getCachedIdCollect({
+        binds: [],
+        sql: 'SELECT id, created_at_ms FROM missing_result_posts',
+      }),
+    ).toBeNull()
+  })
+
+  it('initWorker は Worker を 1 回だけ生成し、origin を送って init 完了を共有する', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('location', { origin: 'https://client.example' })
+    vi.stubGlobal('Worker', FakeBrowserWorker)
+    const notify = vi.fn()
+
+    const first = initWorker(notify)
+    const second = initWorker(vi.fn())
+    const worker = FakeBrowserWorker.instances[0]
+
+    expect(second).toBe(first)
+    expect(FakeBrowserWorker.instances).toHaveLength(1)
+    expect(worker.scriptUrl).toBeInstanceOf(URL)
+    expect(worker.options).toEqual({ type: 'module' })
+    expect(worker.postMessage).toHaveBeenCalledWith({
+      origin: 'https://client.example',
+      type: '__init',
+    })
+    expect(worker.onmessage).toBeTypeOf('function')
+    expect(worker.onerror).toBeTypeOf('function')
+
+    worker.onmessage?.({
+      data: { persistence: 'opfs', type: 'init' },
+    } as MessageEvent)
+
+    await expect(first).resolves.toBe('opfs')
+    expect(getInitTimer()).toBeNull()
+    expect(getNotifyChangeCallback()).toBe(notify)
+    terminateWorker()
+  })
+
+  it('initWorker は init メッセージが来なければ規定時間で reject する', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('location', { origin: 'https://client.example' })
+    vi.stubGlobal('Worker', FakeBrowserWorker)
+
+    const initialization = initWorker(vi.fn())
+    const rejection = expect(initialization).rejects.toThrowError(
+      `Worker initialization timed out after ${INIT_TIMEOUT_MS}ms`,
+    )
+
+    await vi.advanceTimersByTimeAsync(INIT_TIMEOUT_MS - 1)
+    expect(getInitReject()).not.toBeNull()
+
+    await vi.advanceTimersByTimeAsync(1)
+    await rejection
+    expect(getInitReject()).toBeNull()
+    expect(getInitResolve()).toBeNull()
+    expect(getInitTimer()).toBeNull()
+    terminateWorker()
+  })
+
+  it('Worker onerror は初期化を reject してタイマーを解除する', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('location', { origin: 'https://client.example' })
+    vi.stubGlobal('Worker', FakeBrowserWorker)
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+
+    const initialization = initWorker(vi.fn())
+    const rejection = expect(initialization).rejects.toThrowError(
+      'Worker initialization failed: load failed',
+    )
+    const worker = FakeBrowserWorker.instances[0]
+    const errorEvent = { message: 'load failed' } as ErrorEvent
+    worker.onerror?.(errorEvent)
+
+    await rejection
+    expect(consoleError).toHaveBeenCalledWith(
+      'SQLite Worker error:',
+      errorEvent,
+    )
+    expect(getInitReject()).toBeNull()
+    expect(getInitResolve()).toBeNull()
+    expect(getInitTimer()).toBeNull()
+
+    worker.onerror?.({ message: 'late error' } as ErrorEvent)
+    expect(consoleError).toHaveBeenCalledTimes(2)
+    terminateWorker()
+  })
+
+  it('初期化タイマーが既に解除済みでも Worker onerror を処理できる', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('location', { origin: 'https://client.example' })
+    vi.stubGlobal('Worker', FakeBrowserWorker)
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    const initialization = initWorker(vi.fn())
+    const rejection = expect(initialization).rejects.toThrowError(
+      'Worker initialization failed: load failed',
+    )
+    const initTimer = getInitTimer()
+    if (initTimer != null) {
+      clearTimeout(initTimer)
+    }
+    setInitTimer(null)
+
+    FakeBrowserWorker.instances[0].onerror?.({
+      message: 'load failed',
+    } as ErrorEvent)
+
+    await rejection
+    expect(getInitTimer()).toBeNull()
+    terminateWorker()
+  })
+
+  it.each([
+    ['Error', new Error('constructor failed'), 'constructor failed'],
+    ['非 Error', 'string failure', 'string failure'],
+  ])(
+    'Worker constructor が %s を throw した場合も Error として reject する',
+    async (_, thrown, expectedMessage) => {
+      vi.useFakeTimers()
+      vi.stubGlobal('location', { origin: 'https://client.example' })
+      vi.stubGlobal(
+        'Worker',
+        class {
+          constructor() {
+            throw thrown
+          }
+        },
+      )
+
+      await expect(initWorker(vi.fn())).rejects.toThrowError(expectedMessage)
+    },
+  )
+
+  it('terminateWorker は Worker、in-flight、全キュー、共有 callback と採番をリセットする', async () => {
+    const worker = connectFakeWorker()
+    const active = execAsync('SELECT active')
+    const queuedOther = execAsync('SELECT queued')
+    const queuedPriority = sendCommand(
+      {
+        backendUrl: 'https://example.test',
+        mode: 'emergency',
+        type: 'enforceMaxLength',
+      },
+      { kind: 'priority' },
+    )
+    const queuedTimeline = executeFlatFetch(flatFetchRequest, 'terminate-test')
+    const allSettled = Promise.allSettled([
+      active,
+      queuedOther,
+      queuedPriority,
+      queuedTimeline,
+    ])
+    setInitPromise(Promise.resolve('memory'))
+    setInitResolve(vi.fn())
+    setInitReject(vi.fn())
+    setNotifyChangeCallback(vi.fn())
+    setSlowQueryLogCallback(vi.fn())
+    setConsecutiveOther(7)
+
+    terminateWorker()
+
+    const results = await allSettled
+    expect(results).toHaveLength(4)
+    for (const result of results) {
+      expect(result.status).toBe('rejected')
+      if (result.status === 'rejected') {
+        expect(result.reason).toEqual(new Error('Worker terminated'))
+      }
+    }
+    expect(worker.terminate).toHaveBeenCalledOnce()
+    expect(getWorker()).toBeNull()
+    expect(pending.size).toBe(0)
+    expect(priorityQueue).toHaveLength(0)
+    expect(otherQueue).toHaveLength(0)
+    expect(timelineQueue).toHaveLength(0)
+    expect(timelineDedup.size).toBe(0)
+    expect(getActiveRequest()).toBe(false)
+    expect(getConsecutiveOther()).toBe(0)
+    expect(getInitPromise()).toBeNull()
+    expect(getInitResolve()).toBeNull()
+    expect(getInitReject()).toBeNull()
+    expect(getNotifyChangeCallback()).toBeNull()
+    expect(getSlowQueryLogCallback()).toBeNull()
+    expect(incrementNextId()).toBe(0)
+
+    terminateWorker()
+  })
+})

--- a/src/util/db/sqlite/workerClient/queueManager.test.ts
+++ b/src/util/db/sqlite/workerClient/queueManager.test.ts
@@ -1,0 +1,388 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { setQueuePriority } from '../../dbQueue'
+import { cancelStaleRequests, sendRequest } from './queueManager'
+import {
+  getActiveRequest,
+  otherQueue,
+  pending,
+  priorityQueue,
+  setActiveRequest,
+  setConsecutiveOther,
+  setWorker,
+  TIMEOUT_BY_TYPE,
+  TIMEOUT_MS,
+  timelineDedup,
+  timelineQueue,
+} from './state'
+
+class FakeWorker {
+  readonly postMessage = vi.fn()
+  readonly terminate = vi.fn()
+}
+
+function resetWorkerClientState(): void {
+  for (const request of pending.values()) {
+    clearTimeout(request.timer)
+  }
+  pending.clear()
+  priorityQueue.length = 0
+  otherQueue.length = 0
+  timelineQueue.length = 0
+  timelineDedup.clear()
+  setActiveRequest(false)
+  setConsecutiveOther(0)
+  setWorker(null)
+  setQueuePriority('auto')
+}
+
+function resolvePending(id: number, value: unknown): void {
+  const request = pending.get(id)
+  if (!request) {
+    throw new Error(`No pending request for id=${id}`)
+  }
+  pending.delete(id)
+  request.resolve(value)
+}
+
+function rejectPending(id: number, reason: Error): void {
+  const request = pending.get(id)
+  if (!request) {
+    throw new Error(`No pending request for id=${id}`)
+  }
+  pending.delete(id)
+  request.reject(reason)
+}
+
+describe('workerClient queueManager', () => {
+  let worker: FakeWorker
+
+  beforeEach(() => {
+    resetWorkerClientState()
+    worker = new FakeWorker()
+    setWorker(worker as unknown as Worker)
+  })
+
+  afterEach(() => {
+    resetWorkerClientState()
+    vi.useRealTimers()
+  })
+
+  it('Worker が未初期化ならリクエストを拒否する', async () => {
+    setWorker(null)
+
+    await expect(sendRequest({ id: 1, type: 'ready' })).rejects.toThrowError(
+      'Worker not initialized',
+    )
+    expect(worker.postMessage).not.toHaveBeenCalled()
+  })
+
+  it('同時に送信するのは 1 件だけで priority、other、timeline の順に処理する', async () => {
+    setQueuePriority('default')
+    const active = sendRequest({ id: 1, type: 'ready' }, 'other')
+    const timeline = sendRequest(
+      { id: 2, sql: 'SELECT timeline', type: 'exec' },
+      'timeline',
+    )
+    const other = sendRequest({ id: 3, type: 'ready' }, 'other')
+    const priority = sendRequest({ id: 4, type: 'ready' }, 'priority')
+
+    expect(
+      worker.postMessage.mock.calls.map(([message]) => message.id),
+    ).toEqual([1])
+    expect(getActiveRequest()).toBe(true)
+
+    resolvePending(1, 'active')
+    expect(
+      worker.postMessage.mock.calls.map(([message]) => message.id),
+    ).toEqual([1, 4])
+
+    resolvePending(4, 'priority')
+    expect(
+      worker.postMessage.mock.calls.map(([message]) => message.id),
+    ).toEqual([1, 4, 3])
+
+    resolvePending(3, 'other')
+    expect(
+      worker.postMessage.mock.calls.map(([message]) => message.id),
+    ).toEqual([1, 4, 3, 2])
+    resolvePending(2, 'timeline')
+
+    await expect(
+      Promise.all([active, priority, other, timeline]),
+    ).resolves.toEqual(['active', 'priority', 'other', 'timeline'])
+    expect(pending).toHaveLength(0)
+    expect(getActiveRequest()).toBe(false)
+  })
+
+  it('other の連続処理上限に達したら timeline に処理を譲る', async () => {
+    setQueuePriority('balanced')
+    const active = sendRequest({ id: 1, type: 'ready' }, 'other')
+    const other = sendRequest({ id: 2, type: 'ready' }, 'other')
+    const timeline = sendRequest(
+      { id: 3, sql: 'SELECT timeline', type: 'exec' },
+      'timeline',
+    )
+    setConsecutiveOther(2)
+
+    resolvePending(1, undefined)
+    expect(
+      worker.postMessage.mock.calls.map(([message]) => message.id),
+    ).toEqual([1, 3])
+
+    resolvePending(3, undefined)
+    expect(
+      worker.postMessage.mock.calls.map(([message]) => message.id),
+    ).toEqual([1, 3, 2])
+    resolvePending(2, undefined)
+    await Promise.all([active, other, timeline])
+  })
+
+  it('同一 timeline exec を 1 回だけ送信し、結果を全呼び出し元で共有する', async () => {
+    const first = sendRequest(
+      {
+        bind: [1, 'home'],
+        id: 1,
+        returnValue: 'resultRows',
+        sql: 'SELECT * FROM posts WHERE id = ? AND timeline = ?',
+        type: 'exec',
+      },
+      'timeline',
+    )
+    const duplicate = sendRequest(
+      {
+        bind: [1, 'home'],
+        id: 2,
+        returnValue: 'resultRows',
+        sql: 'SELECT * FROM posts WHERE id = ? AND timeline = ?',
+        type: 'exec',
+      },
+      'timeline',
+    )
+
+    expect(worker.postMessage).toHaveBeenCalledOnce()
+    expect(timelineQueue).toHaveLength(0)
+    expect(timelineDedup).toHaveLength(1)
+
+    const rows = [[1, 'post']]
+    resolvePending(1, rows)
+
+    await expect(Promise.all([first, duplicate])).resolves.toEqual([rows, rows])
+    expect(timelineDedup).toHaveLength(0)
+  })
+
+  it('重複排除した timeline exec のエラーを全呼び出し元へ共有する', async () => {
+    const first = sendRequest(
+      { id: 1, sql: 'SELECT broken', type: 'exec' },
+      'timeline',
+    )
+    const duplicate = sendRequest(
+      { id: 2, sql: 'SELECT broken', type: 'exec' },
+      'timeline',
+    )
+    const firstRejection = expect(first).rejects.toThrowError('query failed')
+    const duplicateRejection =
+      expect(duplicate).rejects.toThrowError('query failed')
+
+    rejectPending(1, new Error('query failed'))
+
+    await Promise.all([firstRejection, duplicateRejection])
+    expect(worker.postMessage).toHaveBeenCalledOnce()
+    expect(timelineDedup).toHaveLength(0)
+  })
+
+  it('bind または returnValue が異なる timeline exec は重複排除しない', async () => {
+    const first = sendRequest(
+      { bind: [1], id: 1, sql: 'SELECT ?', type: 'exec' },
+      'timeline',
+    )
+    const differentBind = sendRequest(
+      { bind: [2], id: 2, sql: 'SELECT ?', type: 'exec' },
+      'timeline',
+    )
+    const differentReturnValue = sendRequest(
+      {
+        bind: [1],
+        id: 3,
+        returnValue: 'resultRows',
+        sql: 'SELECT ?',
+        type: 'exec',
+      },
+      'timeline',
+    )
+
+    expect(timelineQueue).toHaveLength(2)
+    resolvePending(1, 'first')
+    resolvePending(2, 'second')
+    resolvePending(3, 'third')
+
+    await expect(
+      Promise.all([first, differentBind, differentReturnValue]),
+    ).resolves.toEqual(['first', 'second', 'third'])
+    expect(
+      worker.postMessage.mock.calls.map(([message]) => message.id),
+    ).toEqual([1, 2, 3])
+  })
+
+  it('fetchTimeline は phase1 が同じなら 1 回の結果を共有する', async () => {
+    const first = sendRequest(
+      {
+        id: 1,
+        phase1: { bind: [], sql: 'SELECT id FROM posts' },
+        phase2BaseSql: 'first detail query',
+        type: 'fetchTimeline',
+      },
+      'timeline',
+    )
+    const duplicate = sendRequest(
+      {
+        id: 2,
+        phase1: { bind: [], sql: 'SELECT id FROM posts' },
+        phase2BaseSql: 'different detail query',
+        type: 'fetchTimeline',
+      },
+      'timeline',
+    )
+
+    expect(worker.postMessage).toHaveBeenCalledOnce()
+    resolvePending(1, { phase1Rows: [[1]] })
+
+    await expect(Promise.all([first, duplicate])).resolves.toEqual([
+      { phase1Rows: [[1]] },
+      { phase1Rows: [[1]] },
+    ])
+  })
+
+  it('dedup 対象外の timeline メッセージは個別にキューへ積む', async () => {
+    const first = sendRequest(
+      { id: 1, plan: {}, type: 'executeGraphPlan' },
+      'timeline',
+    )
+    const second = sendRequest(
+      { id: 2, plan: {}, type: 'executeGraphPlan' },
+      'timeline',
+    )
+
+    expect(timelineQueue).toHaveLength(1)
+    resolvePending(1, 'first')
+    resolvePending(2, 'second')
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      'first',
+      'second',
+    ])
+  })
+
+  it('同じ sessionTag の未送信 timeline を位置を保ったまま最新リクエストへ置換する', async () => {
+    const blocker = sendRequest({ id: 1, type: 'ready' })
+    const stale = sendRequest(
+      { id: 2, sql: 'SELECT old', type: 'exec' },
+      'timeline',
+      'home-tab',
+    )
+    const enqueuedAt = timelineQueue[0].enqueuedAt
+    const latest = sendRequest(
+      { id: 3, sql: 'SELECT latest', type: 'exec' },
+      'timeline',
+      'home-tab',
+    )
+
+    await expect(stale).resolves.toBeUndefined()
+    expect(timelineQueue).toHaveLength(1)
+    expect(timelineQueue[0].message.id).toBe(3)
+    expect(timelineQueue[0].enqueuedAt).toBe(enqueuedAt)
+
+    resolvePending(1, undefined)
+    expect(
+      worker.postMessage.mock.calls.map(([message]) => message.id),
+    ).toEqual([1, 3])
+    resolvePending(3, 'latest')
+
+    await blocker
+    await expect(latest).resolves.toBe('latest')
+  })
+
+  it('cancelStaleRequests は一致する未送信 sessionTag だけを指定値で解決する', async () => {
+    const blocker = sendRequest({ id: 1, type: 'ready' })
+    const stale = sendRequest(
+      { id: 2, sql: 'SELECT stale', type: 'exec' },
+      'timeline',
+      'stale-tab',
+    )
+    const retained = sendRequest(
+      { id: 3, sql: 'SELECT retained', type: 'exec' },
+      'timeline',
+      'active-tab',
+    )
+
+    expect(cancelStaleRequests('missing')).toBe(0)
+    expect(cancelStaleRequests('stale-tab', [])).toBe(1)
+    await expect(stale).resolves.toEqual([])
+    expect(timelineQueue.map((item) => item.message.id)).toEqual([3])
+
+    resolvePending(1, undefined)
+    resolvePending(3, 'retained')
+    await blocker
+    await expect(retained).resolves.toBe('retained')
+  })
+
+  it('timeline キュー上限を超えると最古のリクエストを破棄する', async () => {
+    const blocker = sendRequest({ id: 1, type: 'ready' })
+    const timelineRequests = Array.from({ length: 21 }, (_, index) =>
+      sendRequest(
+        {
+          id: 100 + index,
+          sql: `SELECT ${index}`,
+          type: 'exec',
+        },
+        'timeline',
+      ),
+    )
+
+    await expect(timelineRequests[0]).resolves.toBeUndefined()
+    expect(timelineQueue).toHaveLength(20)
+    expect(timelineQueue[0].message.id).toBe(101)
+
+    resolvePending(1, undefined)
+    for (let id = 101; id <= 120; id++) {
+      resolvePending(id, id)
+    }
+
+    await blocker
+    await expect(Promise.all(timelineRequests.slice(1))).resolves.toEqual(
+      Array.from({ length: 20 }, (_, index) => 101 + index),
+    )
+  })
+
+  it.each([
+    ['未登録の操作種別', 'customRequest', TIMEOUT_MS],
+    [
+      '操作別設定がある種別',
+      'bulkUpsertStatuses',
+      TIMEOUT_BY_TYPE.bulkUpsertStatuses,
+    ],
+  ])(
+    '%sは送信開始後の規定時間でタイムアウトする',
+    async (_, type, timeoutMs) => {
+      vi.useFakeTimers()
+      const timedOut = sendRequest({ id: 1, type })
+      const rejection = expect(timedOut).rejects.toThrowError(
+        `Worker request timed out (id=1, type=${type})`,
+      )
+      const following = sendRequest({ id: 2, type: 'ready' })
+
+      await vi.advanceTimersByTimeAsync(timeoutMs - 1)
+      expect(pending.has(1)).toBe(true)
+      expect(worker.postMessage).toHaveBeenCalledOnce()
+
+      await vi.advanceTimersByTimeAsync(1)
+      await rejection
+      expect(pending.has(1)).toBe(false)
+      expect(
+        worker.postMessage.mock.calls.map(([message]) => message.id),
+      ).toEqual([1, 2])
+
+      resolvePending(2, 'continued')
+      await expect(following).resolves.toBe('continued')
+    },
+  )
+})

--- a/src/util/db/sqlite/workerClient/state.test.ts
+++ b/src/util/db/sqlite/workerClient/state.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  durationForId,
+  getActiveRequest,
+  getConsecutiveOther,
+  getInitPromise,
+  getInitReject,
+  getInitResolve,
+  getInitTimer,
+  getNotifyChangeCallback,
+  getSlowQueryLogCallback,
+  getWorker,
+  INIT_TIMEOUT_MS,
+  incrementNextId,
+  otherQueue,
+  pending,
+  priorityQueue,
+  setActiveRequest,
+  setConsecutiveOther,
+  setInitPromise,
+  setInitReject,
+  setInitResolve,
+  setInitTimer,
+  setNextId,
+  setNotifyChangeCallback,
+  setSlowQueryLogCallback,
+  setWorker,
+  TIMEOUT_BY_TYPE,
+  TIMEOUT_MS,
+  timelineDedup,
+  timelineQueue,
+} from './state'
+
+function resetState(): void {
+  const initTimer = getInitTimer()
+  if (initTimer != null) {
+    clearTimeout(initTimer)
+  }
+  for (const request of pending.values()) {
+    clearTimeout(request.timer)
+  }
+  pending.clear()
+  priorityQueue.length = 0
+  otherQueue.length = 0
+  timelineQueue.length = 0
+  timelineDedup.clear()
+  durationForId.clear()
+  setWorker(null)
+  setNextId(0)
+  setActiveRequest(false)
+  setConsecutiveOther(0)
+  setNotifyChangeCallback(null)
+  setInitResolve(null)
+  setInitReject(null)
+  setInitPromise(null)
+  setInitTimer(null)
+  setSlowQueryLogCallback(null)
+}
+
+describe('workerClient state', () => {
+  afterEach(() => {
+    resetState()
+  })
+
+  it('タイムアウト定数を操作種別ごとに公開する', () => {
+    expect(TIMEOUT_MS).toBe(30_000)
+    expect(INIT_TIMEOUT_MS).toBe(15_000)
+    expect(TIMEOUT_BY_TYPE).toEqual({
+      bulkUpsertStatuses: 60_000,
+      enforceMaxLength: 90_000,
+      executeGraphPlan: 45_000,
+    })
+  })
+
+  it('Worker、キュー状態、採番を共有する', () => {
+    const worker = {
+      postMessage: vi.fn(),
+      terminate: vi.fn(),
+    } as unknown as Worker
+
+    setWorker(worker)
+    setActiveRequest(true)
+    setConsecutiveOther(3)
+    setNextId(41)
+
+    expect(getWorker()).toBe(worker)
+    expect(getActiveRequest()).toBe(true)
+    expect(getConsecutiveOther()).toBe(3)
+    expect(incrementNextId()).toBe(41)
+    expect(incrementNextId()).toBe(42)
+  })
+
+  it('初期化と通知に使うコールバック状態を保持・解除できる', async () => {
+    const notify = vi.fn()
+    const resolve = vi.fn()
+    const reject = vi.fn()
+    const slowQueryLog = vi.fn()
+    const initPromise = Promise.resolve<'opfs' | 'memory'>('opfs')
+    const timer = setTimeout(() => undefined, 60_000)
+
+    setNotifyChangeCallback(notify)
+    setInitResolve(resolve)
+    setInitReject(reject)
+    setInitPromise(initPromise)
+    setInitTimer(timer)
+    setSlowQueryLogCallback(slowQueryLog)
+
+    expect(getNotifyChangeCallback()).toBe(notify)
+    expect(getInitResolve()).toBe(resolve)
+    expect(getInitReject()).toBe(reject)
+    expect(getInitPromise()).toBe(initPromise)
+    expect(getInitTimer()).toBe(timer)
+    expect(getSlowQueryLogCallback()).toBe(slowQueryLog)
+    await expect(getInitPromise()).resolves.toBe('opfs')
+
+    setNotifyChangeCallback(null)
+    setInitResolve(null)
+    setInitReject(null)
+    setInitPromise(null)
+    setInitTimer(null)
+    setSlowQueryLogCallback(null)
+    clearTimeout(timer)
+
+    expect(getNotifyChangeCallback()).toBeNull()
+    expect(getInitResolve()).toBeNull()
+    expect(getInitReject()).toBeNull()
+    expect(getInitPromise()).toBeNull()
+    expect(getInitTimer()).toBeNull()
+    expect(getSlowQueryLogCallback()).toBeNull()
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,7 +14,13 @@ export default defineConfig({
     coverage: {
       include: ['src/util/db/sqlite/**'],
       provider: 'v8',
-      reporter: ['text', 'json', 'json-summary'],
+      reporter: ['text', 'json', 'json-summary', 'lcov'],
+      thresholds: {
+        branches: 90,
+        functions: 90,
+        lines: 90,
+        statements: 90,
+      },
     },
     environment: 'node',
     globals: true,


### PR DESCRIPTION
## Summary

- add focused Vitest coverage for SQLite queries, stores, workers, recovery, and notifications
- enforce 90% thresholds for statements, branches, functions, and lines
- publish LCOV to SonarQube and enforce its quality-gate workflow
- fix reblog row mapping and timeline/tag SQL bind ordering uncovered by the tests

## Verification

- yarn test:coverage: 114 files / 2,135 tests passed
- statements 98.49%, branches 94.70%, functions 99.33%, lines 98.77%
- yarn check
- git diff --check