### PR TITLE
fix: contain horizontal overflow from long reblog names

### DIFF
--- a/src/app/_components/TabbedTimeline.tsx
+++ b/src/app/_components/TabbedTimeline.tsx
@@ -48,10 +48,10 @@ export const TabbedTimeline = ({
   }
 
   return (
-    <section>
+    <section className="min-w-0 max-w-full overflow-x-hidden">
       {/* タブヘッダー */}
       <div
-        className="flex bg-slate-800 overflow-x-auto h-8 items-end"
+        className="flex h-8 items-end overflow-x-auto bg-slate-800"
         role="tablist"
       >
         {configs.map((config, index) => {

--- a/src/app/_parts/Notification.tsx
+++ b/src/app/_parts/Notification.tsx
@@ -140,7 +140,7 @@ export const Notification = ({
   switch (notification.type) {
     case 'poll_expired':
       return (
-        <div className="ml-1 mt-2 box-border border-b-2 border-l-2 border-teal-300 pl-2">
+        <div className="ml-1 mt-2 box-border min-w-0 max-w-full overflow-x-hidden border-b-2 border-l-2 border-teal-300 pl-2">
           {notification.status != null && (
             <Status
               scrolling={scrolling}
@@ -155,7 +155,7 @@ export const Notification = ({
     case 'mention':
     case 'status':
       return (
-        <div className="ml-1 mt-2 box-border border-b-2 border-l-2 border-green-500 pl-2">
+        <div className="ml-1 mt-2 box-border min-w-0 max-w-full overflow-x-hidden border-b-2 border-l-2 border-green-500 pl-2">
           {notification.status != null && (
             <Status
               scrolling={scrolling}
@@ -169,10 +169,10 @@ export const Notification = ({
       )
     case 'reblog':
       return (
-        <div className="ml-1 mt-2 box-border border-b-2 border-l-2 border-blue-500 pl-2">
-          <h3>
+        <div className="ml-1 mt-2 box-border min-w-0 max-w-full overflow-x-hidden border-b-2 border-l-2 border-blue-500 pl-2">
+          <h3 className="min-w-0 max-w-full">
             <button
-              className="flex w-full cursor-pointer appearance-none border-0 bg-transparent p-0 text-left text-inherit"
+              className="flex w-full min-w-0 max-w-full cursor-pointer appearance-none border-0 bg-transparent p-0 text-left text-inherit"
               onClick={openAccountDetail}
               onKeyDown={handleAccountKeyDown}
               type="button"
@@ -189,7 +189,7 @@ export const Notification = ({
                   width={48}
                 />
               )}
-              <span className="w-[calc(100%-56px)] pl-2">
+              <span className="min-w-0 flex-1 overflow-hidden pl-2">
                 <span className="block w-full truncate">
                   <span>{parse(displayName)}</span>
                 </span>
@@ -216,10 +216,10 @@ export const Notification = ({
       )
     case 'favourite':
       return (
-        <div className="ml-1 mt-2 box-border border-b-2 border-l-2 border-orange-300 pl-2">
-          <h3>
+        <div className="ml-1 mt-2 box-border min-w-0 max-w-full overflow-x-hidden border-b-2 border-l-2 border-orange-300 pl-2">
+          <h3 className="min-w-0 max-w-full">
             <button
-              className="flex w-full cursor-pointer appearance-none border-0 bg-transparent p-0 text-left text-inherit"
+              className="flex w-full min-w-0 max-w-full cursor-pointer appearance-none border-0 bg-transparent p-0 text-left text-inherit"
               onClick={openAccountDetail}
               onKeyDown={handleAccountKeyDown}
               type="button"
@@ -236,7 +236,7 @@ export const Notification = ({
                   width={48}
                 />
               )}
-              <span className="w-[calc(100%-56px)] pl-2">
+              <span className="min-w-0 flex-1 overflow-hidden pl-2">
                 <span className="block w-full truncate">
                   <span>{parse(displayName)}</span>
                 </span>
@@ -266,10 +266,10 @@ export const Notification = ({
       )
     case 'emoji_reaction':
       return (
-        <div className="ml-1 mt-2 box-border border-b-2 border-l-2 border-orange-300 pl-2">
-          <h3>
+        <div className="ml-1 mt-2 box-border min-w-0 max-w-full overflow-x-hidden border-b-2 border-l-2 border-orange-300 pl-2">
+          <h3 className="flex min-w-0 max-w-full items-start gap-2">
             <button
-              className="flex w-full cursor-pointer appearance-none border-0 bg-transparent p-0 text-left text-inherit"
+              className="flex min-w-0 flex-1 max-w-full cursor-pointer appearance-none border-0 bg-transparent p-0 text-left text-inherit"
               onClick={openAccountDetail}
               onKeyDown={handleAccountKeyDown}
               type="button"
@@ -286,7 +286,7 @@ export const Notification = ({
                   width={48}
                 />
               )}
-              <span className="w-[calc(100%-56px)] pl-2">
+              <span className="min-w-0 flex-1 overflow-hidden pl-2">
                 <span className="block w-full truncate">
                   <span>{parse(displayName)}</span>
                 </span>
@@ -298,7 +298,7 @@ export const Notification = ({
                 </span>
               </span>
             </button>
-            <div className="min-w-12  mr-2">
+            <div className="mr-2 w-12 shrink-0">
               <ReactionDisplay
                 reactionName={notification.reaction?.name}
                 resolvedReactionUrl={resolvedReactionUrl}
@@ -320,11 +320,11 @@ export const Notification = ({
       )
     case 'follow':
       return (
-        <div className="ml-1 mt-2 box-border border-b-2 border-l-2 border-pink-300 pl-2">
+        <div className="ml-1 mt-2 box-border min-w-0 max-w-full overflow-x-hidden border-b-2 border-l-2 border-pink-300 pl-2">
           <p>Follow</p>
-          <h3>
+          <h3 className="min-w-0 max-w-full">
             <button
-              className="flex w-full cursor-pointer appearance-none border-0 bg-transparent p-0 text-left text-inherit"
+              className="flex w-full min-w-0 max-w-full cursor-pointer appearance-none border-0 bg-transparent p-0 text-left text-inherit"
               onClick={openAccountDetail}
               onKeyDown={handleAccountKeyDown}
               type="button"
@@ -341,7 +341,7 @@ export const Notification = ({
                   width={48}
                 />
               )}
-              <span className="w-[calc(100%-56px)] pl-2">
+              <span className="min-w-0 flex-1 overflow-hidden pl-2">
                 <span className="block w-full truncate">
                   <span>{parse(displayName)}</span>
                 </span>
@@ -358,11 +358,11 @@ export const Notification = ({
       )
     case 'follow_request':
       return (
-        <div className="ml-1 mt-2 box-border border-b-2 border-l-2 border-pink-500 pl-2">
+        <div className="ml-1 mt-2 box-border min-w-0 max-w-full overflow-x-hidden border-b-2 border-l-2 border-pink-500 pl-2">
           <p>Follow request</p>
-          <h3>
+          <h3 className="min-w-0 max-w-full">
             <button
-              className="flex w-full cursor-pointer appearance-none border-0 bg-transparent p-0 text-left text-inherit"
+              className="flex w-full min-w-0 max-w-full cursor-pointer appearance-none border-0 bg-transparent p-0 text-left text-inherit"
               onClick={openAccountDetail}
               onKeyDown={handleAccountKeyDown}
               type="button"
@@ -379,7 +379,7 @@ export const Notification = ({
                   width={48}
                 />
               )}
-              <span className="w-[calc(100%-56px)] pl-2">
+              <span className="min-w-0 flex-1 overflow-hidden pl-2">
                 <span className="block w-full truncate">
                   <span>{parse(displayName)}</span>
                 </span>

--- a/src/app/_parts/Panel.tsx
+++ b/src/app/_parts/Panel.tsx
@@ -28,7 +28,7 @@ export const Panel = ({
     queryDuration == null ? undefined : `Query: ${queryDuration.toFixed(2)} ms`
 
   return (
-    <section>
+    <section className="min-w-0 max-w-full overflow-x-hidden">
       {typeof name === 'string' ? (
         <h2 className="h-8 bg-slate-800 text-center" title={durationTitle}>
           {onClickHeader == null ? (

--- a/src/app/_parts/Status.tsx
+++ b/src/app/_parts/Status.tsx
@@ -119,7 +119,12 @@ export const Status = ({
 
   const getDisplayName = useCallback(
     (account: Entity.Account) =>
-      replaceEmojis(escapeHtml(account.display_name), account.emojis),
+      replaceEmojis(
+        escapeHtml(account.display_name),
+        account.emojis,
+        // min-width 付き絵文字は truncate 行の intrinsic 幅を押し広げるため使わない
+        'h-4 w-4 inline-block',
+      ),
     [],
   )
 
@@ -295,10 +300,12 @@ export const Status = ({
     'box-border',
     'w-full',
     'min-w-0',
+    'max-w-full',
     'p-2',
     'leading-7',
     className,
-    small ? 'max-h-24 overflow-clip' : '',
+    // 列は固定幅のため、はみ出しはここで止めて main の横スクロールを増やさない
+    small ? 'max-h-24 overflow-clip' : 'overflow-x-clip',
     status.reblog == null ? '' : 'border-l-4 border-blue-400 pl-2 mb-2',
   ].join(' ')
 
@@ -326,7 +333,7 @@ export const Status = ({
       ) : (
         <>
           <button
-            className="mb-1 flex w-full min-w-0 max-w-full items-center overflow-hidden border-0 bg-transparent p-0 text-inherit"
+            className="mb-1 w-full min-w-0 max-w-full border-0 bg-transparent p-0 text-left text-inherit"
             onClick={() => {
               setDetail({
                 content: {
@@ -344,20 +351,25 @@ export const Status = ({
             }}
             type="button"
           >
-            <RiRepeatFill
-              className="mr-2 block flex-none text-blue-400"
-              size={small ? 16 : 24}
-            />
-            <img
-              alt="avatar"
-              className={[
-                'block shrink-0 flex-none rounded-lg object-contain',
-                small ? 'h-3 w-3' : 'h-6 w-6',
-              ].join(' ')}
-              loading="lazy"
-              src={toSecureResourceUrl(status.account.avatar)}
-            />
-            <span className="min-w-0 truncate pl-2">{parse(displayName)}</span>
+            {/* button 自体の overflow はブラウザで効きにくいので内側で clip する */}
+            <span className="flex w-full min-w-0 max-w-full items-center overflow-hidden">
+              <RiRepeatFill
+                className="mr-2 block shrink-0 text-blue-400"
+                size={small ? 16 : 24}
+              />
+              <img
+                alt="avatar"
+                className={[
+                  'block shrink-0 rounded-lg object-contain',
+                  small ? 'h-3 w-3' : 'h-6 w-6',
+                ].join(' ')}
+                loading="lazy"
+                src={toSecureResourceUrl(status.account.avatar)}
+              />
+              <span className="min-w-0 flex-1 truncate pl-2">
+                {parse(displayName)}
+              </span>
+            </span>
           </button>
           <UserInfo
             account={{

--- a/src/app/_parts/UserInfo.tsx
+++ b/src/app/_parts/UserInfo.tsx
@@ -30,7 +30,8 @@ export const UserInfo = ({
       replaceEmojis(
         escapeHtml(account.display_name),
         account.emojis,
-        'min-w-5 h-5 inline-block',
+        // min-width 付き絵文字は truncate 行の intrinsic 幅を押し広げる
+        'h-5 w-5 inline-block',
       ),
     [account],
   )
@@ -43,67 +44,75 @@ export const UserInfo = ({
   }
 
   return (
-    <h3 className="flex min-w-0">
+    <h3 className="min-w-0 max-w-full">
       <button
-        className="flex w-full min-w-0 border-0 bg-transparent p-0 text-left font-[inherit] text-inherit"
+        className="w-full min-w-0 max-w-full border-0 bg-transparent p-0 text-left font-[inherit] text-inherit"
         onClick={openAccountDetail}
         type="button"
       >
-        <span className="relative block flex-none">
-          {scrolling ? (
-            <span
-              className={[
-                'block flex-none rounded-lg bg-gray-600 object-contain',
-                small ? 'h-6 w-6' : 'h-12 w-12',
-              ].join(' ')}
-            />
+        <span className="flex w-full min-w-0 max-w-full items-start overflow-hidden">
+          <span className="relative block shrink-0">
+            {scrolling ? (
+              <span
+                className={[
+                  'block rounded-lg bg-gray-600 object-contain',
+                  small ? 'h-6 w-6' : 'h-12 w-12',
+                ].join(' ')}
+              />
+            ) : (
+              <ProxyImage
+                alt="avatar"
+                className={[
+                  'rounded-lg object-contain',
+                  small ? 'h-6 w-6' : 'h-12 w-12',
+                ].join(' ')}
+                height={small ? 24 : 48}
+                src={account.avatar}
+                width={small ? 24 : 48}
+              />
+            )}
+            {account.bot === true && (
+              <RiRobotFill
+                className={[
+                  'absolute bottom-0 right-0 rounded-full bg-gray-800 p-0.5 text-blue-400',
+                  small ? 'h-3 w-3' : 'h-4 w-4',
+                ].join(' ')}
+                size={small ? 8 : 10}
+                title="Bot"
+              />
+            )}
+          </span>
+          {small ? (
+            <span className="min-w-0 flex-1 overflow-hidden pl-2">
+              <span className="flex w-full min-w-0 items-center justify-between gap-1">
+                <span className="min-w-0 flex-1 truncate">
+                  <span>{parse(getDisplayName)}</span>
+                  <span className="pl-1 text-gray-300">@{account.acct}</span>
+                </span>
+                <span className="shrink-0">
+                  <Visibility visibility={visibility} />
+                </span>
+              </span>
+            </span>
           ) : (
-            <ProxyImage
-              alt="avatar"
-              className={[
-                'flex-none rounded-lg object-contain',
-                small ? 'h-6 w-6' : 'h-12 w-12',
-              ].join(' ')}
-              height={small ? 24 : 48}
-              src={account.avatar}
-              width={small ? 24 : 48}
-            />
-          )}
-          {account.bot === true && (
-            <RiRobotFill
-              className={[
-                'absolute bottom-0 right-0 rounded-full bg-gray-800 p-0.5 text-blue-400',
-                small ? 'h-3 w-3' : 'h-4 w-4',
-              ].join(' ')}
-              size={small ? 8 : 10}
-              title="Bot"
-            />
+            <span className="min-w-0 flex-1 overflow-hidden pl-2">
+              <span className="flex w-full min-w-0 items-center justify-between gap-1">
+                <span className="min-w-0 flex-1 truncate">
+                  {parse(getDisplayName)}
+                </span>
+                <span className="shrink-0">
+                  <Visibility visibility={visibility} />
+                </span>
+              </span>
+              <span
+                className="block truncate text-gray-300"
+                title={`@${account.acct}`}
+              >
+                @{account.acct}
+              </span>
+            </span>
           )}
         </span>
-        {small ? (
-          <span className="block min-w-0 flex-1 pl-2">
-            <span className="flex w-full justify-between truncate">
-              <span className="min-w-0 truncate">
-                <span>{parse(getDisplayName)}</span>
-                <span className="pl-1 text-gray-300">@{account.acct}</span>
-              </span>
-              <Visibility visibility={visibility} />
-            </span>
-          </span>
-        ) : (
-          <span className="block min-w-0 flex-1 pl-2">
-            <span className="flex w-full justify-between [&>span]:inline-block">
-              <span className="min-w-0 truncate">{parse(getDisplayName)}</span>
-              <Visibility visibility={visibility} />
-            </span>
-            <span
-              className="block truncate text-gray-300"
-              title={`@${account.acct}`}
-            >
-              @{account.acct}
-            </span>
-          </span>
-        )}
       </button>
     </h3>
   )


### PR DESCRIPTION
## Summary
- Clip reblogger names inside a button-inner wrapper (button `overflow` alone does not contain layout overflow in browsers).
- Replace remaining fixed `calc(100%-…)` widths in notifications with `min-w-0 flex-1`, and add `overflow-x-hidden` on Panel / TabbedTimeline so column content cannot widen `main`'s horizontal scroll.
- Drop `min-w-*` on truncated display-name emoji images so they no longer force intrinsic width past the column.

## Test plan
- [ ] Timeline: open a boosted status whose reblogger display name is very long (with/without custom emoji)
- [ ] Confirm the name truncates and the column does **not** gain extra horizontal scroll
- [ ] Notification (reblog / favourite / emoji_reaction) with `Status small`: same check
- [ ] Tabbed timeline tab bar still scrolls horizontally when many tabs are present
- [ ] Media modal / player still open full-width


Made with [Cursor](https://cursor.com)