### PR TITLE
fix: prevent horizontal overflow from long reblog display names

### DIFF
--- a/src/app/_parts/Status.tsx
+++ b/src/app/_parts/Status.tsx
@@ -294,6 +294,7 @@ export const Status = ({
   const statusClasses = [
     'box-border',
     'w-full',
+    'min-w-0',
     'p-2',
     'leading-7',
     className,
@@ -325,7 +326,7 @@ export const Status = ({
       ) : (
         <>
           <button
-            className="flex mb-1 overflow-clip border-0 bg-transparent p-0 text-inherit"
+            className="mb-1 flex w-full min-w-0 max-w-full items-center overflow-hidden border-0 bg-transparent p-0 text-inherit"
             onClick={() => {
               setDetail({
                 content: {
@@ -344,19 +345,19 @@ export const Status = ({
             type="button"
           >
             <RiRepeatFill
-              className="mr-2 block text-blue-400 flex-none"
-              size={24}
+              className="mr-2 block flex-none text-blue-400"
+              size={small ? 16 : 24}
             />
             <img
               alt="avatar"
               className={[
-                'rounded-lg object-contain flex-none block shrink-0',
-                small ? 'w-3 h-3' : 'w-6 h-6',
+                'block shrink-0 flex-none rounded-lg object-contain',
+                small ? 'h-3 w-3' : 'h-6 w-6',
               ].join(' ')}
               loading="lazy"
               src={toSecureResourceUrl(status.account.avatar)}
             />
-            <span className="pl-2 whitespace-nowrap">{parse(displayName)}</span>
+            <span className="min-w-0 truncate pl-2">{parse(displayName)}</span>
           </button>
           <UserInfo
             account={{

--- a/src/app/_parts/UserInfo.tsx
+++ b/src/app/_parts/UserInfo.tsx
@@ -43,9 +43,9 @@ export const UserInfo = ({
   }
 
   return (
-    <h3 className="flex">
+    <h3 className="flex min-w-0">
       <button
-        className="flex w-full border-0 bg-transparent p-0 text-left font-[inherit] text-inherit"
+        className="flex w-full min-w-0 border-0 bg-transparent p-0 text-left font-[inherit] text-inherit"
         onClick={openAccountDetail}
         type="button"
       >
@@ -53,16 +53,16 @@ export const UserInfo = ({
           {scrolling ? (
             <span
               className={[
-                'block rounded-lg object-contain flex-none bg-gray-600',
-                small ? 'w-6 h-6' : 'w-12 h-12',
+                'block flex-none rounded-lg bg-gray-600 object-contain',
+                small ? 'h-6 w-6' : 'h-12 w-12',
               ].join(' ')}
             />
           ) : (
             <ProxyImage
               alt="avatar"
               className={[
-                'rounded-lg object-contain flex-none',
-                small ? 'w-6 h-6' : 'w-12 h-12',
+                'flex-none rounded-lg object-contain',
+                small ? 'h-6 w-6' : 'h-12 w-12',
               ].join(' ')}
               height={small ? 24 : 48}
               src={account.avatar}
@@ -72,8 +72,8 @@ export const UserInfo = ({
           {account.bot === true && (
             <RiRobotFill
               className={[
-                'absolute text-blue-400 bg-gray-800 rounded-full p-0.5 bottom-0 right-0',
-                small ? 'w-3 h-3' : 'w-4 h-4',
+                'absolute bottom-0 right-0 rounded-full bg-gray-800 p-0.5 text-blue-400',
+                small ? 'h-3 w-3' : 'h-4 w-4',
               ].join(' ')}
               size={small ? 8 : 10}
               title="Bot"
@@ -81,9 +81,9 @@ export const UserInfo = ({
           )}
         </span>
         {small ? (
-          <span className="block w-[calc(100%-24px)] pl-2">
+          <span className="block min-w-0 flex-1 pl-2">
             <span className="flex w-full justify-between truncate">
-              <span>
+              <span className="min-w-0 truncate">
                 <span>{parse(getDisplayName)}</span>
                 <span className="pl-1 text-gray-300">@{account.acct}</span>
               </span>
@@ -91,9 +91,9 @@ export const UserInfo = ({
             </span>
           </span>
         ) : (
-          <span className="block w-[calc(100%-46px)] pl-2">
+          <span className="block min-w-0 flex-1 pl-2">
             <span className="flex w-full justify-between [&>span]:inline-block">
-              <span className="truncate">{parse(getDisplayName)}</span>
+              <span className="min-w-0 truncate">{parse(getDisplayName)}</span>
               <Visibility visibility={visibility} />
             </span>
             <span


### PR DESCRIPTION
## Summary
- Truncate long reblogger display names so the reblog header stays within the column width.
- Replace fixed `w-[calc(100%-…)]` widths in `UserInfo` with `min-w-0 flex-1` to avoid small-status overflow by the reblog icon width.

## Test plan
- [ ] Open a notification that includes a reblogged status with a very long display name (status small)
- [ ] Confirm the reblogger name truncates and the timeline/notification column does not scroll horizontally
- [ ] Confirm normal (non-small) status reblog headers also truncate correctly
- [ ] Confirm UserInfo display names still truncate with visibility icon visible


Made with [Cursor](https://cursor.com)