### PR TITLE
fix: resolve SonarQube issues in Status content click handler

### DIFF
--- a/src/app/_parts/Status.tsx
+++ b/src/app/_parts/Status.tsx
@@ -16,6 +16,7 @@ import parse, {
 } from 'html-react-parser'
 import type { Entity } from 'megalodon'
 import {
+  type KeyboardEvent,
   type MouseEvent,
   useCallback,
   useContext,
@@ -171,8 +172,18 @@ export const Status = ({
   const handleContentClick = useCallback(
     (e: MouseEvent<HTMLDivElement>) => {
       if ((e.target as HTMLElement).closest('a, button')) return
-      const selection = window.getSelection()
+      const selection = globalThis.getSelection()
       if (selection != null && selection.toString().length > 0) return
+      openStatusDetail()
+    },
+    [openStatusDetail],
+  )
+
+  const handleContentKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLDivElement>) => {
+      if (e.key !== 'Enter' && e.key !== ' ') return
+      if ((e.target as HTMLElement).closest('a, button')) return
+      e.preventDefault()
       openStatusDetail()
     },
     [openStatusDetail],
@@ -406,7 +417,14 @@ export const Status = ({
           })}
         </div>
       )}
-      <div className="content cursor-text" onClick={handleContentClick}>
+      {/* biome-ignore lint/a11y/useSemanticElements: parsed status HTML may contain nested buttons */}
+      <div
+        className="content cursor-text"
+        onClick={handleContentClick}
+        onKeyDown={handleContentKeyDown}
+        role="button"
+        tabIndex={0}
+      >
         <EditedAt editedAt={status.edited_at} />
         {parse(contentFormatted, { replace })}
       </div>


### PR DESCRIPTION
## Summary
- SonarQube の OPEN issue 3件（`Status.tsx`）を修正
- `window.getSelection()` を `globalThis.getSelection()` に変更
- ステータス本文クリック領域に `role="button"`、`tabIndex={0}`、`onKeyDown` を追加してアクセシビリティ対応
- パース済み HTML 内に mention 用 `button` が含まれるため、外側要素は `div` のまま維持

## Test plan
- [ ] ステータス本文クリックで詳細パネルが開く
- [ ] 本文テキストをドラッグ選択した場合、クリックで詳細が開かない
- [ ] mention / ハッシュタグ / リンククリックは従来どおり動作する
- [ ] Enter / Space キーで詳細パネルが開く
- [ ] `yarn check` / `yarn typecheck` が通る


Made with [Cursor](https://cursor.com)