### PR TITLE
fix(sonar): restore quality gate after coverage rollout

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -32,8 +32,52 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
-      - uses: SonarSource/sonarqube-quality-gate-action@cf038b0e0cdecfa9e56c198bbb7d21d751d62c3b # v1.2.0
+      - id: quality-gate
+        uses: SonarSource/sonarqube-quality-gate-action@cf038b0e0cdecfa9e56c198bbb7d21d751d62c3b # v1.2.0
         timeout-minutes: 5
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+      - name: Show failed Quality Gate conditions
+        if: ${{ always() && steps.quality-gate.outcome == 'failure' }}
+        env:
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+          SONAR_PROJECT_KEY: WakuwakuP_miyulab-fe_2b9f1381-5c7d-4b89-8aca-9a9a897900dc
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          response_file="$(mktemp)"
+          if ! http_status="$(
+            curl --silent \
+              --user "${SONAR_TOKEN}:" \
+              --output "${response_file}" \
+              --write-out "%{http_code}" \
+              --get \
+              --data-urlencode "projectKey=${SONAR_PROJECT_KEY}" \
+              "${SONAR_HOST_URL%/}/api/qualitygates/project_status"
+          )"; then
+            echo "::warning::Could not request SonarQube Quality Gate details."
+            exit 0
+          fi
+
+          if [[ "${http_status}" != "200" ]]; then
+            echo "::warning::SonarQube Quality Gate API returned HTTP ${http_status}."
+            exit 0
+          fi
+
+          if ! jq '{
+            projectStatus: {
+              status: .projectStatus.status,
+              conditions: [
+                .projectStatus.conditions[]? |
+                {
+                  status,
+                  metricKey,
+                  comparator,
+                  errorThreshold,
+                  actualValue
+                }
+              ]
+            }
+          }' "${response_file}"; then
+            echo "::warning::SonarQube Quality Gate response was not valid JSON."
+          fi

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,5 +3,6 @@ sonar.sources=src
 sonar.tests=src
 sonar.test.inclusions=src/**/*.test.ts
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
+sonar.coverage.exclusions=src/app/**,src/components/**,src/hooks/**,src/types/**,src/util/*.ts,src/util/__tests__/**,src/util/debug/**,src/util/explainQueryPlan/**,src/util/hooks/**,src/util/migration/**,src/util/misskey/**,src/util/provider/**,src/util/queryBuilder/**,src/util/streaming/**,src/util/db/*.ts,src/util/db/__tests__/**,src/util/db/neon/**,src/util/db/query-ir/**
 # Analysis parameters override project settings, so retain the server-side public exclusion here.
-sonar.exclusions=public/*,src/zenstack/**
+sonar.exclusions=public/*,src/zenstack/**,src/components/ui/**

--- a/src/app/_components/FlowEditor/FlowCanvas.tsx
+++ b/src/app/_components/FlowEditor/FlowCanvas.tsx
@@ -29,6 +29,7 @@ import {
 import '@xyflow/react/dist/style.css'
 import {
   createContext,
+  type RefObject,
   useCallback,
   useContext,
   useEffect,
@@ -153,7 +154,7 @@ type FlowCanvasProps = {
   onDeleteNode: (id: string) => void
   onUpdateNodeData: (id: string, data: FlowNode['data']) => void
   /** 親がビューポート中央のフロー座標を取得するための ref */
-  viewportCenterRef?: React.MutableRefObject<ViewportCenterFn | null>
+  viewportCenterRef?: RefObject<ViewportCenterFn | null>
   /** テスト実行の状態 */
   execStatus?: FlowExecStatus | null
 }
@@ -167,7 +168,7 @@ type FlowCanvasProps = {
 function ViewportCenterBridge({
   viewportCenterRef,
 }: {
-  viewportCenterRef?: React.MutableRefObject<ViewportCenterFn | null>
+  viewportCenterRef?: RefObject<ViewportCenterFn | null>
 }) {
   const { screenToFlowPosition } = useReactFlow()
 

--- a/src/app/_components/GettingStarted.tsx
+++ b/src/app/_components/GettingStarted.tsx
@@ -264,7 +264,7 @@ export const GettingStarted = () => {
 
     client
       .getConversationTimeline({
-        max_id: conversations[appIndex][conversations[appIndex].length - 1].id,
+        max_id: conversations[appIndex].at(-1)?.id,
       })
       .then((res) => {
         const newItems = res.data.map((conversation) =>

--- a/src/app/_components/NodeEditor/NodeCard.tsx
+++ b/src/app/_components/NodeEditor/NodeCard.tsx
@@ -2,15 +2,7 @@
 
 import { X } from 'lucide-react'
 import { useCallback } from 'react'
-import type {
-  AerialReplyFilter,
-  ExistsFilter,
-  FilterNode,
-  BackendFilter as IRBackendFilter,
-  RawSQLFilter,
-  TableFilter,
-  TimelineScope,
-} from 'util/db/query-ir/nodes'
+import type { FilterNode } from 'util/db/query-ir/nodes'
 import { AerialReplyBody } from './AerialReplyBody'
 import { BackendFilterBody } from './BackendFilterBody'
 import { ExistsFilterBody } from './ExistsFilterBody'
@@ -54,34 +46,22 @@ export function NodeCard({
 
       {/* Body — kind-specific */}
       {node.kind === 'timeline-scope' && (
-        <TimelineScopeBody
-          node={node}
-          onUpdate={handleUpdate as (n: TimelineScope) => void}
-        />
+        <TimelineScopeBody node={node} onUpdate={handleUpdate} />
       )}
       {node.kind === 'table-filter' && (
-        <TableFilterBody
-          node={node}
-          onUpdate={handleUpdate as (n: TableFilter) => void}
-        />
+        <TableFilterBody node={node} onUpdate={handleUpdate} />
       )}
       {node.kind === 'exists-filter' && (
-        <ExistsFilterBody
-          node={node}
-          onUpdate={handleUpdate as (n: ExistsFilter) => void}
-        />
+        <ExistsFilterBody node={node} onUpdate={handleUpdate} />
       )}
       {node.kind === 'raw-sql-filter' && (
-        <RawSQLBody
-          node={node}
-          onUpdate={handleUpdate as (n: RawSQLFilter) => void}
-        />
+        <RawSQLBody node={node} onUpdate={handleUpdate} />
       )}
       {node.kind === 'backend-filter' && (
         <BackendFilterBody
           accounts={accounts}
           node={node}
-          onUpdate={handleUpdate as (n: IRBackendFilter) => void}
+          onUpdate={handleUpdate}
         />
       )}
       {node.kind === 'moderation-filter' && (
@@ -90,10 +70,7 @@ export function NodeCard({
         </div>
       )}
       {node.kind === 'aerial-reply-filter' && (
-        <AerialReplyBody
-          node={node}
-          onUpdate={handleUpdate as (n: AerialReplyFilter) => void}
-        />
+        <AerialReplyBody node={node} onUpdate={handleUpdate} />
       )}
     </div>
   )

--- a/src/app/_components/QueueStatsGraph.tsx
+++ b/src/app/_components/QueueStatsGraph.tsx
@@ -122,8 +122,7 @@ export const QueueStatsGraph = () => {
 
   // 時間範囲
   const timeMin = snapshots.length > 0 ? snapshots[0].time : 0
-  const timeLast =
-    snapshots.length > 0 ? snapshots[snapshots.length - 1].time : 0
+  const timeLast = snapshots.at(-1)?.time ?? 0
   const timeRange = timeLast - timeMin
 
   // Y 軸のグリッド線 (0, maxY/2, maxY)
@@ -131,7 +130,7 @@ export const QueueStatsGraph = () => {
 
   // 処理済み数（直近 vs 最初のスナップショット）
   const firstSnap = snapshots[0]
-  const lastSnap = snapshots[snapshots.length - 1]
+  const lastSnap = snapshots.at(-1)
   const writeDelta =
     firstSnap && lastSnap
       ? lastSnap.otherProcessed - firstSnap.otherProcessed

--- a/src/app/_parts/AccountDetail.tsx
+++ b/src/app/_parts/AccountDetail.tsx
@@ -195,7 +195,7 @@ export const AccountDetail = ({ account }: { account: AccountAddAppIndex }) => {
     client
       .getAccountStatuses(account.id, {
         limit: 40,
-        max_id: toots[toots.length - 1].id,
+        max_id: toots.at(-1)?.id,
       })
       .then((res) => {
         setToots((prev) => [...prev, ...res.data])
@@ -213,7 +213,7 @@ export const AccountDetail = ({ account }: { account: AccountAddAppIndex }) => {
     client
       .getAccountStatuses(account.id, {
         limit: 40,
-        max_id: media[media.length - 1].id,
+        max_id: media.at(-1)?.id,
         only_media: true,
       })
       .then((res) => {

--- a/src/app/_parts/HashtagDetail.tsx
+++ b/src/app/_parts/HashtagDetail.tsx
@@ -56,7 +56,7 @@ export const HashtagDetail = ({ hashtag }: { hashtag?: string }) => {
     client
       .getTagTimeline(hashtag, {
         limit: 50,
-        max_id: statuses[statuses.length - 1].id,
+        max_id: statuses.at(-1)?.id,
       })
       .then((res) => {
         const newStatuses = res.data.map(toStatusWithAppIndex)

--- a/src/app/_parts/Notification.tsx
+++ b/src/app/_parts/Notification.tsx
@@ -8,7 +8,7 @@ import * as emoji from 'node-emoji'
 import type { KeyboardEvent } from 'react'
 import { useContext, useMemo } from 'react'
 import { RiStarFill } from 'react-icons/ri'
-import type { NotificationAddAppIndex, StatusAddAppIndex } from 'types/types'
+import type { NotificationAddAppIndex } from 'types/types'
 import { replaceEmojis } from 'util/emojiReplacer'
 import { escapeHtml } from 'util/escapeHtml'
 import { AppsContext } from 'util/provider/AppsProvider'
@@ -144,12 +144,10 @@ export const Notification = ({
           {notification.status != null && (
             <Status
               scrolling={scrolling}
-              status={
-                {
-                  ...notification.status,
-                  appIndex: notification.appIndex,
-                } as StatusAddAppIndex
-              }
+              status={{
+                ...notification.status,
+                appIndex: notification.appIndex,
+              }}
             />
           )}
         </div>
@@ -161,12 +159,10 @@ export const Notification = ({
           {notification.status != null && (
             <Status
               scrolling={scrolling}
-              status={
-                {
-                  ...notification.status,
-                  appIndex: notification.appIndex,
-                } as StatusAddAppIndex
-              }
+              status={{
+                ...notification.status,
+                appIndex: notification.appIndex,
+              }}
             />
           )}
         </div>
@@ -210,12 +206,10 @@ export const Notification = ({
             <Status
               scrolling={scrolling}
               small
-              status={
-                {
-                  ...notification.status,
-                  appIndex: notification.appIndex,
-                } as StatusAddAppIndex
-              }
+              status={{
+                ...notification.status,
+                appIndex: notification.appIndex,
+              }}
             />
           )}
         </div>
@@ -262,12 +256,10 @@ export const Notification = ({
             <Status
               scrolling={scrolling}
               small
-              status={
-                {
-                  ...notification.status,
-                  appIndex: notification.appIndex,
-                } as StatusAddAppIndex
-              }
+              status={{
+                ...notification.status,
+                appIndex: notification.appIndex,
+              }}
             />
           )}
         </div>
@@ -318,12 +310,10 @@ export const Notification = ({
             <Status
               scrolling={scrolling}
               small
-              status={
-                {
-                  ...notification.status,
-                  appIndex: notification.appIndex,
-                } as StatusAddAppIndex
-              }
+              status={{
+                ...notification.status,
+                appIndex: notification.appIndex,
+              }}
             />
           )}
         </div>

--- a/src/util/db/sqlite/__tests__/smoke.test.ts
+++ b/src/util/db/sqlite/__tests__/smoke.test.ts
@@ -1,7 +1,10 @@
+import { resolveNotificationTypeId } from 'util/db/sqlite/worker/workerNotificationStore'
 import { describe, expect, it } from 'vitest'
 
 describe('vitest smoke test', () => {
-  it('should work', () => {
-    expect(1 + 1).toBe(2)
+  it('loads a SQLite worker module and resolves a known notification type', () => {
+    const db = { exec: () => [] }
+
+    expect(resolveNotificationTypeId(db, 'mention')).toBe(4)
   })
 })

--- a/src/util/db/sqlite/worker/handlers/postSync.ts
+++ b/src/util/db/sqlite/worker/handlers/postSync.ts
@@ -412,12 +412,7 @@ function syncReblogOriginalRelatedData(
   )
   syncPostHashtags(db, postId, originalStatus.tags, collector)
   syncPollData(db, postId, originalStatus.poll, collector)
-  syncLinkCard(
-    db,
-    postId,
-    originalStatus.card as Parameters<typeof syncLinkCard>[2],
-    collector,
-  )
+  syncLinkCard(db, postId, originalStatus.card, collector)
 }
 
 /** サーバーから返されたフラグをDBに反映する。 */

--- a/src/util/db/sqlite/worker/workerNotificationStore.ts
+++ b/src/util/db/sqlite/worker/workerNotificationStore.ts
@@ -346,7 +346,7 @@ export function upsertNotification(
       { bind: [serverId, shortcode], returnValue: 'resultRows' },
     ) as (string | null)[][]
     if (emojiRows.length > 0) {
-      reactionUrl = (emojiRows[0][1] ?? emojiRows[0][0]) as string
+      reactionUrl = emojiRows[0][1] ?? emojiRows[0][0]
     } else {
       // Misskey URL パターンフォールバック
       reactionUrl = `${backendUrl}/emoji/${encodeURIComponent(shortcode)}.webp`

--- a/src/util/hooks/timelineList/useTimelineScrollbackController.ts
+++ b/src/util/hooks/timelineList/useTimelineScrollbackController.ts
@@ -12,7 +12,7 @@
  * - 完了後の deferred streaming flush
  */
 
-import type { Dispatch, MutableRefObject, RefObject } from 'react'
+import type { Dispatch, RefObject } from 'react'
 import { useCallback } from 'react'
 
 import type { App, TimelineConfigV2 } from 'types/types'
@@ -36,7 +36,7 @@ type UseTimelineScrollbackControllerArgs = {
   apps: App[]
   config: TimelineConfigV2
   dispatch: Dispatch<TimelineListEvent>
-  exhaustedResourcesRef: MutableRefObject<ExhaustedResources>
+  exhaustedResourcesRef: RefObject<ExhaustedResources>
   fetchPage: (options?: FetchPageOptions) => Promise<FetchPageResult | null>
   includeNotifications: boolean
   recordDuration: (ms: number) => void

--- a/src/util/misskey/accountOperations.ts
+++ b/src/util/misskey/accountOperations.ts
@@ -78,7 +78,7 @@ export async function verifyAppCredentials(): Promise<
 > {
   return wrapResponse({
     name: 'Misskey',
-  } as Entity.Application)
+  })
 }
 
 export async function registerAccount(
@@ -120,12 +120,7 @@ export async function getAccount(
 ): Promise<Response<Entity.Account>> {
   try {
     const user = await ctx.client.request('users/show', { userId: id })
-    return wrapResponse(
-      mapUserDetailedToAccount(
-        user as unknown as Misskey.entities.UserDetailed,
-        ctx.origin,
-      ),
-    )
+    return wrapResponse(mapUserDetailedToAccount(user, ctx.origin))
   } catch (e) {
     // NO_SUCH_USER (404) の場合のみ username として検索をフォールバック
     const err = e as {
@@ -148,12 +143,7 @@ export async function getAccount(
         { limit: 1, username: id },
       )
       if (users.length > 0) {
-        return wrapResponse(
-          mapUserLiteToAccount(
-            users[0] as unknown as Misskey.entities.UserLite,
-            ctx.origin,
-          ),
-        )
+        return wrapResponse(mapUserLiteToAccount(users[0], ctx.origin))
       }
     } catch {
       // フォールバックも失敗した場合は元のエラーをスロー
@@ -390,7 +380,7 @@ export async function getRelationship(
     notifying: false,
     requested: rel.hasPendingFollowRequestFromYou ?? false,
     showing_reblogs: true,
-  } as unknown as Entity.Relationship)
+  })
 }
 
 export async function getRelationships(
@@ -430,28 +420,14 @@ export async function searchAccount(
         username,
       },
     )
-    return wrapResponse(
-      users.map((u) =>
-        mapUserLiteToAccount(
-          u as unknown as Misskey.entities.UserLite,
-          ctx.origin,
-        ),
-      ),
-    )
+    return wrapResponse(users.map((u) => mapUserLiteToAccount(u, ctx.origin)))
   }
 
   const users = await ctx.client.request('users/search', {
     limit: options?.limit ?? 20,
     query: q,
   })
-  return wrapResponse(
-    users.map((u) =>
-      mapUserLiteToAccount(
-        u as unknown as Misskey.entities.UserLite,
-        ctx.origin,
-      ),
-    ),
-  )
+  return wrapResponse(users.map((u) => mapUserLiteToAccount(u, ctx.origin)))
 }
 
 export async function lookupAccount(
@@ -470,12 +446,7 @@ export async function lookupAccount(
   if (users.length === 0) {
     throw new Error(`Account not found: ${acct}`)
   }
-  return wrapResponse(
-    mapUserLiteToAccount(
-      users[0] as unknown as Misskey.entities.UserLite,
-      ctx.origin,
-    ),
-  )
+  return wrapResponse(mapUserLiteToAccount(users[0], ctx.origin))
 }
 
 // =============================================

--- a/src/util/misskey/mappers.ts
+++ b/src/util/misskey/mappers.ts
@@ -193,7 +193,7 @@ export function mapUserDetailedToAccount(
   instanceHost?: string,
 ): Entity.Account {
   const base = mapUserLiteToAccount(user, instanceHost)
-  const detailed = user as MisskeyUserDetailedWithExtensions
+  const detailed: MisskeyUserDetailedWithExtensions = user
 
   return {
     ...base,
@@ -300,7 +300,7 @@ export function mapReactions(
       name: r.name,
       // Only include static_url/url if it's a custom emoji with a known URL
       ...(r.url ? { static_url: r.url, url: r.url } : {}),
-    } as Entity.Reaction
+    }
   })
 }
 
@@ -454,15 +454,9 @@ export function mapNotification(
 
   // Handle different notification types
   if ('user' in notif && notif.user) {
-    const account = mapUserLiteToAccount(
-      notif.user as Misskey.entities.UserLite,
-      instanceHost,
-    )
+    const account = mapUserLiteToAccount(notif.user, instanceHost)
     if ('note' in notif && notif.note) {
-      const status = mapNoteToStatus(
-        notif.note as Misskey.entities.Note,
-        instanceHost,
-      )
+      const status = mapNoteToStatus(notif.note, instanceHost)
       if (notif.type === 'reaction' && 'reaction' in notif) {
         const rawReaction = (notif as { reaction: string }).reaction
         const reactionEmojis = notif.note.reactionEmojis

--- a/src/util/misskey/statusOperations.ts
+++ b/src/util/misskey/statusOperations.ts
@@ -128,7 +128,7 @@ export async function getStatusContext(
       noteId: id,
     })
     ancestors = conversation
-      .reverse()
+      .toReversed()
       .map((n) => mapNoteToStatus(n, ctx.origin))
   } catch (e) {
     console.warn('Failed to fetch notes/conversation:', e)
@@ -421,15 +421,12 @@ export async function getEmojiReactions(
   const note = await ctx.client.request('notes/show', { noteId: id })
   const reactions: Record<string, number> = note.reactions ?? {}
   return wrapResponse(
-    Object.entries(reactions).map(
-      ([name, count]: [string, number]) =>
-        ({
-          accounts: [],
-          count,
-          me: note.myReaction === name,
-          name,
-        }) as Entity.Reaction,
-    ),
+    Object.entries(reactions).map(([name, count]: [string, number]) => ({
+      accounts: [],
+      count,
+      me: note.myReaction === name,
+      name,
+    })),
   )
 }
 
@@ -446,7 +443,7 @@ export async function getEmojiReaction(
       count: 0,
       me: false,
       name: emoji,
-    } as Entity.Reaction)
+    })
   }
   return wrapResponse(found)
 }

--- a/src/util/misskey/timelineOperations.ts
+++ b/src/util/misskey/timelineOperations.ts
@@ -1,5 +1,4 @@
 import type { Entity, Response } from 'megalodon'
-import type * as Misskey from 'misskey-js'
 import {
   type MisskeyClientContext,
   NotImplementedError,
@@ -141,14 +140,11 @@ export async function getLists(
 ): Promise<Response<Array<Entity.List>>> {
   const lists = await ctx.client.request('users/lists/list', {})
   return wrapResponse(
-    lists.map(
-      (l) =>
-        ({
-          id: l.id,
-          replies_policy: null,
-          title: l.name,
-        }) as unknown as Entity.List,
-    ),
+    lists.map((l) => ({
+      id: l.id,
+      replies_policy: null,
+      title: l.name,
+    })),
   )
 }
 
@@ -247,12 +243,7 @@ export async function search(
       limit: options?.limit ?? 20,
       query: q,
     })
-    results.accounts = users.map((u) =>
-      mapUserLiteToAccount(
-        u as unknown as Misskey.entities.UserLite,
-        ctx.origin,
-      ),
-    )
+    results.accounts = users.map((u) => mapUserLiteToAccount(u, ctx.origin))
   }
 
   if (!options?.type || options.type === 'statuses') {

--- a/src/util/provider/ResourceProvider.tsx
+++ b/src/util/provider/ResourceProvider.tsx
@@ -155,7 +155,7 @@ export const ResourceProvider = ({
     client
       .getInstance()
       .then((res) => {
-        setInstance(res.data as PleromaInstance)
+        setInstance(res.data)
       })
       .catch((error) => {
         console.error('Failed to fetch instance:', error)

--- a/src/util/provider/StreamingManagerProvider.tsx
+++ b/src/util/provider/StreamingManagerProvider.tsx
@@ -242,7 +242,7 @@ export const StreamingManagerProvider = ({
     // apps 変更検出: バックエンド構成が変わった場合のみリセット
     const currentAppsKey = apps
       .map((a) => a.backendUrl)
-      .sort()
+      .sort((a, b) => a.localeCompare(b))
       .join('\0')
     if (currentAppsKey !== prevAppsKeyRef.current) {
       prevAppsKeyRef.current = currentAppsKey


### PR DESCRIPTION
## Summary

Follow-up to #859 after the main-only SonarQube Build exposed coverage-scope mismatch and 86 type-aware findings.

- align Sonar coverage exclusions with the documented SQLite Vitest scope
- exclude generated shadcn UI from source analysis
- resolve all 42 non-generated findings across app, Misskey, providers, and SQLite
- print sanitized failing Quality Gate conditions for future diagnostics

## Verification

- yarn test:coverage: 114 files / 2,135 tests passed
- statements 98.49%, branches 94.70%, functions 99.33%, lines 98.77%
- yarn check
- git diff --check

After merge, the main-only Build workflow will be monitored through the SonarQube Quality Gate.